### PR TITLE
Fix regression on HLS from 2.0.0

### DIFF
--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -105,6 +105,7 @@ class BackendAudioPlayer: NSObject {
   private var volumePlayer: Float = 1.0
 
   private var player: AudioStreamingPlayer?
+  private var basicAVPlayer: AVPlayer?
   private var equalizer: AVAudioUnitEQ?
   private var replayGainNode: AVAudioMixerNode?
   public private(set) var audioAnalyzer: AudioAnalyzer
@@ -438,6 +439,7 @@ class BackendAudioPlayer: NSObject {
       perloadedStreamingBitrate = nil
       activeTranscodingFormat = nil
       preloadTranscodingFormat = nil
+      basicAVPlayer = nil
       guard playable.isPlayableOniOS || streamingTranscodings
         .isTranscodingActive(networkMonitor: networkMonitor) else {
         reactToIncompatibleContentType(
@@ -452,6 +454,16 @@ class BackendAudioPlayer: NSObject {
               URL(string: urlString) != nil
         else {
           reactToInvalidRadioUrl(playableDisplayTitle: playable.displayString)
+          return
+        }
+        // Basic AVFoundation radio playback quick and easy
+        if urlString.contains(".m3u8"),
+           let radioUrl = URL(string: urlString) {
+          stop()
+          basicAVPlayer = AVPlayer(url: radioUrl)
+          basicAVPlayer?.play()
+
+          isPlaying = true
           return
         }
       }
@@ -515,6 +527,8 @@ class BackendAudioPlayer: NSObject {
     seekTimeWhenStarted = nil
     isPlaying = false
     playType = nil
+    basicAVPlayer?.pause()
+    basicAVPlayer = nil
 
     stopTimers()
     audioAnalyzer.stop()


### PR DESCRIPTION
There's a regression on HTTP Live Streaming radios, since the use of the AudrioStreaming Library that doesn't support it.
When you play a radio with this format is always impossible to play the music and often a crash `Crashed: AURemoteIO::IOThread`.
But before using this library it was working without issues.

I've put together a quick hotfix to use the AVPlayer instead when we are using a m3u8 file, tested with:

- switching from other radios / songs
- enqueuing after other songs
- using the control buttons

I know the fix it's not optimal and you may want to make it better but pls, I need my radios in gym 🏋️ 