### PR TITLE
Fix #439 and #447

### DIFF
--- a/Amperfy/Screens/Basics/Mac - Toolbar/NowPlayingBarItem.swift
+++ b/Amperfy/Screens/Basics/Mac - Toolbar/NowPlayingBarItem.swift
@@ -34,6 +34,7 @@ import UIKit
     override init(frame: CGRect) {
       super.init(frame: frame)
       self.preferredBehavioralStyle = .pad
+      self.isContinuous = false
       refreshSliderDesign()
     }
 
@@ -68,12 +69,24 @@ import UIKit
       return super.trackRect(forBounds: customBounds)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+      refreshSliderDesign()
+    }
+
     // MARK: - Increase touch area for thumb
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
       let increasedBounds = bounds.insetBy(dx: -thumbTouchSize.width, dy: -thumbTouchSize.height)
       let containsPoint = increasedBounds.contains(point)
       return containsPoint
+    }
+
+    // If we click inside the thumb's extended touch area, no event is registered.
+    // We can fix this by always returning true here. Since this is macOS only, it
+    // is fine to always start tracking.
+    override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+      true
     }
   }
 

--- a/Amperfy/Screens/Basics/Mac - Toolbar/VolumeBarItem.swift
+++ b/Amperfy/Screens/Basics/Mac - Toolbar/VolumeBarItem.swift
@@ -27,7 +27,7 @@ import UIKit
 
   fileprivate class VolumeSlider: UISlider {
     static var sliderHeight: CGFloat = 3.0
-    static var sliderThumbHeight: CGFloat = 15.0
+    static var sliderThumbHeight: CGFloat = 14.0
 
     private var thumbTouchSize = CGSize(width: 50, height: 20)
 
@@ -43,22 +43,35 @@ import UIKit
 
     fileprivate func refreshSliderDesign() {
       let tint = UIColor.secondaryLabel
-      setUnicolorRectangularMinimumTrackImage(
+      setUnicolorRoundedMinimumTrackImage(
         trackHeight: Self.sliderHeight,
         color: tint,
         for: .normal
       )
-      setUnicolorRectangularMaximumTrackImage(
+      setUnicolorRoundedMaximumTrackImage(
         trackHeight: Self.sliderHeight,
-        color: .systemGray6,
+        color: UIColor(dynamicProvider: { traitCollection in
+          let isDark = traitCollection.userInterfaceStyle == .dark
+          return isDark ? .systemGray2 : .systemGray4
+        }),
         for: .normal
       )
       setUnicolorRoundedThumbImage(
-        thumbSize: CGSize(width: 7, height: Self.sliderThumbHeight),
-        color: .systemGray,
-        for: .normal
+        thumbSize: CGSize(width: Self.sliderThumbHeight, height: Self.sliderThumbHeight),
+        color: .systemBackground,
+        for: .normal,
+        lineWidth: 1.0,
+        strokeColor: UIColor(dynamicProvider: { traitCollection in
+          let isDark = traitCollection.userInterfaceStyle == .dark
+          return isDark ? tint : .systemGray4
+        })
       )
       backgroundColor = .clear
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+      refreshSliderDesign()
     }
 
     // MARK: - Increase touch area for thumb
@@ -69,18 +82,11 @@ import UIKit
       return containsPoint
     }
 
+    // If we click inside the thumb's extended touch area, no event is registered.
+    // We can fix this by always returning true here. Since this is macOS only, it
+    // is fine to always start tracking.
     override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
-      let percentage = CGFloat((value - minimumValue) / (maximumValue - minimumValue))
-      let thumbSizeHeight = thumbRect(
-        forBounds: bounds,
-        trackRect: trackRect(forBounds: bounds),
-        value: 0
-      ).size.height
-      let thumbPosition = thumbSizeHeight +
-        (percentage * (bounds.size.width - (2 * thumbSizeHeight)))
-      let touchLocation = touch.location(in: self)
-      return touchLocation.x <= (thumbPosition + thumbTouchSize.width) && touchLocation
-        .x >= (thumbPosition - thumbTouchSize.width)
+      true
     }
   }
 

