### PR TITLE
HapticFeedback: can be disabled in settings

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		50E77DB928D21A9300BDF882 /* SettingsHostVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E77DB828D21A9300BDF882 /* SettingsHostVC.swift */; };
 		50ED756628CBC5D200E5D347 /* LibrarySyncerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ED756528CBC5D200E5D347 /* LibrarySyncerProxy.swift */; };
 		50FF311B2BBC4D8000C2C3B9 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */; };
+		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -894,6 +895,7 @@
 		50FE808D26A55CEA00CB434D /* DownloadMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		50FF31192BBB27AC00C2C3B9 /* Amperfy v36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v36.xcdatamodel"; sourceTree = "<group>"; };
 		50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1184,6 +1186,7 @@
 				508385F321C5965E00C4BB32 /* Info.plist */,
 				5078AFB32B44AE260038FD17 /* AppIntentVocabulary.plist */,
 				50ACAF1327B277B50039913C /* Amperfy.entitlements */,
+				641708582C13BF5100BA2619 /* Haptics.swift */,
 			);
 			path = Amperfy;
 			sourceTree = "<group>";
@@ -1976,6 +1979,7 @@
 				504262B32BF5FC3800B5EF38 /* AmperfyIntentHandler.swift in Sources */,
 				507148AD2B767FE200557904 /* ContextQueuePrevSectionHeader.swift in Sources */,
 				500B7D4721EDB0890083ED6F /* LibraryElementDetailTableHeaderView.swift in Sources */,
+				641708592C13BF5100BA2619 /* Haptics.swift in Sources */,
 				50CCD0592B6C388B0073793B /* PodcastDescriptionVC.swift in Sources */,
 				50A30E4F2B73DDC800722894 /* PlayerControlView.swift in Sources */,
 				509001B82716C8F400A8056D /* AppDelegateNotificationExtensions.swift in Sources */,

--- a/Amperfy/Haptics.swift
+++ b/Amperfy/Haptics.swift
@@ -12,47 +12,46 @@ import AudioToolbox
 import AmperfyKit
 
 enum Haptics {
-        case error
-        case success
-        case warning
-        case light
-        case medium
-        case heavy
-        @available(iOS 13.0, *)
-        case soft
-        @available(iOS 13.0, *)
-        case rigid
-        case selection
-        case oldSchool
-
-        public func vibrate() {
-            if AmperKit.shared.storage.settings.isHapticsEnabled {
-                switch self {
-                case .error:
-                    UINotificationFeedbackGenerator().notificationOccurred(.error)
-                case .success:
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
-                case .warning:
-                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
-                case .light:
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                case .medium:
-                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                case .heavy:
-                    UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
-                case .soft:
-                    if #available(iOS 13.0, *) {
-                        UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                    }
-                case .rigid:
-                    if #available(iOS 13.0, *) {
-                        UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
-                    }
-                case .selection:
-                    UISelectionFeedbackGenerator().selectionChanged()
-                case .oldSchool:
-                    AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
-                }
+    case error
+    case success
+    case warning
+    case light
+    case medium
+    case heavy
+    @available(iOS 13.0, *)
+    case soft
+    @available(iOS 13.0, *)
+    case rigid
+    case selection
+    case oldSchool
+    
+    public func vibrate(isHapticsEnabled: Bool) {
+        guard isHapticsEnabled else { return }
+        switch self {
+        case .error:
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+        case .success:
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        case .warning:
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        case .light:
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        case .medium:
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        case .heavy:
+            UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+        case .soft:
+            if #available(iOS 13.0, *) {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
             }
+        case .rigid:
+            if #available(iOS 13.0, *) {
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+            }
+        case .selection:
+            UISelectionFeedbackGenerator().selectionChanged()
+        case .oldSchool:
+            AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
         }
     }
+}

