### PR TITLE
Feature: Song `Date Added` Sort Feature

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -1050,6 +1050,7 @@
 		63DCDB992C6752F000522F68 /* AppKitController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitController.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
+		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3425,6 +3426,7 @@
 		500BB49521CAAA2700D367CF /* Amperfy.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */,
 				5042B71F2D82FFA50086B9C4 /* Amperfy v45.xcdatamodel */,
 				50CA61272D4D72F600EEF515 /* Amperfy v44.xcdatamodel */,
 				50CA61222D4B658200EEF515 /* Amperfy v43.xcdatamodel */,
@@ -3471,7 +3473,7 @@
 				506B3A3823B4539D00E31F21 /* Amperfy v2.xcdatamodel */,
 				500BB49621CAAA2700D367CF /* Amperfy.xcdatamodel */,
 			);
-			currentVersion = 5042B71F2D82FFA50086B9C4 /* Amperfy v45.xcdatamodel */;
+			currentVersion = 64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */;
 			path = Amperfy.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddSongsVC.swift
+++ b/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddSongsVC.swift
@@ -180,6 +180,8 @@ class PlaylistAddSongsVC: SingleFetchedResultsTableViewController<SongMO>, Playl
       return 0.0
     case .rating:
       return CommonScreenOperations.tableSectionHeightLarge
+    case .addedDate:
+      return 0.0
     case .duration:
       return 0.0
     case .starredDate:
@@ -202,6 +204,8 @@ class PlaylistAddSongsVC: SingleFetchedResultsTableViewController<SongMO>, Playl
       } else {
         return "Not rated"
       }
+    case .addedDate:
+      return nil
     case .duration:
       return nil
     case .starredDate:

--- a/Amperfy/Screens/ViewController/SongsVC.swift
+++ b/Amperfy/Screens/ViewController/SongsVC.swift
@@ -183,6 +183,8 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
       return 0.0
     case .rating:
       return CommonScreenOperations.tableSectionHeightLarge
+    case .addedDate:
+      return 0.0
     case .duration:
       return 0.0
     case .starredDate:
@@ -205,6 +207,8 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
       } else {
         return "Not rated"
       }
+    case .addedDate:
+      return nil
     case .duration:
       return nil
     case .starredDate:
@@ -358,12 +362,33 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
         )
       }
     )
+    let sortByAddedDate = UIAction(
+      title: "Date Added",
+      image: sortType == .addedDate ? .check : nil,
+      handler: { _ in
+        self.change(sortType: .addedDate)
+        self.saveSortPreference(preference: .addedDate)
+        self.updateSearchResults(for: self.searchController)
+        self.appDelegate.notificationHandler.post(
+          name: .fetchControllerSortChanged,
+          object: nil,
+          userInfo: nil
+        )
+      }
+    )
     if displayFilter == .favorites, appDelegate.backendApi.selectedApi != .ampache {
       return UIMenu(
         title: "Sort",
         image: .sort,
         options: [],
-        children: [sortByName, sortByRating, sortByDuration, sortByStarredDate]
+        children: [sortByName, sortByRating, sortByDuration, sortByStarredDate, sortByAddedDate]
+      )
+    } else if appDelegate.backendApi.selectedApi != .ampache {
+      return UIMenu(
+        title: "Sort",
+        image: .sort,
+        options: [],
+        children: [sortByName, sortByRating, sortByDuration, sortByAddedDate]
       )
     } else {
       return UIMenu(

--- a/AmperfyKit/Api/Subsonic/SsSongParserDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SsSongParserDelegate.swift
@@ -131,6 +131,11 @@ class SsSongParserDelegate: SsPlayableParserDelegate {
           songBuffer?.genre = genre
         }
       }
+      if let createdTag = attributeDict["created"] {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions.insert(.withFractionalSeconds)
+        songBuffer?.addedDate = dateFormatter.date(from: createdTag)
+      }
     }
 
     super.parser(

--- a/AmperfyKit/Storage/EntityWrappers/Song.swift
+++ b/AmperfyKit/Storage/EntityWrappers/Song.swift
@@ -76,6 +76,16 @@ public class Song: AbstractPlayable, Identifyable {
     }
   }
 
