### PR TITLE
Re-write audio/m4a mime type to audio/mp4

### DIFF
--- a/AmperfyKit/Storage/EntityWrappers/AbstractPlayable.swift
+++ b/AmperfyKit/Storage/EntityWrappers/AbstractPlayable.swift
@@ -159,6 +159,9 @@ public class AbstractPlayable: AbstractLibraryEntity, Downloadable {
         if originalContenType == "audio/x-flac" {
             return "audio/flac"
         }
+        if originalContenType == "audio/m4a" {
+            return "audio/mp4"
+        }
         return originalContenType
     }
     public var isPlayableOniOS: Bool {


### PR DESCRIPTION
The mime type `audio/m4a` is wrongly used by some Subsonic servers for ISOBMFF files containing audio data in ALAC format. However, it doesn't appear on the [official list of mime types](https://www.iana.org/assignments/media-types/media-types.xhtml) and attempting to play a file with that mime type will fail silently. The mime `audio/mp4` is used for [ISOMBFF files containing any audio codec](https://www.iana.org/assignments/media-types/audio/mp4).