### PR TITLE
[Bugfix] Fix scrubbing issue with UISlider

### DIFF
--- a/Amperfy/Screens/Player/PlayerUIHandler.swift
+++ b/Amperfy/Screens/Player/PlayerUIHandler.swift
@@ -369,8 +369,18 @@ class PlayerUIHandler: NSObject {
     playTypeIcon: UIImageView,
     liveLabel: UILabel
   ) {
+    if timeSlider.trackConfiguration == nil {
+      timeSlider.trackConfiguration = UISlider.TrackConfiguration(
+        allowsTickValuesOnly: false,
+        ticks: []
+      )
+    } else {
+      timeSlider.trackConfiguration?.allowsTickValuesOnly = false
+    }
+
     timeSlider.preferredBehavioralStyle = .pad
     timeSlider.sliderStyle = .thumbless
+
     if let currentlyPlaying = player.currentlyPlaying {
       let supportTimeInteraction = !currentlyPlaying.isRadio
       timeSlider.isEnabled = supportTimeInteraction && (style != .miniPlayeriOS)


### PR DESCRIPTION
I believe the reason why song scrubbing isn't working (https://github.com/BLeeEZ/amperfy/issues/600) is because UISlider has a property called `allowsTickValuesOnly` that defaults to `true`. I'm assuming this was a recent iOS change or something and that scrubbing used to work without needing to override this property. It seems like we don't want this restriction, instead we want to be able to scrub anywhere between 0 and the song's max duration. I tested this fix in XCode on an iPhone 17 Pro and it seemed to fix the issue for me!