### PR TITLE
Consistent/ proper capitalization of UI elements

### DIFF
--- a/Amperfy/Screens/Base.lproj/Main.storyboard
+++ b/Amperfy/Screens/Base.lproj/Main.storyboard
@@ -60,7 +60,7 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Server url" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fDZ-Za-sK8">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Server URL" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fDZ-Za-sK8">
                                 <rect key="frame" x="30" y="230" width="79" height="34"/>
                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1182,7 +1182,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="40"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Build number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hp6-ny-Kde" userLabel="Description">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Build Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hp6-ny-Kde" userLabel="Description">
                                                     <rect key="frame" x="20" y="5" width="200" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="szS-5C-IB3"/>
@@ -2342,7 +2342,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto cache played songs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p7L-Ac-hSc" userLabel="BackendApi Label">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto Cache Played Songs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p7L-Ac-hSc" userLabel="BackendApi Label">
                                                     <rect key="frame" x="20" y="7.5" width="200" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="2S8-q7-Rhy"/>

--- a/Amperfy/Screens/View/PlayerView.xib
+++ b/Amperfy/Screens/View/PlayerView.xib
@@ -26,7 +26,7 @@
                         <action selector="artistNameCompactPressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="PSZ-f0-sKI"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8F1-fg-8m2" userLabel="Artist Name Compact Label" customClass="MarqueeLabel" customModule="Amperfy">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8F1-fg-8m2" userLabel="Artist Name Compact Label" customClass="MarqueeLabel" customModule="Amperfy">
                     <rect key="frame" x="124" y="95.5" width="235" height="23"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="23" id="avd-wI-xLF"/>
@@ -41,7 +41,7 @@
                         <action selector="titleCompactPressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="9aD-KS-kRv"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Songs title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pOR-k2-6Vf" userLabel="Title Compact Label" customClass="MarqueeLabel" customModule="Amperfy">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Songs Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pOR-k2-6Vf" userLabel="Title Compact Label" customClass="MarqueeLabel" customModule="Amperfy">
                     <rect key="frame" x="124" y="58" width="235" height="25.5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="25.5" id="Bvd-8w-sJe"/>
@@ -176,7 +176,7 @@
                         <action selector="artistNameLargePressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="Lno-fc-kKQ"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GST-UH-ejT" userLabel="Artist Name Large Label" customClass="MarqueeLabel" customModule="Amperfy">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GST-UH-ejT" userLabel="Artist Name Large Label" customClass="MarqueeLabel" customModule="Amperfy">
                     <rect key="frame" x="16" y="225.5" width="343" height="23"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="23" id="yJg-88-RGh"/>
@@ -191,7 +191,7 @@
                         <action selector="titleLargePressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="f7Y-PD-RbX"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Songs title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6NT-8n-tg9" userLabel="Title Large Label" customClass="MarqueeLabel" customModule="Amperfy">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Songs Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6NT-8n-tg9" userLabel="Title Large Label" customClass="MarqueeLabel" customModule="Amperfy">
                     <rect key="frame" x="16" y="188" width="343" height="25.5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="25.5" id="Srp-a1-Y1D"/>

--- a/Amperfy/Screens/View/PlaylistTableCell.xib
+++ b/Amperfy/Screens/View/PlaylistTableCell.xib
@@ -46,7 +46,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="TxE-Fh-ozu">
                         <rect key="frame" x="94" y="27" width="296" height="38.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Playlist name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MMM-Yr-IkZ">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Playlist Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MMM-Yr-IkZ">
                                 <rect key="frame" x="0.0" y="0.0" width="296" height="20.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="MBe-4a-Yhx"/>


### PR DESCRIPTION
As far as I've seen in the text of UI elements all the words are capitalized, except sometimes words like "to". The change on line 63 of `Amperfy/Screens/Base.lproj/Main.storyboard` is a correction since the proper abbreviation is "URL", [source](https://www.oxfordlearnersdictionaries.com/definition/english/url?q=URL).

Please be aware that this PR isn't tested, since I can't compile this on linux. It did seem more useful to just change the capitalization than to open a issue so that's what I did. If this is is the wrong way to change these strings then I can open a issue.