### PR TITLE
Inverts Podcasts and Music Icons

### DIFF
--- a/Amperfy/Screens/Player/PlayerControlView.swift
+++ b/Amperfy/Screens/Player/PlayerControlView.swift
@@ -460,9 +460,9 @@ class PlayerControlView: UIView {
         playerModeButton.isHidden = !appDelegate.storage.settings.libraryDisplaySettings.isVisible(libraryType: .podcasts)
         switch player.playerMode {
         case .music:
-            playerModeButton.setImage(UIImage.musicalNotes, for: .normal)
-        case .podcast:
             playerModeButton.setImage(UIImage.podcast, for: .normal)
+        case .podcast:
+            playerModeButton.setImage(UIImage.musicalNotes, for: .normal)
         }
         optionsStackView.layoutIfNeeded()
     }


### PR DESCRIPTION
The podcast and music icons are inverted. When podcast is the selected `playerMode`, the `musicalNote` icon should be shown, and vice versa.