+  public var addedDate: Date? {
+    get {
+      guard let addedDateMO = managedObject.addedDate else { return nil }
+      return addedDateMO
+    }
+    set {
+      managedObject.addedDate = newValue
+    }
+  }
+
   public var isOrphaned: Bool {
     guard let album = album else { return true }
     return album.isOrphaned

--- a/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/.xccurrentversion
+++ b/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Amperfy v45.xcdatamodel</string>
+    <string>Amperfy v46.xcdatamodel</string>
 </dict>
 </plist>

--- a/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/Amperfy v46.xcdatamodel/contents
+++ b/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/Amperfy v46.xcdatamodel/contents
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AbstractLibraryEntity" representedClassName="AbstractLibraryEntityMO" isAbstract="YES" elementID="AbstractLibraryElementMO" syncable="YES">
+        <attribute name="alphabeticSectionInitial" attributeType="String" defaultValueString="?"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="playCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rating" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteStatus" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="starredDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="artwork" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Artwork" inverseName="owners" inverseEntity="Artwork"/>
+        <relationship name="searchHistory" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SearchHistoryItem" inverseName="searchedLibraryEntity" inverseEntity="SearchHistoryItem"/>
+        <fetchIndex name="byAbstractLibraryEntityIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="AbstractPlayable" representedClassName="AbstractPlayableMO" isAbstract="YES" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="bitrate" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="combinedDuration" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="contentType" optional="YES" attributeType="String"/>
+        <attribute name="contentTypeTranscoded" optional="YES" attributeType="String"/>
+        <attribute name="disk" optional="YES" attributeType="String"/>
+        <attribute name="playDuration" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playProgress" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="relFilePath" optional="YES" attributeType="String"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 16" usesScalarValueType="YES" elementID="duration"/>
+        <attribute name="size" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="track" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="year" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="download" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Download" inverseName="playable" inverseEntity="Download"/>
+        <relationship name="embeddedArtwork" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="EmbeddedArtwork" inverseName="owner" inverseEntity="EmbeddedArtwork"/>
+        <relationship name="file" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="PlayableFile" inverseName="info" inverseEntity="PlayableFile" elementID="dataMO"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PlaylistItem" inverseName="playable" inverseEntity="PlaylistItem" elementID="playlistElements"/>
+        <relationship name="scrobbleEntries" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ScrobbleEntry" inverseName="playable" inverseEntity="ScrobbleEntry"/>
+        <fetchIndex name="byAbstractPlayableIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Album" representedClassName="AlbumMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isCached" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSongsMetaDataSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="newestIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="recentIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteSongCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="songCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="year" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="albums" inverseEntity="Artist"/>
+        <relationship name="genre" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Genre" inverseName="albums" inverseEntity="Genre"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="album" inverseEntity="Song" elementID="songsMO"/>
+        <fetchIndex name="byAlbumIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Artist" representedClassName="ArtistMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="albumCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="remoteAlbumCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="albums" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Album" inverseName="artist" inverseEntity="Album"/>
+        <relationship name="genre" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Genre" inverseName="artists" inverseEntity="Genre"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="artist" inverseEntity="Song" elementID="songsMO"/>
+        <fetchIndex name="byArtistIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byArtistNameIndex">
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Artwork" representedClassName="ArtworkMO" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="imageData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="relFilePath" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" elementID="statusMO"/>
+        <attribute name="type" attributeType="String" defaultValueString=""/>
+        <attribute name="url" optional="YES" attributeType="String" elementID="urlMO"/>
+        <relationship name="download" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Download" inverseName="artwork" inverseEntity="Download"/>
+        <relationship name="owners" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractLibraryEntity" inverseName="artwork" inverseEntity="AbstractLibraryEntity"/>
+        <fetchIndex name="byArtworkIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Directory" representedClassName="DirectoryMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="isCached" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subdirectoryCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="musicFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MusicFolder" inverseName="directories" inverseEntity="MusicFolder"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Directory" inverseName="subdirectories" inverseEntity="Directory"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="directory" inverseEntity="Song"/>
+        <relationship name="subdirectories" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Directory" inverseName="parent" inverseEntity="Directory"/>
+        <fetchIndex name="byDirectoryIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Download" representedClassName="DownloadMO" syncable="YES">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="errorDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="errorType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="finishDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="progressPercent" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="totalSize" optional="YES" attributeType="String"/>
+        <attribute name="urlString" attributeType="String" defaultValueString=""/>
+        <relationship name="artwork" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="download" inverseEntity="Artwork"/>
+        <relationship name="playable" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="download" inverseEntity="AbstractPlayable"/>
+        <fetchIndex name="byDownloadIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="EmbeddedArtwork" representedClassName="EmbeddedArtworkMO" syncable="YES">
+        <attribute name="imageData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="relFilePath" optional="YES" attributeType="String"/>
+        <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="embeddedArtwork" inverseEntity="AbstractPlayable"/>
+    </entity>
+    <entity name="Genre" representedClassName="GenreMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="albumCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="artistCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="albums" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Album" inverseName="genre" inverseEntity="Album"/>
+        <relationship name="artists" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Artist" inverseName="genre" inverseEntity="Artist"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="genre" inverseEntity="Song"/>
+        <fetchIndex name="byGenreIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byGenreNameIndex">
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="LogEntry" representedClassName="LogEntryMO" syncable="YES">
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="message" attributeType="String"/>
+        <attribute name="statusCode" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="suppressionTimeInterval" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="MusicFolder" representedClassName="MusicFolderMO" syncable="YES">
+        <attribute name="directoryCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isCached" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="directories" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Directory" inverseName="musicFolder" inverseEntity="Directory"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="musicFolder" inverseEntity="Song"/>
+        <fetchIndex name="byMusicFolderIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PlayableFile" representedClassName="PlayableFileMO" elementID="SongFile" syncable="YES">
+        <attribute name="data" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <relationship name="info" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="file" inverseEntity="AbstractPlayable"/>
+    </entity>
+    <entity name="Player" representedClassName="PlayerMO" syncable="YES">
+        <attribute name="autoCachePlayedItemSetting" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES" elementID="autoCachePlayedSongSetting"/>
+        <attribute name="isUserQueuePlaying" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES" elementID="isWaitingQueuePlaying"/>
+        <attribute name="musicIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" elementID="currentSongIndex"/>
+        <attribute name="musicPlaybackRate" optional="YES" attributeType="Double" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="playerMode" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="podcastIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="podcastPlaybackRate" optional="YES" attributeType="Double" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="repeatSetting" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="shuffleSetting" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" elementID="shuffelSetting"/>
+        <relationship name="contextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersContextPlaylist" inverseEntity="Playlist" elementID="playlist"/>
+        <relationship name="podcastPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersPodcastPlaylist" inverseEntity="Playlist"/>
+        <relationship name="shuffledContextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersShuffledContextPlaylist" inverseEntity="Playlist" elementID="shuffledPlaylist"/>
+        <relationship name="userQueuePlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersUserQueuePlaylist" inverseEntity="Playlist" elementID="waitingQueuePlaylist"/>
+    </entity>
+    <entity name="Playlist" representedClassName="PlaylistMO" syncable="YES">
+        <attribute name="alphabeticSectionInitial" attributeType="String" defaultValueString="?"/>
+        <attribute name="changeDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isCached" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="playCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteSongCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="songCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="artworkItems" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PlaylistItem" inverseName="playlistArtworkItem" inverseEntity="PlaylistItem"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PlaylistItem" inverseName="playlist" inverseEntity="PlaylistItem" elementID="entries"/>
+        <relationship name="playersContextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="contextPlaylist" inverseEntity="Player" elementID="currentlyPlaying"/>
+        <relationship name="playersPodcastPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="podcastPlaylist" inverseEntity="Player"/>
+        <relationship name="playersShuffledContextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="shuffledContextPlaylist" inverseEntity="Player" elementID="playersShuffledPlaylist"/>
+        <relationship name="playersUserQueuePlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="userQueuePlaylist" inverseEntity="Player" elementID="playersWaitingQueuePlaylist"/>
+        <relationship name="searchHistory" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SearchHistoryItem" inverseName="searchedPlaylist" inverseEntity="SearchHistoryItem"/>
+        <fetchIndex name="byPlaylistIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PlaylistItem" representedClassName="PlaylistItemMO" syncable="YES">
+        <attribute name="order" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="playable" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="playlistItems" inverseEntity="AbstractPlayable" elementID="song"/>
+        <relationship name="playlist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="items" inverseEntity="Playlist"/>
+        <relationship name="playlistArtworkItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="artworkItems" inverseEntity="Playlist"/>
+    </entity>
+    <entity name="Podcast" representedClassName="PodcastMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="depiction" attributeType="String" defaultValueString=""/>
+        <attribute name="episodeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isCached" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="episodes" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="PodcastEpisode" inverseName="podcast" inverseEntity="PodcastEpisode"/>
+        <fetchIndex name="byPodcastIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PodcastEpisode" representedClassName="PodcastEpisodeMO" parentEntity="AbstractPlayable" syncable="YES">
+        <attribute name="depiction" optional="YES" attributeType="String"/>
+        <attribute name="publishDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="streamId" optional="YES" attributeType="String"/>
+        <relationship name="podcast" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Podcast" inverseName="episodes" inverseEntity="Podcast"/>
+        <fetchIndex name="byPodcastEpisodeIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Radio" representedClassName="RadioMO" parentEntity="AbstractPlayable" syncable="YES">
+        <attribute name="siteUrl" optional="YES" attributeType="String"/>
+        <fetchIndex name="byRadioIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ScrobbleEntry" representedClassName="ScrobbleEntryMO" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isUploaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="playable" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="scrobbleEntries" inverseEntity="AbstractPlayable"/>
+    </entity>
+    <entity name="SearchHistoryItem" representedClassName="SearchHistoryItemMO" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="searchedLibraryEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractLibraryEntity" inverseName="searchHistory" inverseEntity="AbstractLibraryEntity"/>
+        <relationship name="searchedPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="searchHistory" inverseEntity="Playlist"/>
+        <fetchIndex name="bySearchHistoryDateIndex">
+            <fetchIndexElement property="date" type="Binary" order="descending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Song" representedClassName="SongMO" parentEntity="AbstractPlayable" syncable="YES">
+        <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lyricsRelFilePath" optional="YES" attributeType="String"/>
+        <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="songs" inverseEntity="Album"/>
+        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="songs" inverseEntity="Artist"/>
+        <relationship name="directory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Directory" inverseName="songs" inverseEntity="Directory"/>
+        <relationship name="genre" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Genre" inverseName="songs" inverseEntity="Genre"/>
+        <relationship name="musicFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MusicFolder" inverseName="songs" inverseEntity="MusicFolder"/>
+        <fetchIndex name="bySongIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="UserStatistics" representedClassName="UserStatisticsMO" syncable="YES">
+        <attribute name="activeRepeatAllSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeRepeatOffSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeRepeatSingleSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeShuffleOffSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeShuffleOnSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="appSessionsStartedCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="appStartedViaNotificationCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="appVersion" attributeType="String" defaultValueString=""/>
+        <attribute name="backgroundFetchFailedCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backgroundFetchNewDataCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backgroundFetchNoDataCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="localNotificationCreationCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playedSongFromCacheCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playedSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playedSongViaStreamCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAirplayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAlertGoToAlbumCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAlertGoToArtistCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAlertGoToPodcastCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedChangePlayerDisplayStyleCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedPlayerOptionsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedPlayerSeekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedAlbumDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedAlbumsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedArtistDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedArtistsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedDirectoriesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedDownloadsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedEventLogCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedGenreDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedGenresCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedIndexesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedLibraryCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedLicenseCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedMusicFoldersCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPlaylistDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPlaylistsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPlaylistSelectorCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPodcastDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPodcastsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPopupPlayerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedRadiosCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSearchCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsLibraryCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsPlayerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsPlayerSongTabCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsServerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsSupportCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/AmperfyKit/Storage/ManagedObjects/Migration/CoreDataMigrationVersion.swift
+++ b/AmperfyKit/Storage/ManagedObjects/Migration/CoreDataMigrationVersion.swift
@@ -55,6 +55,7 @@ enum CoreDataMigrationVersion: String, CaseIterable {
   case v43 = "Amperfy v43" // Add isCached, Increase duration for collections from Int16 to Int64
   case v44 = "Amperfy v44" // use Fetch Index
   case v45 = "Amperfy v45" // Download: id has default value "Empty String"
+  case v46 = "Amperfy v46" // Add addedDate for songs
 
   // MARK: - Current
 
@@ -159,6 +160,8 @@ enum CoreDataMigrationVersion: String, CaseIterable {
     case .v44:
       return .v45
     case .v45:
+      return .v46
+    case .v46:
       return nil
     }
   }

--- a/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataClass.swift
+++ b/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataClass.swift
@@ -147,4 +147,22 @@ extension SongMO: CoreDataIdentifyable {
     ]
     return fetchRequest
   }
