### PR TITLE
adjust scrobble timing logic

### DIFF
--- a/AmperfyKit/Player/ScrobbleSyncer.swift
+++ b/AmperfyKit/Player/ScrobbleSyncer.swift
@@ -27,7 +27,7 @@ import os.log
 
 @MainActor
 public class ScrobbleSyncer {
-  private static let maximumWaitDurationInSec = 20
+  private static let maximumWaitDurationInSec = 240 //scrobble at 4 min or 50% of duration
 
   private let log = OSLog(subsystem: "Amperfy", category: "ScrobbleSyncer")
   private let musicPlayer: AudioPlayer


### PR DESCRIPTION
Using 20 seconds for `maximumWaitDurationInSec` creates a situation where the player will submit `submission=true` after only 20 seconds of play time. This creates a problem as it fires anytime the user clicks pause/next.

Setting it to 4 minutes follows the standard scrobble logic of 50% of the song duration (`curPlayingSong.duration / 2`) or 4 minutes for any song longer than 4 minutes.


