### PR TITLE
starting frame on 1;1 so the inset version is centered.

### DIFF
--- a/AmperfyKit/Common/Utilities.swift
+++ b/AmperfyKit/Common/Utilities.swift
@@ -528,7 +528,7 @@ extension UIAlertAction {
 
 extension UISlider {
     public func setUnicolorThumbImage(thumbSize: CGFloat, color: UIColor, for state: UIControl.State) {
-        let layerFrame = CGRect(x: 0, y: 0, width: thumbSize, height: thumbSize)
+        let layerFrame = CGRect(x: 1, y: 1, width: thumbSize, height: thumbSize)
         let path = CGPath(ellipseIn: layerFrame.insetBy(dx: 1, dy: 1), transform: nil)
 
         let thumbImage = createImage(path: path, inFrame: layerFrame, color: color)

--- a/AmperfyKit/Common/Utilities.swift
+++ b/AmperfyKit/Common/Utilities.swift
@@ -528,10 +528,10 @@ extension UIAlertAction {
 
 extension UISlider {
     public func setUnicolorThumbImage(thumbSize: CGFloat, color: UIColor, for state: UIControl.State) {
-        let layerFrame = CGRect(x: 1, y: 1, width: thumbSize, height: thumbSize)
-        let path = CGPath(ellipseIn: layerFrame.insetBy(dx: 1, dy: 1), transform: nil)
+        let layerFrame = CGRect(x: 0, y: 0, width: thumbSize, height: thumbSize)
+        let path = CGPath(ellipseIn: layerFrame, transform: nil)
 
-        let thumbImage = createImage(path: path, inFrame: layerFrame, color: color)
+        let thumbImage = createImage(path: path, inFrame: layerFrame, color: color, lineWidth: 0)
         self.setThumbImage(thumbImage, for: state)
     }
 


### PR DESCRIPTION
Small but very pleasing visual change.

Before and After:
<img width="1363" alt="Screenshot 2024-12-31 at 11 30 44" src="https://github.com/user-attachments/assets/71d7428e-c52a-42c7-87a8-1bc643f94148" />
