### PR TITLE
Assume isDir is false by default to fix support with LMS

### DIFF
--- a/AmperfyKit/Api/Subsonic/SsPlayableParserDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SsPlayableParserDelegate.swift
@@ -48,8 +48,8 @@ class SsPlayableParserDelegate: SsXmlLibWithArtworkParser {
 
     if elementName == "song" || elementName == "entry" || elementName == "child" || elementName ==
       "episode" {
-      guard let isDir = attributeDict["isDir"], let isDirBool = Bool(isDir),
-            isDirBool == false else { return }
+      let isDir = attributeDict["isDir"] ?? "false"
+      guard let isDirBool = Bool(isDir), isDirBool == false else { return }
 
       if let attributeTitle = attributeDict["title"] {
         if elementName == "episode" {

--- a/AmperfyKit/Api/Subsonic/SsSongParserDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SsSongParserDelegate.swift
@@ -41,8 +41,8 @@ class SsSongParserDelegate: SsPlayableParserDelegate {
     if elementName == "song" || elementName == "entry" || elementName == "child" || elementName ==
       "episode" {
       guard let songId = attributeDict["id"] else { return }
-      guard let isDir = attributeDict["isDir"], let isDirBool = Bool(isDir),
-            isDirBool == false else { return }
+      let isDir = attributeDict["isDir"] ?? "false"
+      guard let isDirBool = Bool(isDir), isDirBool == false else { return }
 
       if let fetchedSong = library.getSong(id: songId) {
         songBuffer = fetchedSong


### PR DESCRIPTION
There is a [Lightweight Music Server](https://github.com/epoupon/lms) that is mostly compatible with the subsonic api, but does not return isDir attribute for songs. So the fix just assumes that the song is not a directory if the server did not return it explicitly. 
I don't know if this is the fine/right approach, or there should be some other way to handle this. It was just easier to fix in the app, and maybe this can help.