--- a/Amperfy/Haptics.swift
+++ b/Amperfy/Haptics.swift
@@ -1,0 +1,58 @@
+//
+//  Haptics.swift
+//  Amperfy
+//
+//  Created by daniele on 08/06/24.
+//  Copyright © 2024 Maximilian Bauer. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import AudioToolbox
+import AmperfyKit
+
+enum Haptics {
+        case error
+        case success
+        case warning
+        case light
+        case medium
+        case heavy
+        @available(iOS 13.0, *)
+        case soft
+        @available(iOS 13.0, *)
+        case rigid
+        case selection
+        case oldSchool
+
+        public func vibrate() {
+            if AmperKit.shared.storage.settings.isHapticsEnabled {
+                switch self {
+                case .error:
+                    UINotificationFeedbackGenerator().notificationOccurred(.error)
+                case .success:
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                case .warning:
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                case .light:
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                case .medium:
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                case .heavy:
+                    UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                case .soft:
+                    if #available(iOS 13.0, *) {
+                        UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                    }
+                case .rigid:
+                    if #available(iOS 13.0, *) {
+                        UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+                    }
+                case .selection:
+                    UISelectionFeedbackGenerator().selectionChanged()
+                case .oldSchool:
+                    AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
+                }
+            }
+        }
+    }

--- a/Amperfy/Screens/View/LibraryElementDetailTableHeaderView.swift
+++ b/Amperfy/Screens/View/LibraryElementDetailTableHeaderView.swift
@@ -83,12 +83,12 @@ class LibraryElementDetailTableHeaderView: UIView {
     }
     
     @IBAction func playAllButtonPressed(_ sender: Any) {
-        Haptics.success.vibrate()
+        Haptics.success.vibrate(isHapticsEnabled: appDelegate.storage.settings.isHapticsEnabled)
         play(isShuffled: false)
     }
     
     @IBAction func addAllShuffledButtonPressed(_ sender: Any) {
-        Haptics.success.vibrate()
+        Haptics.success.vibrate(isHapticsEnabled: appDelegate.storage.settings.isHapticsEnabled)
         shuffle()
     }
     

--- a/Amperfy/Screens/View/LibraryElementDetailTableHeaderView.swift
+++ b/Amperfy/Screens/View/LibraryElementDetailTableHeaderView.swift
@@ -83,14 +83,12 @@ class LibraryElementDetailTableHeaderView: UIView {
     }
     
     @IBAction func playAllButtonPressed(_ sender: Any) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.success)
+        Haptics.success.vibrate()
         play(isShuffled: false)
     }
     
     @IBAction func addAllShuffledButtonPressed(_ sender: Any) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.success)
+        Haptics.success.vibrate()
         shuffle()
     }
     

--- a/Amperfy/Screens/View/PlayableTableCell.swift
+++ b/Amperfy/Screens/View/PlayableTableCell.swift
@@ -213,7 +213,7 @@ class PlayableTableCell: BasicTableCell {
             playable.isCached || appDelegate.storage.settings.isOnlineMode {
              animateActivation()
              hideSearchBarKeyboardInRootView()
-             Haptics.success.vibrate()
+             Haptics.success.vibrate(isHapticsEnabled: appDelegate.storage.settings.isHapticsEnabled)
              appDelegate.player.play(context: context)
          }
     }

--- a/Amperfy/Screens/View/PlayableTableCell.swift
+++ b/Amperfy/Screens/View/PlayableTableCell.swift
@@ -213,8 +213,7 @@ class PlayableTableCell: BasicTableCell {
             playable.isCached || appDelegate.storage.settings.isOnlineMode {
              animateActivation()
              hideSearchBarKeyboardInRootView()
-             let generator = UINotificationFeedbackGenerator()
-             generator.notificationOccurred(.success)
+             Haptics.success.vibrate()
              appDelegate.player.play(context: context)
          }
     }