--- a/Amperfy/Screens/Basics/PlaytimeSlider.swift
+++ b/Amperfy/Screens/Basics/PlaytimeSlider.swift
@@ -46,16 +46,19 @@ class PlaytimeSlider: UISlider {
     return containsPoint
   }
 
-  override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
-    let percentage = CGFloat((value - minimumValue) / (maximumValue - minimumValue))
-    let thumbSizeHeight = thumbRect(
-      forBounds: bounds,
-      trackRect: trackRect(forBounds: bounds),
-      value: 0
-    ).size.height
-    let thumbPosition = thumbSizeHeight + (percentage * (bounds.size.width - (2 * thumbSizeHeight)))
-    let touchLocation = touch.location(in: self)
-    return touchLocation.x <= (thumbPosition + thumbTouchSize.width) && touchLocation
-      .x >= (thumbPosition - thumbTouchSize.width)
-  }
+  #if !targetEnvironment(macCatalyst)
+    override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+      let percentage = CGFloat((value - minimumValue) / (maximumValue - minimumValue))
+      let thumbSizeHeight = thumbRect(
+        forBounds: bounds,
+        trackRect: trackRect(forBounds: bounds),
+        value: 0
+      ).size.height
+      let thumbPosition = thumbSizeHeight +
+        (percentage * (bounds.size.width - (2 * thumbSizeHeight)))
+      let touchLocation = touch.location(in: self)
+      return touchLocation.x <= (thumbPosition + thumbTouchSize.width) && touchLocation
+        .x >= (thumbPosition - thumbTouchSize.width)
+    }
+  #endif
 }

