### PR TITLE
Change scrobble API call to use correct "time" parameter

### DIFF
--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -865,7 +865,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
         id: id
       )
       if let date = date {
-        urlComp.addQueryItem(name: "date", value: Int(date.timeIntervalSince1970))
+        urlComp.addQueryItem(name: "time", value: Int(date.timeIntervalSince1970))
       }
       urlComp.addQueryItem(name: "submission", value: submission.description)
       return try self.createUrl(from: urlComp)


### PR DESCRIPTION
Should resolve https://github.com/BLeeEZ/amperfy/issues/461#issue-3035113343

I double checked the code and I think this is the only change that should be made to change all scrobble API calls to the correct parameter "time" instead of the incorrect "date".

Subsonic API for reference: https://subsonic.org/pages/api.jsp#scrobble.