--- a/Amperfy/Screens/View/PodcastEpisodeTableCell.swift
+++ b/Amperfy/Screens/View/PodcastEpisodeTableCell.swift
@@ -121,7 +121,7 @@ class PodcastEpisodeTableCell: BasicTableCell {
     }
     
     @IBAction func showDescriptionButtonPressed(_ sender: Any) {
-        Haptics.light.vibrate()
+        Haptics.light.vibrate(isHapticsEnabled: appDelegate.storage.settings.isHapticsEnabled)
         guard let episode = self.episode, let rootView = rootView else { return }
         let showDescriptionVC = PodcastDescriptionVC()
         showDescriptionVC.display(podcastEpisode: episode, on: rootView)

--- a/Amperfy/Screens/View/PodcastEpisodeTableCell.swift
+++ b/Amperfy/Screens/View/PodcastEpisodeTableCell.swift
@@ -121,8 +121,7 @@ class PodcastEpisodeTableCell: BasicTableCell {
     }
     
     @IBAction func showDescriptionButtonPressed(_ sender: Any) {
-        let generator = UIImpactFeedbackGenerator(style: .light)
-        generator.impactOccurred()
+        Haptics.light.vibrate()
         guard let episode = self.episode, let rootView = rootView else { return }
         let showDescriptionVC = PodcastDescriptionVC()
         showDescriptionVC.display(podcastEpisode: episode, on: rootView)

--- a/Amperfy/Screens/ViewController/SettingsHostVC.swift
+++ b/Amperfy/Screens/ViewController/SettingsHostVC.swift
@@ -136,6 +136,11 @@ class SettingsHostVC: UIViewController {
         changesAgent.append(settings.$cacheSizeLimit.sink(receiveValue: { newValue in
             self.appDelegate.storage.settings.cacheLimit = newValue
         }))
+        
+        settings.isHapticsEnabled = self.appDelegate.storage.settings.isHapticsEnabled
+        changesAgent.append(settings.$isHapticsEnabled.sink(receiveValue: { newValue in
+            self.appDelegate.storage.settings.isHapticsEnabled = newValue
+        }))
     }
     
     @IBSegueAction func segueToSwiftUI(_ coder: NSCoder) -> UIViewController? {

--- a/Amperfy/Screens/ViewController/TableViewHelper/BasicTableViewController.swift
+++ b/Amperfy/Screens/ViewController/TableViewHelper/BasicTableViewController.swift
@@ -192,8 +192,7 @@ class BasicTableViewController: KeyCommandTableViewController {
 
     func createSwipeAction(for actionType: SwipeActionType, buttonColor: UIColor, indexPath: IndexPath, preCbContainable: PlayableContainable, actionCallback: @escaping SwipeActionCallback) -> UIContextualAction {
         let action = UIContextualAction(style: .normal, title: actionType.displayName) { (action, view, completionHandler) in
-            let generator = UINotificationFeedbackGenerator()
-            generator.notificationOccurred(.success)
+            Haptics.success.vibrate()
             actionCallback(indexPath) { actionContext in
                 guard let actionContext = actionContext else { return }
                 switch actionType {

--- a/Amperfy/Screens/ViewController/TableViewHelper/BasicTableViewController.swift
+++ b/Amperfy/Screens/ViewController/TableViewHelper/BasicTableViewController.swift
@@ -192,7 +192,7 @@ class BasicTableViewController: KeyCommandTableViewController {
 
     func createSwipeAction(for actionType: SwipeActionType, buttonColor: UIColor, indexPath: IndexPath, preCbContainable: PlayableContainable, actionCallback: @escaping SwipeActionCallback) -> UIContextualAction {
         let action = UIContextualAction(style: .normal, title: actionType.displayName) { (action, view, completionHandler) in
-            Haptics.success.vibrate()
+            Haptics.success.vibrate(isHapticsEnabled: self.appDelegate.storage.settings.isHapticsEnabled)
             actionCallback(indexPath) { actionContext in
                 guard let actionContext = actionContext else { return }
                 switch actionType {

--- a/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
@@ -30,6 +30,17 @@ struct DisplaySettingsView: View {
             List {
                 Section(content: {
                     HStack {
+                        Text("Haptic Feedback")
+                        Spacer()
+                        Toggle(isOn: $settings.isHapticsEnabled) {}
+                    }
+                }
+                , footer: {
+                    Text("Certain interactions provide haptic feedback. Long pressing to display the details menu will always trigger haptic feedback.")
+                })
+                
+                Section(content: {
+                    HStack {
                         Text("Music player skip buttons")
                         Spacer()
                         Toggle(isOn: $settings.isShowMusicPlayerSkipButtons) {}

--- a/Amperfy/SwiftUI/Settings/ObservableSettings.swift
+++ b/Amperfy/SwiftUI/Settings/ObservableSettings.swift
@@ -42,4 +42,6 @@ final class Settings: ObservableObject {
     @Published var isShowMusicPlayerSkipButtons = false
     @Published var swipeActionSettings = SwipeActionSettings(leading: [], trailing: [])
     @Published var cacheSizeLimit : Int = 0 // limit in byte
+    @Published var isHapticsEnabled = true
+
 }

--- a/Amperfy/SwiftUI/Settings/SettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/SettingsView.swift
@@ -76,15 +76,6 @@ struct SettingsView: View {
                 
                 Section(content: {
                     HStack {
-                        Text("Haptic Feedback")
-                        Spacer()
-                        Toggle(isOn: $settings.isHapticsEnabled) {}
-                    }
- 
-                })
-                
-                Section(content: {
-                    HStack {
                         Text("Prevent Screen Lock")
                         Spacer()
                         Menu(settings.screenLockPreventionPreference.description) {
@@ -97,7 +88,7 @@ struct SettingsView: View {
                 
                 Section() {
                     NavigationLink(destination: DisplaySettingsView()) {
-                        Text("Display")
+                        Text("Display & Interaction")
                     }
                     NavigationLink(destination: ServerSettingsView()) {
                         Text("Server")

--- a/Amperfy/SwiftUI/Settings/SettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/SettingsView.swift
@@ -76,6 +76,15 @@ struct SettingsView: View {
                 
                 Section(content: {
                     HStack {
+                        Text("Haptic Feedback")
+                        Spacer()
+                        Toggle(isOn: $settings.isHapticsEnabled) {}
+                    }
+ 
+                })
+                
+                Section(content: {
+                    HStack {
                         Text("Prevent Screen Lock")
                         Spacer()
                         Menu(settings.screenLockPreventionPreference.description) {

--- a/AmperfyKit/Storage/PersistentStorage.swift
+++ b/AmperfyKit/Storage/PersistentStorage.swift
@@ -259,6 +259,7 @@ public class PersistentStorage {
         case IsScrobbleStreamedItems = "isScrobbleStreamedItems"
         case IsPlaybackStartOnlyOnPlay = "isPlaybackStartOnlyOnPlay"
         case LibrarySyncVersion = "librarySyncVersion"
+        case IsHapticsEnabled = "isHapticsEnabled"
         
         case LibrarySyncInfoReadByUser = "librarySyncInfoReadByUser"
     }
@@ -470,6 +471,11 @@ public class PersistentStorage {
         
         public var isOnlineMode: Bool {
             return !isOfflineMode
+        }
+        
+        public var isHapticsEnabled: Bool {
+            get { return UserDefaults.standard.object(forKey: UserDefaultsKey.IsHapticsEnabled.rawValue) as? Bool ?? true }
+            set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.IsHapticsEnabled.rawValue) }
         }
     }
     


### PR DESCRIPTION
Hi, I've added an toggle in the settings to disable haptic feedback in the app. Now the haptic feedback is managed via the `Haptic` enum, this allows to check for the user preference so we don't need to check every time.

The usage of the Haptic enum is pretty simple, for example:
`Haptics.FEEDBACK_TYPE.vibrate()`
Where `FEEDBACK_TYPE` is the type of feedback we want

I couldn't test this in a real device so please if you can give it a check 