### PR TITLE
Adding a button to copy the X-Callback-URL examples

### DIFF
--- a/Amperfy/Screens/Player/PlayerControlView.swift
+++ b/Amperfy/Screens/Player/PlayerControlView.swift
@@ -460,9 +460,9 @@ class PlayerControlView: UIView {
         playerModeButton.isHidden = !appDelegate.storage.settings.libraryDisplaySettings.isVisible(libraryType: .podcasts)
         switch player.playerMode {
         case .music:
-            playerModeButton.setImage(UIImage.musicalNotes, for: .normal)
-        case .podcast:
             playerModeButton.setImage(UIImage.podcast, for: .normal)
+        case .podcast:
+            playerModeButton.setImage(UIImage.musicalNotes, for: .normal)
         }
         optionsStackView.layoutIfNeeded()
     }

--- a/Amperfy/Screens/Player/PlayerControlView.swift
+++ b/Amperfy/Screens/Player/PlayerControlView.swift
@@ -460,9 +460,9 @@ class PlayerControlView: UIView {
         playerModeButton.isHidden = !appDelegate.storage.settings.libraryDisplaySettings.isVisible(libraryType: .podcasts)
         switch player.playerMode {
         case .music:
-            playerModeButton.setImage(UIImage.podcast, for: .normal)
-        case .podcast:
             playerModeButton.setImage(UIImage.musicalNotes, for: .normal)
+        case .podcast:
+            playerModeButton.setImage(UIImage.podcast, for: .normal)
         }
         optionsStackView.layoutIfNeeded()
     }

--- a/Amperfy/SwiftUI/Settings/XCallbackURLsSetttingsView.swift
+++ b/Amperfy/SwiftUI/Settings/XCallbackURLsSetttingsView.swift
@@ -36,6 +36,7 @@ struct XCallbackURLsSetttingsView: View {
                             Text(actionDocu.name)
                                 .font(.subheadline)
                                 .fontWeight(.bold)
+                                .foregroundColor(.accentColor)
                                 .padding([.top], 8)
                             Text("\(actionDocu.description)")
                                 .font(.caption)
@@ -49,9 +50,13 @@ struct XCallbackURLsSetttingsView: View {
                                 .underline()
                                 .padding([.bottom], 4)
                             ForEach(actionDocu.exampleURLs, id: \.self) { url in
-                                Text("- " + url)
-                                    .font(.caption)
-                                    .padding([.leading], 8)
+                                HStack {
+                                    Text("- " + url)
+                                        .font(.caption)
+                                        .padding([.leading, .bottom], 8)
+                                    Spacer()
+                                    copyToPasteBoardButton(for: url)
+                                }
                             }
 
                             if !actionDocu.parameters.isEmpty {
@@ -63,6 +68,7 @@ struct XCallbackURLsSetttingsView: View {
                             ForEach(actionDocu.parameters, id: \.self) { para in
                                 Text("\(para.name) \(para.isMandatory ? "(mandatory)" : "")")
                                     .font(.caption)
+                                    .fontWeight(.bold)
                                     .padding([.top], 4)
                                 Text("Type: \(para.type)")
                                     .font(.caption)
@@ -83,6 +89,23 @@ struct XCallbackURLsSetttingsView: View {
         }
         .navigationTitle("X-Callback-URL Documentation")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+extension XCallbackURLsSetttingsView {
+    
+    /// Generates a button with an action to set the given URL to the system pasteBoard.
+    func copyToPasteBoardButton(for url: String) -> some View {
+        Button(action: {
+            copyToPasteBoard(url: url)
+        }, label: {
+            Image(systemName: "document.on.document")
+        })
+        .buttonStyle(.borderless)
+    }
+    
+    private func copyToPasteBoard(url: String) {
+        UIPasteboard.general.string = url
     }
 }
 


### PR DESCRIPTION
I think it would be very helpful for users to copy the X-Callback-URL examples instead of writing them manually. Unfortunately, because of the way the View is structured it is not easy to make the text selectable. What iI have done here instead, is adding a copy button on the side of each example.

I also added the accent color to the section titles.

<img width="532" alt="Screenshot 2024-12-25 at 12 04 28" src="https://github.com/user-attachments/assets/a00b6bbf-5c7b-470b-9372-aaf57992e8d1" />