--- a/Amperfy/Screens/Player/PlayerControlView.swift
+++ b/Amperfy/Screens/Player/PlayerControlView.swift
@@ -374,7 +374,9 @@ class PlayerControlView: UIView {
       if !supportTimeInteraction {
         liveLabel.isHidden = false
         timeSlider.setThumbImage(UIImage(), for: .normal)
-        timeSlider.setThumbImage(UIImage(), for: .highlighted)
+        #if !targetEnvironment(macCatalyst)
+          timeSlider.setThumbImage(UIImage(), for: .highlighted)
+        #endif
         timeSlider.minimumValue = 0.0
         timeSlider.maximumValue = 1.0
         timeSlider.value = 0.0
@@ -406,11 +408,13 @@ class PlayerControlView: UIView {
           color: .labelColor,
           for: UIControl.State.normal
         )
-        timeSlider.setUnicolorThumbImage(
-          thumbSize: 30.0,
-          color: .labelColor,
-          for: UIControl.State.highlighted
-        )
+        #if !targetEnvironment(macCatalyst)
+          timeSlider.setUnicolorThumbImage(
+            thumbSize: 30.0,
+            color: .labelColor,
+            for: UIControl.State.highlighted
+          )
+        #endif
         let progress = Float(player.elapsedTime / player.duration)
         rootView?.popupItem.progress = progress.isNormal ? progress : 0.0
       }
@@ -422,11 +426,13 @@ class PlayerControlView: UIView {
         color: .labelColor,
         for: UIControl.State.normal
       )
-      timeSlider.setUnicolorThumbImage(
-        thumbSize: 30.0,
-        color: .labelColor,
-        for: UIControl.State.highlighted
-      )
+      #if !targetEnvironment(macCatalyst)
+        timeSlider.setUnicolorThumbImage(
+          thumbSize: 30.0,
+          color: .labelColor,
+          for: UIControl.State.highlighted
+        )
+      #endif
       elapsedTimeLabel.text = "--:--"
       remainingTimeLabel.text = "--:--"
       timeSlider.minimumValue = 0.0

--- a/AmperfyKit/Common/Utilities.swift
+++ b/AmperfyKit/Common/Utilities.swift
@@ -547,15 +547,23 @@ extension UISlider {
   public func setUnicolorRoundedThumbImage(
     thumbSize: CGSize,
     color: UIColor,
-    for state: UIControl.State
+    for state: UIControl.State,
+    lineWidth: CGFloat,
+    strokeColor: UIColor? = nil
   ) {
-    let layerFrame = CGRect(origin: .zero, size: thumbSize)
+    let layerFrame = CGRect(origin: .zero, size: thumbSize).insetBy(dx: lineWidth, dy: lineWidth)
     let path = UIBezierPath(
       roundedRect: layerFrame,
       byRoundingCorners: [.topLeft, .topRight, .bottomLeft, .bottomRight],
       cornerRadii: CGSize(width: thumbSize.width / 2, height: thumbSize.height / 2)
     ).cgPath
-    let thumbImage = createImage(path: path, inFrame: layerFrame, color: color, lineWidth: 0)
+    let thumbImage = createImage(
+      path: path,
+      inFrame: layerFrame,
+      color: color,
+      lineWidth: lineWidth,
+      strokeColor: strokeColor
+    )
     setThumbImage(thumbImage, for: state)
   }
 
@@ -572,6 +580,26 @@ extension UISlider {
     ).cgPath
     let thumbImage = createImage(path: path, inFrame: layerFrame, color: color, lineWidth: 0)
     setThumbImage(thumbImage, for: state)
+  }
+
+  public func setUnicolorRoundedMinimumTrackImage(
+    trackHeight: CGFloat,
+    color: UIColor,
+    for state: UIControl.State
+  ) {
+    let layerFrame = CGRect(origin: .zero, size: CGSize(width: trackHeight, height: trackHeight))
+    let radii = trackHeight / 2
+    let path = UIBezierPath(
+      roundedRect: layerFrame,
+      byRoundingCorners: [.topLeft, .bottomLeft],
+      cornerRadii: CGSize(width: radii, height: radii)
+    ).cgPath
+    let trackImage = createImage(path: path, inFrame: layerFrame, color: color, lineWidth: 0)
+      .resizableImage(
+        withCapInsets: UIEdgeInsets(top: 0, left: radii, bottom: 0, right: 0),
+        resizingMode: .stretch
+      )
+    setMinimumTrackImage(trackImage, for: .normal)
   }
 
   public func setUnicolorRectangularMinimumTrackImage(
@@ -593,6 +621,26 @@ extension UISlider {
     let layerFrame = CGRect(origin: .zero, size: CGSize(width: 1, height: trackHeight))
     let path = CGPath(rect: layerFrame, transform: nil)
     let trackImage = createImage(path: path, inFrame: layerFrame, color: color, lineWidth: 0)
+    setMaximumTrackImage(trackImage, for: .normal)
+  }
+
+  public func setUnicolorRoundedMaximumTrackImage(
+    trackHeight: CGFloat,
+    color: UIColor,
+    for state: UIControl.State
+  ) {
+    let layerFrame = CGRect(origin: .zero, size: CGSize(width: trackHeight, height: trackHeight))
+    let radii = trackHeight / 2
+    let path = UIBezierPath(
+      roundedRect: layerFrame,
+      byRoundingCorners: [.topRight, .bottomRight],
+      cornerRadii: CGSize(width: radii, height: radii)
+    ).cgPath
+    let trackImage = createImage(path: path, inFrame: layerFrame, color: color, lineWidth: 0)
+      .resizableImage(
+        withCapInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: radii),
+        resizingMode: .stretch
+      )
     setMaximumTrackImage(trackImage, for: .normal)
   }
 


### PR DESCRIPTION
Changes: 
- NowPlayingSlider: isContinous set to false
- NowPlayingSlider: Fix beginTracking 
- NowPlayingSlider: Fix toggle light and dark mode does not update design
- VolumeBarItem: Update design to match the native music app
- VolumeBarItem: Fix toggle light and dark mode does not update design
- VolumeBarItem: Fix background disappears when tabbar is visible
- MiniPlayer: Fix playtime slider is not clickable and magnifies 