### PR TITLE
Settings: fix player bar element having background color and update large titles to match other tabs

### DIFF
--- a/Amperfy/Screens/Base.lproj/Main.storyboard
+++ b/Amperfy/Screens/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -760,18 +760,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bcG-FU-Xh9">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="847"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <connections>
                                     <segue destination="Wdk-bS-aW2" kind="embed" destinationCreationSelector="segueToSwiftUI:" id="rgx-91-t0t"/>
                                 </connections>
                             </containerView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="kTI-Wq-9sy"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="bcG-FU-Xh9" firstAttribute="leading" secondItem="kTI-Wq-9sy" secondAttribute="leading" id="Feh-dt-yoo"/>
-                            <constraint firstItem="kTI-Wq-9sy" firstAttribute="bottom" secondItem="bcG-FU-Xh9" secondAttribute="bottom" id="I7Z-vX-NPk"/>
-                            <constraint firstItem="kTI-Wq-9sy" firstAttribute="trailing" secondItem="bcG-FU-Xh9" secondAttribute="trailing" id="gwe-Pw-LmG"/>
+                            <constraint firstItem="bcG-FU-Xh9" firstAttribute="leading" secondItem="hwu-20-I2H" secondAttribute="leading" id="Feh-dt-yoo"/>
+                            <constraint firstAttribute="bottom" secondItem="bcG-FU-Xh9" secondAttribute="bottom" id="I7Z-vX-NPk"/>
+                            <constraint firstAttribute="trailing" secondItem="bcG-FU-Xh9" secondAttribute="trailing" id="gwe-Pw-LmG"/>
                             <constraint firstItem="bcG-FU-Xh9" firstAttribute="top" secondItem="hwu-20-I2H" secondAttribute="top" id="hpc-ft-5Pw"/>
                         </constraints>
                     </view>

--- a/Amperfy/Screens/ViewController/SplitVC.swift
+++ b/Amperfy/Screens/ViewController/SplitVC.swift
@@ -46,13 +46,7 @@ class SplitVC: UISplitViewController {
     }
     
     func embeddInNavigation(vc: UIViewController) -> UINavigationController {
-        let nav = UINavigationController(rootViewController: vc)
-        if vc is SettingsHostVC {
-            nav.navigationBar.prefersLargeTitles = false
-        } else {
-            nav.navigationBar.prefersLargeTitles = true
-        }
-        return nav
+        return UINavigationController(rootViewController: vc)
     }
     
     var defaultSecondaryVC: UINavigationController {

--- a/Amperfy/SwiftUI/Settings/Artwork/ArtworkSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Artwork/ArtworkSettingsView.swift
@@ -82,6 +82,7 @@ struct ArtworkSettingsView: View {
             }
         }
         .navigationTitle("Artwork")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             updateValues()
         }

--- a/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
@@ -110,6 +110,7 @@ struct DisplaySettingsView: View {
             }
         }
         .navigationTitle("Display")
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/Amperfy/SwiftUI/Settings/LibrarySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/LibrarySettingsView.swift
@@ -250,6 +250,7 @@ struct LibrarySettingsView: View {
             }
         }
         .navigationTitle("Library")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             updateValues()
             appDelegate.userStatistics.visited(.settingsLibrary)

--- a/Amperfy/SwiftUI/Settings/LicenseSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/LicenseSettingsView.swift
@@ -305,6 +305,7 @@ THE SOFTWARE.
             .padding([.leading, .trailing], 16)
         }
         .navigationTitle("Licenses")
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/Amperfy/SwiftUI/Settings/PlayerSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/PlayerSettingsView.swift
@@ -221,6 +221,7 @@ struct PlayerSettingsView: View {
             }
         }
         .navigationTitle("Player, Stream & Scrobble")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             appDelegate.userStatistics.visited(.settingsPlayer)
         }

--- a/Amperfy/SwiftUI/Settings/Server/ServerSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Server/ServerSettingsView.swift
@@ -105,6 +105,7 @@ struct ServerSettingsView: View {
             }
         }
         .navigationTitle("Server")
+        .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $isPwUpdateDialogVisible) {
             UpdatePasswordView(isVisible: $isPwUpdateDialogVisible)
         }

--- a/Amperfy/SwiftUI/Settings/SettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/SettingsView.swift
@@ -120,9 +120,8 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
-            .navigationBarTitleDisplayMode(.inline)
         }
-        .navigationViewStyle(StackNavigationViewStyle())
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/Amperfy/SwiftUI/Settings/Support/SupportSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Support/SupportSettingsView.swift
@@ -72,6 +72,7 @@ struct SupportSettingsView: View {
             }
         }
         .navigationTitle("Support")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             appDelegate.userStatistics.visited(.settingsSupport)
         }

--- a/Amperfy/SwiftUI/Settings/Swipe/SwipeSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Swipe/SwipeSettingsView.swift
@@ -121,6 +121,7 @@ struct SwipeSettingsView: View {
             }
         }
         .navigationTitle("Swipe")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             reload()
         }

--- a/Amperfy/SwiftUI/Settings/XCallbackURLsSetttingsView.swift
+++ b/Amperfy/SwiftUI/Settings/XCallbackURLsSetttingsView.swift
@@ -82,6 +82,7 @@ struct XCallbackURLsSetttingsView: View {
             }
         }
         .navigationTitle("X-Callback-URL Documentation")
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 


### PR DESCRIPTION
Hi. Just putting up a couple of minor tweaks to the settings page. The main one is to remove the background behind the player bar on the settings page by expanding the settings page behind the player bar.

Before:
<img width="394" alt="Before" src="https://github.com/BLeeEZ/amperfy/assets/41772129/4dd35af8-b128-4630-acb9-53e6d9dc9570">

After:
<img width="393" alt="After" src="https://github.com/BLeeEZ/amperfy/assets/41772129/fbb309a6-3c49-4872-8546-5c3caf963ff3">

In addition, I updated the main settings view to show large titles to match the other tabs, which the same style. The sub-views still use the inline style (this matches the Settings app and the general UI guidelines as far as I can tell). This change is probably a bit more subjective so if you'd prefer not to have it, or to have it split to a different PR just let me know and I'll sort it out. Thanks!