+
+  static var addedDateSortedFetchRequest: NSFetchRequest<SongMO> {
+    let fetchRequest: NSFetchRequest<SongMO> = SongMO.fetchRequest()
+    fetchRequest.sortDescriptors = [
+      NSSortDescriptor(key: #keyPath(SongMO.addedDate), ascending: false),
+      NSSortDescriptor(
+        key: Self.identifierKeyString,
+        ascending: true,
+        selector: #selector(NSString.localizedStandardCompare)
+      ),
+      NSSortDescriptor(
+        key: "id",
+        ascending: true,
+        selector: #selector(NSString.localizedStandardCompare)
+      ),
+    ]
+    return fetchRequest
+  }
 }

--- a/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataProperties.swift
+++ b/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataProperties.swift
@@ -31,6 +31,8 @@ extension SongMO {
   @NSManaged
   public var lyricsRelFilePath: String?
   @NSManaged
+  public var addedDate: Date?
+  @NSManaged
   public var album: AlbumMO?
   @NSManaged
   public var artist: ArtistMO?
@@ -42,6 +44,7 @@ extension SongMO {
   public var musicFolder: MusicFolderMO?
 
   static let relationshipKeyPathsForPrefetching = [
+    #keyPath(SongMO.addedDate),
     #keyPath(SongMO.album),
     #keyPath(SongMO.artist),
     #keyPath(SongMO.artwork),

--- a/AmperfyKit/Storage/ResultController/FetchedResultsControllers.swift
+++ b/AmperfyKit/Storage/ResultController/FetchedResultsControllers.swift
@@ -108,6 +108,7 @@ public enum PlaylistSortType: Int, Sendable {
 public enum SongElementSortType: Int, Sendable {
   case name = 0
   case rating = 1
+  case addedDate = 2
   case duration = 3
   case starredDate = 4
 
@@ -120,6 +121,8 @@ public enum SongElementSortType: Int, Sendable {
       return .alphabet
     case .rating:
       return .rating
+    case .addedDate:
+      return .newestOrRecent
     case .duration:
       return .durationSong
     case .starredDate:
@@ -133,6 +136,8 @@ public enum SongElementSortType: Int, Sendable {
       return true
     case .rating:
       return true
+    case .addedDate:
+      return false
     case .duration:
       return true
     case .starredDate:
@@ -713,6 +718,8 @@ public class SongsFetchedResultsController: CachedFetchedResultsController<SongM
       fetchRequest = SongMO.alphabeticSortedFetchRequest
     case .rating:
       fetchRequest = SongMO.ratingSortedFetchRequest
+    case .addedDate:
+      fetchRequest = SongMO.addedDateSortedFetchRequest
     case .duration:
       fetchRequest = SongMO.durationSortedFetchRequest
     case .starredDate:


### PR DESCRIPTION
### Description
Added the ability for Subsonic users to sort songs in their library by the date they were added to their library.

> [!NOTE]
> I was able to run the linter/formatter, but (after troubleshooting for hours) I was not able to get unit tests to run.  It has something to do with code signing configurations and development team configurations.  I apologize for the inconvenience.  The error body is below in case you find it useful.

#### Unit Test Issue
```text
Failed to load the test bundle. (Underlying Error: The bundle “AmperfyKitTests” couldn’t be loaded. The bundle couldn’t be loaded. Try reinstalling the bundle. dlopen(/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests, 0x0109): tried: '/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/AmperfyKitTests' (no such file), '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/AmperfyKitTests' (no such file), '/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/AmperfyKitTests' (no such file), '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/AmperfyKitTests' (no such file), '/System/iOSSupport/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/System/iOSSupport/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' (no such file), '/System/iOSSupport/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' (no such file), '/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' (code signature in <26C26DB2-D607-3F34-A22B-E42C5DDD5311> '/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/System/Volumes/Preboot/Cryptexes/OS/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' (no such file), '/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' (code signature in <26C26DB2-D607-3F34-A22B-E42C5DDD5311> '/Users/USERNAME/Library/Developer/Xcode/DerivedData/Amperfy-dmzfyzzvlfmizucdhjkgkzqpsytv/Build/Products/Debug-maccatalyst/Amperfy.app/Contents/PlugIns/AmperfyKitTests.xctest/Contents/MacOS/AmperfyKitTests' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs))
```