### PR TITLE
Fix for scrobble timer

### DIFF
--- a/Amperfy/Screens/ViewController/TableViewHelper/BasicTableViewController.swift
+++ b/Amperfy/Screens/ViewController/TableViewHelper/BasicTableViewController.swift
@@ -407,7 +407,9 @@ class BasicTableViewController: KeyCommandTableViewController {
     }
     action.backgroundColor = buttonColor
     if actionType == .favorite {
-      action.image = preCbContainable.isFavorite ? UIImage.heartFill : UIImage.heartEmpty
+        action.image = preCbContainable.isFavorite
+            ? UIImage.heartFill.withRenderingMode(.alwaysOriginal)
+            : UIImage.heartEmpty.withRenderingMode(.alwaysOriginal)
     } else {
       action.image = actionType.image.withRenderingMode(.alwaysOriginal)
     }

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -984,7 +984,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   private func scrobble(song: Song, submission: Bool, date: Date? = nil) async throws {
     guard isSyncAllowed else { return }
     if !submission {
-      os_log("Now Playing Beginn: %s", log: log, type: .info, song.displayString)
+      os_log("Now Playing Begin: %s", log: log, type: .info, song.displayString)
     } else if let date = date {
       os_log("Scrobbled at %s: %s", log: log, type: .info, date.description, song.displayString)
     } else {

--- a/AmperfyKit/Player/ScrobbleSyncer.swift
+++ b/AmperfyKit/Player/ScrobbleSyncer.swift
@@ -27,7 +27,7 @@ import os.log
 
 @MainActor
 public class ScrobbleSyncer {
-  private static let maximumWaitDurationInSec = 20
+  private static let maximumWaitDurationInSec = 240 //scrobble at 4 min or 50% of duration
 
   private let log = OSLog(subsystem: "Amperfy", category: "ScrobbleSyncer")
   private let musicPlayer: AudioPlayer

--- a/AmperfyKit/Player/ScrobbleSyncer.swift
+++ b/AmperfyKit/Player/ScrobbleSyncer.swift
@@ -27,7 +27,7 @@ import os.log
 
 @MainActor
 public class ScrobbleSyncer {
-  private static let maximumWaitDurationInSec = 240 //scrobble at 4 min or 50% of duration
+  private static let maximumWaitDurationInSec: TimeInterval = 240 //scrobble at 4 min or 50% of duration
 
   private let log = OSLog(subsystem: "Amperfy", category: "ScrobbleSyncer")
   private let musicPlayer: AudioPlayer
@@ -39,6 +39,11 @@ public class ScrobbleSyncer {
   private var isRunning = false
   private var isActive = false
   private var scrobbleTimer: Timer?
+  
+  // Track how long the song has actually been played
+  private var accumulatedPlayTime: TimeInterval = 0
+  private var playStartTimestamp: Date?
+  private var currentSongThreshold: TimeInterval = 0
 
   private var songToBeScrobbled: Song?
   private var songHasBeenListendEnough = false
@@ -179,16 +184,28 @@ public class ScrobbleSyncer {
     else { return }
 
     songToBeScrobbled = curPlayingSong
+    
+    // Reset tracking variables
+    accumulatedPlayTime = 0
+    playStartTimestamp = Date()
 
-    var waitDuration = curPlayingSong.duration / 2
+    // Calculate threshold time (half of duration or maximum)
+    let waitDuration: TimeInterval = TimeInterval(curPlayingSong.duration) / 2
     if waitDuration > Self.maximumWaitDurationInSec {
-      waitDuration = Self.maximumWaitDurationInSec
+      currentSongThreshold = Self.maximumWaitDurationInSec
+    } else {
+      currentSongThreshold = waitDuration
     }
-    let curPlayingId = curPlayingSong.managedObject.objectID
-
+    
+    startScrobbleTimer(forSong: curPlayingSong, withDuration: currentSongThreshold)
+  }
+  
+  private func startScrobbleTimer(forSong song: Song, withDuration duration: TimeInterval) {
+    let curPlayingId = song.managedObject.objectID
+    
     scrobbleTimer?.invalidate()
     scrobbleTimer = Timer.scheduledTimer(
-      withTimeInterval: TimeInterval(waitDuration),
+      withTimeInterval: duration,
       repeats: false
     ) { _ in
       Task { @MainActor in
@@ -206,7 +223,12 @@ public class ScrobbleSyncer {
   private func syncSongStopped(clearCurPlaying: Bool) async {
     func clearingCurPlaying() {
       songHasBeenListendEnough = false
+      scrobbleTimer?.invalidate()
+      scrobbleTimer = nil
       songToBeScrobbled = nil
+      accumulatedPlayTime = 0
+      playStartTimestamp = nil
+      currentSongThreshold = 0
     }
 
     if let oldSong = songToBeScrobbled,
@@ -230,10 +252,41 @@ extension ScrobbleSyncer: MusicPlayable {
     guard let curPlaying = musicPlayer.currentlyPlaying,
           let curPlayingSong = curPlaying.asSong
     else { return }
+    
+    // Check if it's still the same song after a pause
+    if let songToBeScrobbled = songToBeScrobbled, songToBeScrobbled == curPlayingSong {
+      // Record when we started playing again
+      playStartTimestamp = Date()
+      
+      // Only restart the timer if we haven't already hit the threshold
+      if !songHasBeenListendEnough {
+        // Calculate remaining time needed
+        let remainingTime = currentSongThreshold - accumulatedPlayTime
+        if remainingTime > 0 {
+          // Start a new timer with just the remaining time needed
+          startScrobbleTimer(forSong: curPlayingSong, withDuration: remainingTime)
+        } else {
+          // Threshold met, mark it immediately
+          songHasBeenListendEnough = true
+        }
+      }
+    }
+    
     Task { await scrobble(playedSong: curPlayingSong, songPosition: .start) }
   }
 
   public func didPause() {
+    // Update the accumulated play time when paused
+    if let startTime = playStartTimestamp {
+      let playedTime = Date().timeIntervalSince(startTime)
+      accumulatedPlayTime += playedTime
+      playStartTimestamp = nil
+    }
+    
+    // Cancel the current timer
+    scrobbleTimer?.invalidate()
+    scrobbleTimer = nil
+    
     Task { await syncSongStopped(clearCurPlaying: false) }
   }
 


### PR DESCRIPTION
This ensures songs are only scrobbled after being truly listened to for the required duration (50% of the song or 4 minutes, whichever is less).

The scrobbling system previously continued the timer even when songs were paused, incorrectly counting paused time toward the scrobble threshold.

This change properly tracks only actual play time by:

- Adding tracking for accumulated play time across pause/resume cycles
- Storing playback start timestamps to measure actual listening duration
- Canceling timers during pause and recalculating remaining time on resume


Previously maximumWaitDurationInSec was set to 20 seconds creating a situation where the player would submit submission=true after only 20 seconds of play time. This creates a problem as it fires anytime the user clicks pause/next.

Setting it to 240 seconds follows the standard scrobble logic of 50% of the song duration or 4 minutes for songs that are >=4 minutes in duration.
