### PR TITLE
Add parametric equalizer with interactive frequency response curve

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A10000010000000000000007 /* BandControlPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000010000000000000001 /* BandControlPanel.swift */; };
+		A10000010000000000000008 /* EQToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000010000000000000002 /* EQToolbar.swift */; };
+		A10000010000000000000009 /* FrequencyResponseCurve.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000010000000000000003 /* FrequencyResponseCurve.swift */; };
+		A1000001000000000000000A /* ParametricEQView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000010000000000000004 /* ParametricEQView.swift */; };
+		A1000001000000000000000B /* ParametricEQViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000010000000000000005 /* ParametricEQViewModel.swift */; };
+		A1000001000000000000000C /* ParametricEQTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000010000000000000006 /* ParametricEQTest.swift */; };
 		43FBE27F250D4DFD00D5F9B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43FBE27E250D4DFD00D5F9B3 /* LaunchScreen.storyboard */; };
 		5003D8FB267B3390006946BF /* LibrarySyncPopupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5003D8FA267B3390006946BF /* LibrarySyncPopupVC.swift */; };
 		5005938928E2D4EF008C8DF6 /* CommonCollectionSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5005938828E2D4EF008C8DF6 /* CommonCollectionSectionHeader.xib */; };
@@ -586,6 +592,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A10000010000000000000001 /* BandControlPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandControlPanel.swift; sourceTree = "<group>"; };
+		A10000010000000000000002 /* EQToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EQToolbar.swift; sourceTree = "<group>"; };
+		A10000010000000000000003 /* FrequencyResponseCurve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyResponseCurve.swift; sourceTree = "<group>"; };
+		A10000010000000000000004 /* ParametricEQView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParametricEQView.swift; sourceTree = "<group>"; };
+		A10000010000000000000005 /* ParametricEQViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParametricEQViewModel.swift; sourceTree = "<group>"; };
+		A10000010000000000000006 /* ParametricEQTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParametricEQTest.swift; sourceTree = "<group>"; };
 		43FBE27E250D4DFD00D5F9B3 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5002565625E69DC700674CE1 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		5003D8F62678DD39006946BF /* SsAlbumParserPreCreatedArtistsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsAlbumParserPreCreatedArtistsTest.swift; sourceTree = "<group>"; };
@@ -1272,11 +1284,24 @@
 		502041962E2A37D6003CE29A /* Player */ = {
 			isa = PBXGroup;
 			children = (
+				A1000001000000000000000D /* ParametricEQ */,
 				5020419C2E2A3C77003CE29A /* iOS-SpotifyEquilizerView */,
 				50791E8628D3B7BF006CE6E5 /* PlayerSettingsView.swift */,
 				502041972E2A37F2003CE29A /* EqualizerSettingsView.swift */,
 			);
 			path = Player;
+			sourceTree = "<group>";
+		};
+		A1000001000000000000000D /* ParametricEQ */ = {
+			isa = PBXGroup;
+			children = (
+				A10000010000000000000001 /* BandControlPanel.swift */,
+				A10000010000000000000002 /* EQToolbar.swift */,
+				A10000010000000000000003 /* FrequencyResponseCurve.swift */,
+				A10000010000000000000004 /* ParametricEQView.swift */,
+				A10000010000000000000005 /* ParametricEQViewModel.swift */,
+			);
+			path = ParametricEQ;
 			sourceTree = "<group>";
 		};
 		5020419C2E2A3C77003CE29A /* iOS-SpotifyEquilizerView */ = {
@@ -1567,6 +1592,7 @@
 			children = (
 				5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */,
 				5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */,
+				A10000010000000000000006 /* ParametricEQTest.swift */,
 			);
 			path = Player;
 			sourceTree = "<group>";
@@ -2511,6 +2537,11 @@
 				50DF1E5628DDE3FA00F3EA00 /* AlbumCollectionCell.swift in Sources */,
 				502B98ED2D03A02D000FE187 /* PlaylistEditVC.swift in Sources */,
 				502041982E2A37F2003CE29A /* EqualizerSettingsView.swift in Sources */,
+				A10000010000000000000007 /* BandControlPanel.swift in Sources */,
+				A10000010000000000000008 /* EQToolbar.swift in Sources */,
+				A10000010000000000000009 /* FrequencyResponseCurve.swift in Sources */,
+				A1000001000000000000000A /* ParametricEQView.swift in Sources */,
+				A1000001000000000000000B /* ParametricEQViewModel.swift in Sources */,
 				50E77DB928D21A9300BDF882 /* SettingsHostVC.swift in Sources */,
 				501DBE9F2632D2D000B31128 /* GenreDetailVC.swift in Sources */,
 				504B441928D6F0920033982C /* LicenseSettingsView.swift in Sources */,
@@ -2842,6 +2873,7 @@
 				50BE5D6E2850F4FB00156FC6 /* SsPlaylistsParserTest.swift in Sources */,
 				50BE5D862850F50F00156FC6 /* PlaylistSongsParserTest.swift in Sources */,
 				50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */,
+				A1000001000000000000000C /* ParametricEQTest.swift in Sources */,
 				50BE5D732850F4FB00156FC6 /* SsPodcastParserTest.swift in Sources */,
 				50BE5D722850F4FB00156FC6 /* SsSongExample1ParserTest.swift in Sources */,
 				50BE5D912850F50F00156FC6 /* GenreParserTest.swift in Sources */,

--- a/Amperfy/Screens/ViewController/SettingsHostVC.swift
+++ b/Amperfy/Screens/ViewController/SettingsHostVC.swift
@@ -212,6 +212,19 @@ class SettingsHostVC: UIViewController {
       self.appDelegate.storage.settings.user.equalizerSettings = newValue
     }))
 
+    settings.activeParametricEqualizerSetting = appDelegate.storage.settings.user
+      .activeParametricEqualizerSetting
+    changesAgent.append(settings.$activeParametricEqualizerSetting.sink(receiveValue: { newValue in
+      self.appDelegate.storage.settings.user.activeParametricEqualizerSetting = newValue
+      self.appDelegate.player.updateParametricEqualizerSetting(setting: newValue)
+    }))
+
+    settings.parametricEqualizerSettings = appDelegate.storage.settings.user
+      .parametricEqualizerSettings
+    changesAgent.append(settings.$parametricEqualizerSettings.sink(receiveValue: { newValue in
+      self.appDelegate.storage.settings.user.parametricEqualizerSettings = newValue
+    }))
+
     changesAgent.append(settings.$swipeActionSettings.sink(receiveValue: { newValue in
       self.appDelegate.storage.settings.user.swipeActionSettings = newValue
     }))

--- a/Amperfy/SwiftUI/Settings/ObservableSettings.swift
+++ b/Amperfy/SwiftUI/Settings/ObservableSettings.swift
@@ -86,5 +86,10 @@ final class Settings: ObservableObject {
   var equalizerSettings: [EqualizerSetting] = []
 
   @Published
+  var activeParametricEqualizerSetting: ParametricEqualizerSetting = .off
+  @Published
+  var parametricEqualizerSettings: [ParametricEqualizerSetting] = []
+
+  @Published
   var isReplayGainEnabled = true
 }

--- a/Amperfy/SwiftUI/Settings/Player/EqualizerSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Player/EqualizerSettingsView.swift
@@ -28,139 +28,310 @@ struct EqualizerSettingsView: View {
   @EnvironmentObject
   private var settings: Settings
 
-  @State
-  private var eqSettingToEdit: EqualizerSetting?
-  @State
-  private var eqSettingNameSaved: String = ""
-  @State
-  private var eqSettingName: String = ""
-  @State
-  var eqSettingGains: [CGFloat] = EqualizerSetting.frequencies.map { _ in 0.0 }
-  @State
-  var sliderLabel: [String] = EqualizerSetting.frequencies.map {
-    if $0 < 1000 {
-      return "\(Int($0))"
-    } else {
-      return "\(Int($0 / 1000))k"
-    }
-  }
+  @StateObject
+  private var viewModel = ParametricEQViewModel()
 
   @State
-  var isShowDeleteAlert = false
+  private var selectedPresetId: UUID?
+  @State
+  private var isShowingNewPresetDialog = false
+  @State
+  private var newPresetName = ""
+  @State
+  private var isShowingDeleteAlert = false
+  @State
+  private var presetToDelete: ParametricEqualizerSetting?
+  @State
+  private var isShowingRenameDialog = false
+  @State
+  private var renameText = ""
 
   var body: some View {
-    ZStack {
-      SettingsList {
-        SettingsSection(content: {
-          SettingsCheckBoxRow(
-            title: "Enable Equalizer",
-            isOn: Binding(
-              get: { settings.isEqualizerEnabled },
-              set: { isEnabled in
-                settings.isEqualizerEnabled = isEnabled
-              }
-            )
-          )
+    ScrollView {
+      VStack(spacing: 20) {
+        // Enable/Disable Toggle
+        enableSection
 
-          if settings.isEqualizerEnabled {
-            SettingsRow(title: "Active Equalizer") {
-              Menu(settings.activeEqualizerSetting.description) {
-                Button(EqualizerSetting.off.description) {
-                  settings.activeEqualizerSetting = EqualizerSetting.off
-                }
-                ForEach(settings.equalizerSettings, id: \.self) { eqSetting in
-                  Button(eqSetting.description) {
-                    settings.activeEqualizerSetting = eqSetting
-                  }
-                }
-              }
-            }
+        if settings.isEqualizerEnabled {
+          // Preset selector
+          presetSection
+
+          // Parametric EQ Editor
+          if selectedPresetId != nil {
+            editorSection
           }
-        })
-
-        SettingsSection(content: {
-          SettingsRow(title: "Equalizer") {
-            Menu((eqSettingToEdit != nil) ? eqSettingNameSaved : "Select") {
-              ForEach(settings.equalizerSettings, id: \.self) { eqSetting in
-                Button(eqSetting.description) {
-                  eqSettingToEdit = eqSetting
-                  eqSettingName = eqSetting.name
-                  eqSettingNameSaved = eqSetting.name
-                  eqSettingGains = eqSetting.gains.compactMap { CGFloat($0) }
-                }
-              }
-              Button("Create new Equalizer") {
-                let newEQ = EqualizerSetting(name: "My new Equalizer")
-                var curEqSetting = settings.equalizerSettings
-                curEqSetting.append(newEQ)
-                settings.equalizerSettings = curEqSetting
-                eqSettingToEdit = newEQ
-                eqSettingName = newEQ.name
-                eqSettingNameSaved = newEQ.name
-                eqSettingGains = newEQ.gains.compactMap { CGFloat($0) }
-              }
-            }
-          }
-
-          if eqSettingToEdit != nil {
-            SettingsRow(title: "Name") {
-              TextField("Equalizer Name", text: $eqSettingName)
-                .multilineTextAlignment(.trailing)
-            }
-
-            EqualizerView(
-              sliderLabels: $sliderLabel,
-              sliderValues: $eqSettingGains,
-              sliderTintColor: Color(settings.themePreference.asColor),
-              gradientColors: [Color(settings.themePreference.asColor), .clear]
-            )
-
-            SettingsButtonRow(title: "Save") {
-              guard var eqSettingToEdit else { return }
-              var curEqSetting = settings.equalizerSettings
-              guard let index = curEqSetting.firstIndex(of: eqSettingToEdit) else { return }
-              eqSettingToEdit.name = eqSettingName
-              eqSettingNameSaved = eqSettingName
-              eqSettingToEdit.gains = eqSettingGains.compactMap { Float($0) }
-              self.eqSettingToEdit = eqSettingToEdit
-              curEqSetting[index] = eqSettingToEdit
-              settings.equalizerSettings = curEqSetting
-
-              if settings.activeEqualizerSetting == eqSettingToEdit {
-                settings.activeEqualizerSetting = eqSettingToEdit
-              }
-            }
-            SettingsButtonRow(title: "Delete", actionType: .destructive) {
-              isShowDeleteAlert = true
-            }.alert(isPresented: $isShowDeleteAlert) {
-              Alert(
-                title: Text("Delete Equalizer"),
-                message: Text(
-                  "Are you sure to delete this equalizer?"
-                ),
-                primaryButton: .destructive(Text("Delete")) {
-                  guard let eqSettingToEdit else { return }
-                  var curEqSetting = settings.equalizerSettings
-                  guard let index = curEqSetting.firstIndex(of: eqSettingToEdit) else { return }
-                  curEqSetting.remove(at: index)
-                  settings.equalizerSettings = curEqSetting
-
-                  if settings.activeEqualizerSetting == eqSettingToEdit {
-                    settings.activeEqualizerSetting = .off
-                  }
-
-                  self.eqSettingToEdit = nil
-                },
-                secondaryButton: .cancel()
-              )
-            }
-          }
-
-        }, header: "Equalizer Editor")
+        }
       }
+      .padding()
     }
     .navigationTitle("Equalizer")
     .navigationBarTitleDisplayMode(.inline)
+    .onAppear {
+      loadActivePreset()
+    }
+    .alert("New Preset", isPresented: $isShowingNewPresetDialog) {
+      TextField("Preset Name", text: $newPresetName)
+      Button("Cancel", role: .cancel) {
+        newPresetName = ""
+      }
+      Button("Create") {
+        createNewPreset()
+      }
+    } message: {
+      Text("Enter a name for the new equalizer preset")
+    }
+    .alert("Delete Preset", isPresented: $isShowingDeleteAlert) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        if let preset = presetToDelete {
+          deletePreset(preset)
+        }
+      }
+    } message: {
+      Text("Are you sure you want to delete this preset?")
+    }
+    .alert("Rename Preset", isPresented: $isShowingRenameDialog) {
+      TextField("Preset Name", text: $renameText)
+      Button("Cancel", role: .cancel) {
+        renameText = ""
+      }
+      Button("Rename") {
+        renameCurrentPreset()
+      }
+    } message: {
+      Text("Enter a new name for the preset")
+    }
+  }
+
+  // MARK: - Enable Section
+
+  private var enableSection: some View {
+    SettingsSection(content: {
+      SettingsCheckBoxRow(
+        title: "Enable Equalizer",
+        isOn: Binding(
+          get: { settings.isEqualizerEnabled },
+          set: { isEnabled in
+            settings.isEqualizerEnabled = isEnabled
+          }
+        )
+      )
+    })
+  }
+
+  // MARK: - Preset Section
+
+  private var presetSection: some View {
+    SettingsSection(content: {
+      // Active Preset Picker
+      SettingsRow(title: "Active Preset") {
+        Menu(settings.activeParametricEqualizerSetting.description) {
+          Button(ParametricEqualizerSetting.off.description) {
+            settings.activeParametricEqualizerSetting = .off
+            selectedPresetId = nil
+            viewModel.load(from: .off)
+          }
+
+          ForEach(settings.parametricEqualizerSettings, id: \.id) { preset in
+            Button(preset.description) {
+              settings.activeParametricEqualizerSetting = preset
+              selectedPresetId = preset.id
+              viewModel.load(from: preset)
+            }
+          }
+        }
+      }
+
+      // Preset Management
+      HStack {
+        // Edit existing preset
+        if !settings.parametricEqualizerSettings.isEmpty {
+          Menu("Edit Preset") {
+            ForEach(settings.parametricEqualizerSettings, id: \.id) { preset in
+              Button(preset.name) {
+                selectedPresetId = preset.id
+                viewModel.load(from: preset)
+              }
+            }
+          }
+          .buttonStyle(.bordered)
+        }
+
+        Spacer()
+
+        // New preset button
+        Button {
+          newPresetName = "New Preset"
+          isShowingNewPresetDialog = true
+        } label: {
+          Label("New", systemImage: "plus")
+        }
+        .buttonStyle(.bordered)
+      }
+      .padding(.vertical, 4)
+    }, header: "Presets")
+  }
+
+  // MARK: - Editor Section
+
+  private var editorSection: some View {
+    VStack(spacing: 16) {
+      // Preset name and actions
+      if let presetId = selectedPresetId,
+         let preset = findPreset(id: presetId) {
+        HStack {
+          Text(preset.name)
+            .font(.headline)
+
+          Spacer()
+
+          Menu {
+            Button {
+              renameText = preset.name
+              isShowingRenameDialog = true
+            } label: {
+              Label("Rename", systemImage: "pencil")
+            }
+
+            Button {
+              viewModel.createDefaultBands()
+              saveCurrentPreset()
+            } label: {
+              Label("Reset to Default Bands", systemImage: "arrow.counterclockwise")
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+              presetToDelete = preset
+              isShowingDeleteAlert = true
+            } label: {
+              Label("Delete Preset", systemImage: "trash")
+            }
+          } label: {
+            Image(systemName: "ellipsis.circle")
+          }
+        }
+        .padding(.horizontal)
+      }
+
+      // Parametric EQ View
+      ParametricEQView(
+        viewModel: viewModel,
+        accentColor: Color(settings.themePreference.asColor),
+        onSettingChanged: { _ in
+          saveCurrentPreset()
+        }
+      )
+
+      // Save indicator
+      if selectedPresetId != nil {
+        Text("Changes are saved automatically")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+    .padding(.vertical)
+    .background(Color(.systemBackground))
+    .cornerRadius(12)
+  }
+
+  // MARK: - Actions
+
+  private func loadActivePreset() {
+    let active = settings.activeParametricEqualizerSetting
+    if active.id != ParametricEqualizerSetting.off.id {
+      selectedPresetId = active.id
+      viewModel.load(from: active)
+    } else if let first = settings.parametricEqualizerSettings.first {
+      // Load first preset for editing but don't activate
+      selectedPresetId = first.id
+      viewModel.load(from: first)
+    }
+  }
+
+  private func createNewPreset() {
+    var newPreset = ParametricEqualizerSetting(name: newPresetName)
+
+    // Create default bands
+    newPreset = ParametricEqualizerSetting(
+      id: newPreset.id,
+      name: newPresetName,
+      bands: ParametricBand.defaultFrequencies.enumerated().map { index, freq in
+        let filterType: ParametricBandFilterType
+        if index == 0 {
+          filterType = .lowShelf
+        } else if index == ParametricBand.defaultFrequencies.count - 1 {
+          filterType = .highShelf
+        } else {
+          filterType = .bell
+        }
+        return ParametricBand(frequency: freq, gain: 0, q: 1.0, filterType: filterType)
+      },
+      globalBypass: false
+    )
+
+    var presets = settings.parametricEqualizerSettings
+    presets.append(newPreset)
+    settings.parametricEqualizerSettings = presets
+
+    // Activate and edit the new preset
+    settings.activeParametricEqualizerSetting = newPreset
+    selectedPresetId = newPreset.id
+    viewModel.load(from: newPreset)
+
+    newPresetName = ""
+  }
+
+  private func saveCurrentPreset() {
+    guard let presetId = selectedPresetId else { return }
+
+    let updatedSetting = viewModel.toSetting(withId: presetId)
+
+    // Update in the presets list
+    var presets = settings.parametricEqualizerSettings
+    if let index = presets.firstIndex(where: { $0.id == presetId }) {
+      presets[index] = updatedSetting
+      settings.parametricEqualizerSettings = presets
+    }
+
+    // Update active preset if it's the one being edited
+    if settings.activeParametricEqualizerSetting.id == presetId {
+      settings.activeParametricEqualizerSetting = updatedSetting
+    }
+  }
+
+  private func deletePreset(_ preset: ParametricEqualizerSetting) {
+    var presets = settings.parametricEqualizerSettings
+    presets.removeAll { $0.id == preset.id }
+    settings.parametricEqualizerSettings = presets
+
+    // Reset active if it was deleted
+    if settings.activeParametricEqualizerSetting.id == preset.id {
+      settings.activeParametricEqualizerSetting = .off
+    }
+
+    // Clear selection
+    if selectedPresetId == preset.id {
+      selectedPresetId = presets.first?.id
+      if let first = presets.first {
+        viewModel.load(from: first)
+      }
+    }
+
+    presetToDelete = nil
+  }
+
+  private func renameCurrentPreset() {
+    guard let presetId = selectedPresetId else { return }
+
+    viewModel.name = renameText
+    saveCurrentPreset()
+    renameText = ""
+  }
+
+  private func findPreset(id: UUID) -> ParametricEqualizerSetting? {
+    settings.parametricEqualizerSettings.first { $0.id == id }
   }
 }
 

--- a/Amperfy/SwiftUI/Settings/Player/ParametricEQ/BandControlPanel.swift
+++ b/Amperfy/SwiftUI/Settings/Player/ParametricEQ/BandControlPanel.swift
@@ -1,0 +1,207 @@
+//
+//  BandControlPanel.swift
+//  Amperfy
+//
+//  Created by Maximilian Bauer on 19.07.25.
+//  Copyright (c) 2025 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+
+// MARK: - BandControlPanel
+
+struct BandControlPanel: View {
+  @Binding
+  var band: ParametricBand
+  var accentColor: Color
+  var onDelete: () -> ()
+
+  @State
+  private var frequencyText: String = ""
+  @State
+  private var gainText: String = ""
+  @State
+  private var qText: String = ""
+
+  var body: some View {
+    VStack(spacing: 12) {
+      // Filter type picker
+      HStack {
+        Text("Type")
+          .foregroundColor(.secondary)
+        Spacer()
+        Picker("Filter Type", selection: $band.filterType) {
+          Text("Bell").tag(ParametricBandFilterType.bell)
+          Text("Low Shelf").tag(ParametricBandFilterType.lowShelf)
+          Text("High Shelf").tag(ParametricBandFilterType.highShelf)
+        }
+        .pickerStyle(.menu)
+        .tint(accentColor)
+      }
+
+      Divider()
+
+      // Frequency control
+      VStack(alignment: .leading, spacing: 4) {
+        HStack {
+          Text("Frequency")
+            .foregroundColor(.secondary)
+          Spacer()
+          Text(formatFrequency(band.frequency))
+            .font(.system(.body, design: .monospaced))
+            .foregroundColor(accentColor)
+        }
+
+        LogarithmicSlider(
+          value: $band.frequency,
+          range: ParametricBand.frequencyRange,
+          accentColor: accentColor
+        )
+      }
+
+      Divider()
+
+      // Gain control
+      VStack(alignment: .leading, spacing: 4) {
+        HStack {
+          Text("Gain")
+            .foregroundColor(.secondary)
+          Spacer()
+          Text(formatGain(band.gain))
+            .font(.system(.body, design: .monospaced))
+            .foregroundColor(accentColor)
+        }
+
+        Slider(
+          value: $band.gain,
+          in: ParametricBand.gainRange,
+          step: 0.1
+        )
+        .tint(accentColor)
+      }
+
+      // Q control (only for Bell filters)
+      if band.filterType == .bell {
+        Divider()
+
+        VStack(alignment: .leading, spacing: 4) {
+          HStack {
+            Text("Q (Bandwidth)")
+              .foregroundColor(.secondary)
+            Spacer()
+            Text(String(format: "%.2f", band.q))
+              .font(.system(.body, design: .monospaced))
+              .foregroundColor(accentColor)
+          }
+
+          LogarithmicSlider(
+            value: $band.q,
+            range: ParametricBand.qRange,
+            accentColor: accentColor
+          )
+        }
+      }
+
+      Divider()
+
+      // Bypass and Delete
+      HStack {
+        Toggle("Bypass", isOn: $band.bypass)
+          .tint(accentColor)
+
+        Spacer()
+
+        Button(role: .destructive) {
+          onDelete()
+        } label: {
+          Label("Delete", systemImage: "trash")
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+    .padding()
+    .background(Color(.secondarySystemBackground))
+    .cornerRadius(12)
+  }
+
+  // MARK: - Helpers
+
+  private func formatFrequency(_ freq: Float) -> String {
+    if freq >= 1000 {
+      return String(format: "%.1f kHz", freq / 1000)
+    } else {
+      return String(format: "%.0f Hz", freq)
+    }
+  }
+
+  private func formatGain(_ gain: Float) -> String {
+    let sign = gain >= 0 ? "+" : ""
+    return String(format: "%@%.1f dB", sign, gain)
+  }
+}
+
+// MARK: - LogarithmicSlider
+
+struct LogarithmicSlider: View {
+  @Binding
+  var value: Float
+  let range: ClosedRange<Float>
+  var accentColor: Color
+
+  private var logValue: Binding<Double> {
+    Binding(
+      get: {
+        let logMin = log10(Double(range.lowerBound))
+        let logMax = log10(Double(range.upperBound))
+        let logVal = log10(Double(value))
+        return (logVal - logMin) / (logMax - logMin)
+      },
+      set: { newValue in
+        let logMin = log10(Double(range.lowerBound))
+        let logMax = log10(Double(range.upperBound))
+        let logVal = logMin + newValue * (logMax - logMin)
+        value = Float(pow(10, logVal)).clamped(to: range)
+      }
+    )
+  }
+
+  var body: some View {
+    Slider(value: logValue, in: 0 ... 1)
+      .tint(accentColor)
+  }
+}
+
+// MARK: - NoBandSelectedView
+
+struct NoBandSelectedView: View {
+  var body: some View {
+    VStack(spacing: 8) {
+      Image(systemName: "slider.horizontal.3")
+        .font(.largeTitle)
+        .foregroundColor(.secondary)
+      Text("Select a band to edit")
+        .foregroundColor(.secondary)
+      Text("Drag nodes on the curve or tap to select")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity)
+    .padding()
+    .background(Color(.secondarySystemBackground))
+    .cornerRadius(12)
+  }
+}

--- a/Amperfy/SwiftUI/Settings/Player/ParametricEQ/EQToolbar.swift
+++ b/Amperfy/SwiftUI/Settings/Player/ParametricEQ/EQToolbar.swift
@@ -1,0 +1,100 @@
+//
+//  EQToolbar.swift
+//  Amperfy
+//
+//  Created by Maximilian Bauer on 19.07.25.
+//  Copyright (c) 2025 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+// MARK: - EQToolbar
+
+struct EQToolbar: View {
+  var canUndo: Bool
+  var canRedo: Bool
+  var canAddBand: Bool
+  var globalBypass: Bool
+  var isABCompareActive: Bool
+  var currentABState: ParametricEQViewModel.ABState
+  var accentColor: Color
+
+  var onUndo: () -> ()
+  var onRedo: () -> ()
+  var onAddBand: () -> ()
+  var onToggleBypass: () -> ()
+  var onStartABCompare: () -> ()
+  var onToggleAB: () -> ()
+  var onEndABCompare: (Bool) -> ()
+  var onReset: () -> ()
+
+  var body: some View {
+    HStack {
+      // Undo
+      Button {
+        onUndo()
+      } label: {
+        Image(systemName: "arrow.uturn.backward")
+      }
+      .disabled(!canUndo)
+
+      Spacer()
+
+      // Redo
+      Button {
+        onRedo()
+      } label: {
+        Image(systemName: "arrow.uturn.forward")
+      }
+      .disabled(!canRedo)
+
+      Spacer()
+
+      // Global bypass
+      Button {
+        onToggleBypass()
+      } label: {
+        Image(systemName: globalBypass ? "speaker.slash.fill" : "speaker.wave.2.fill")
+          .foregroundColor(globalBypass ? .orange : accentColor)
+      }
+
+      Spacer()
+
+      // Reset button
+      Menu {
+        Button(role: .destructive) {
+          onReset()
+        } label: {
+          Label("Reset All Bands", systemImage: "arrow.counterclockwise")
+        }
+      } label: {
+        Image(systemName: "ellipsis.circle")
+      }
+
+      Spacer()
+
+      // Add band
+      Button {
+        onAddBand()
+      } label: {
+        Image(systemName: "plus.circle.fill")
+      }
+      .disabled(!canAddBand)
+    }
+    .buttonStyle(.bordered)
+    .tint(accentColor)
+  }
+}

--- a/Amperfy/SwiftUI/Settings/Player/ParametricEQ/FrequencyResponseCurve.swift
+++ b/Amperfy/SwiftUI/Settings/Player/ParametricEQ/FrequencyResponseCurve.swift
@@ -1,0 +1,352 @@
+//
+//  FrequencyResponseCurve.swift
+//  Amperfy
+//
+//  Created by Maximilian Bauer on 19.07.25.
+//  Copyright (c) 2025 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+
+// MARK: - FrequencyResponseCurve
+
+struct FrequencyResponseCurve: View {
+  @Binding
+  var bands: [ParametricBand]
+  @Binding
+  var selectedBandId: UUID?
+  var globalBypass: Bool
+  var accentColor: Color
+
+  let onBandDragStart: () -> ()
+  let onBandDrag: (UUID, Float, Float) -> ()
+  let onBandDragEnd: () -> ()
+  let onBandSelect: (UUID?) -> ()
+
+  // Constants
+  private let minFreq: Float = 20
+  private let maxFreq: Float = 20000
+  private let minGain: Float = -12
+  private let maxGain: Float = 12
+  private let sampleRate: Float = 44100
+
+  // Frequency labels for the grid
+  private let freqLabels: [(Float, String)] = [
+    (20, "20"), (50, "50"), (100, "100"), (200, "200"),
+    (500, "500"), (1000, "1k"), (2000, "2k"), (5000, "5k"),
+    (10000, "10k"), (20000, "20k"),
+  ]
+
+  // Gain labels for the grid
+  private let gainLabels: [Float] = [-12, -6, 0, 6, 12]
+
+  var body: some View {
+    GeometryReader { geometry in
+      let size = geometry.size
+      ZStack {
+        // Background grid
+        gridView(size: size)
+
+        // Frequency response curve
+        responseCurvePath(size: size)
+          .stroke(
+            globalBypass ? Color.gray : accentColor,
+            lineWidth: 2
+          )
+
+        // Filled area under curve
+        responseCurveFilledPath(size: size)
+          .fill(
+            LinearGradient(
+              gradient: Gradient(colors: [
+                (globalBypass ? Color.gray : accentColor).opacity(0.3),
+                Color.clear,
+              ]),
+              startPoint: .top,
+              endPoint: .bottom
+            )
+          )
+
+        // Band nodes (draggable)
+        ForEach(bands) { band in
+          bandNode(band: band, size: size)
+        }
+      }
+      .contentShape(Rectangle())
+      .gesture(
+        DragGesture(minimumDistance: 0)
+          .onEnded { value in
+            // Tap on empty space deselects
+            let location = value.location
+            if !isNearAnyBand(location: location, size: size) {
+              onBandSelect(nil)
+            }
+          }
+      )
+    }
+    .aspectRatio(2.5, contentMode: .fit)
+  }
+
+  // MARK: - Grid View
+
+  @ViewBuilder
+  private func gridView(size: CGSize) -> some View {
+    ZStack {
+      // Vertical frequency lines (logarithmic)
+      ForEach(freqLabels, id: \.0) { freq, label in
+        let x = freqToX(freq, width: size.width)
+        Path { path in
+          path.move(to: CGPoint(x: x, y: 0))
+          path.addLine(to: CGPoint(x: x, y: size.height))
+        }
+        .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
+
+        Text(label)
+          .font(.system(size: 9))
+          .foregroundColor(.secondary)
+          .position(x: x, y: size.height - 8)
+      }
+
+      // Horizontal gain lines
+      ForEach(gainLabels, id: \.self) { gain in
+        let y = gainToY(gain, height: size.height)
+        Path { path in
+          path.move(to: CGPoint(x: 0, y: y))
+          path.addLine(to: CGPoint(x: size.width, y: y))
+        }
+        .stroke(
+          gain == 0 ? Color.gray.opacity(0.6) : Color.gray.opacity(0.3),
+          lineWidth: gain == 0 ? 1 : 0.5
+        )
+
+        Text("\(Int(gain)) dB")
+          .font(.system(size: 9))
+          .foregroundColor(.secondary)
+          .position(x: 24, y: y)
+      }
+    }
+  }
+
+  // MARK: - Response Curve
+
+  private func responseCurvePath(size: CGSize) -> Path {
+    Path { path in
+      let points = calculateResponsePoints(size: size)
+      guard let first = points.first else { return }
+      path.move(to: first)
+      for point in points.dropFirst() {
+        path.addLine(to: point)
+      }
+    }
+  }
+
+  private func responseCurveFilledPath(size: CGSize) -> Path {
+    Path { path in
+      let points = calculateResponsePoints(size: size)
+      guard let first = points.first else { return }
+      path.move(to: CGPoint(x: first.x, y: size.height))
+      path.addLine(to: first)
+      for point in points.dropFirst() {
+        path.addLine(to: point)
+      }
+      if let last = points.last {
+        path.addLine(to: CGPoint(x: last.x, y: size.height))
+      }
+      path.closeSubpath()
+    }
+  }
+
+  private func calculateResponsePoints(size: CGSize) -> [CGPoint] {
+    let numPoints = Int(size.width)
+    var points: [CGPoint] = []
+
+    for i in 0 ..< numPoints {
+      let x = CGFloat(i)
+      let freq = xToFreq(Float(x), width: Float(size.width))
+      let totalGain = calculateTotalGain(at: freq)
+      let y = gainToY(totalGain, height: size.height)
+      points.append(CGPoint(x: x, y: y))
+    }
+
+    return points
+  }
+
+  private func calculateTotalGain(at freq: Float) -> Float {
+    guard !globalBypass else { return 0 }
+
+    var totalGain: Float = 0
+
+    for band in bands where !band.bypass {
+      let bandGain = calculateBandResponse(band: band, at: freq)
+      totalGain += bandGain
+    }
+
+    return totalGain.clamped(to: minGain ... maxGain)
+  }
+
+  // MARK: - Biquad Filter Response Calculation
+
+  private func calculateBandResponse(band: ParametricBand, at freq: Float) -> Float {
+    // Calculate biquad filter frequency response
+    let w0 = 2 * Float.pi * band.frequency / sampleRate
+    let A = pow(10, band.gain / 40) // Gain in linear form (sqrt for amplitude)
+
+    let cosW0 = cos(w0)
+    let sinW0 = sin(w0)
+    let alpha = sinW0 / (2 * band.q)
+
+    var b0: Float = 1, b1: Float = 0, b2: Float = 0
+    var a0: Float = 1, a1: Float = 0, a2: Float = 0
+
+    switch band.filterType {
+    case .bell:
+      // Peaking EQ
+      b0 = 1 + alpha * A
+      b1 = -2 * cosW0
+      b2 = 1 - alpha * A
+      a0 = 1 + alpha / A
+      a1 = -2 * cosW0
+      a2 = 1 - alpha / A
+
+    case .lowShelf:
+      // Low shelf
+      let sqrtA = sqrt(A)
+      let sqrtA2Alpha = 2 * sqrtA * alpha
+      b0 = A * ((A + 1) - (A - 1) * cosW0 + sqrtA2Alpha)
+      b1 = 2 * A * ((A - 1) - (A + 1) * cosW0)
+      b2 = A * ((A + 1) - (A - 1) * cosW0 - sqrtA2Alpha)
+      a0 = (A + 1) + (A - 1) * cosW0 + sqrtA2Alpha
+      a1 = -2 * ((A - 1) + (A + 1) * cosW0)
+      a2 = (A + 1) + (A - 1) * cosW0 - sqrtA2Alpha
+
+    case .highShelf:
+      // High shelf
+      let sqrtA = sqrt(A)
+      let sqrtA2Alpha = 2 * sqrtA * alpha
+      b0 = A * ((A + 1) + (A - 1) * cosW0 + sqrtA2Alpha)
+      b1 = -2 * A * ((A - 1) + (A + 1) * cosW0)
+      b2 = A * ((A + 1) + (A - 1) * cosW0 - sqrtA2Alpha)
+      a0 = (A + 1) - (A - 1) * cosW0 + sqrtA2Alpha
+      a1 = 2 * ((A - 1) - (A + 1) * cosW0)
+      a2 = (A + 1) - (A - 1) * cosW0 - sqrtA2Alpha
+    }
+
+    // Normalize coefficients
+    b0 /= a0
+    b1 /= a0
+    b2 /= a0
+    a1 /= a0
+    a2 /= a0
+
+    // Calculate frequency response at the given frequency
+    let w = 2 * Float.pi * freq / sampleRate
+    let cosW = cos(w)
+    let cos2W = cos(2 * w)
+    let sinW = sin(w)
+    let sin2W = sin(2 * w)
+
+    // H(e^jw) = (b0 + b1*e^-jw + b2*e^-2jw) / (1 + a1*e^-jw + a2*e^-2jw)
+    let numReal = b0 + b1 * cosW + b2 * cos2W
+    let numImag = -(b1 * sinW + b2 * sin2W)
+    let denReal = 1 + a1 * cosW + a2 * cos2W
+    let denImag = -(a1 * sinW + a2 * sin2W)
+
+    let numMag = sqrt(numReal * numReal + numImag * numImag)
+    let denMag = sqrt(denReal * denReal + denImag * denImag)
+
+    let magnitude = numMag / denMag
+    let gainDb = 20 * log10(max(magnitude, 0.0001))
+
+    return gainDb
+  }
+
+  // MARK: - Band Nodes
+
+  @ViewBuilder
+  private func bandNode(band: ParametricBand, size: CGSize) -> some View {
+    let x = freqToX(band.frequency, width: size.width)
+    let y = gainToY(band.gain, height: size.height)
+    let isSelected = band.id == selectedBandId
+
+    Circle()
+      .fill(band.bypass ? Color.gray : accentColor)
+      .frame(width: isSelected ? 20 : 14, height: isSelected ? 20 : 14)
+      .overlay(
+        Circle()
+          .stroke(isSelected ? Color.white : Color.clear, lineWidth: 2)
+      )
+      .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+      .position(x: x, y: y)
+      .gesture(
+        DragGesture()
+          .onChanged { value in
+            onBandSelect(band.id)
+            onBandDragStart()
+            let newFreq = xToFreq(Float(value.location.x), width: Float(size.width))
+            let newGain = yToGain(Float(value.location.y), height: Float(size.height))
+            onBandDrag(band.id, newFreq, newGain)
+          }
+          .onEnded { _ in
+            onBandDragEnd()
+          }
+      )
+      .onTapGesture {
+        onBandSelect(band.id)
+      }
+  }
+
+  // MARK: - Coordinate Conversion
+
+  private func freqToX(_ freq: Float, width: CGFloat) -> CGFloat {
+    // Logarithmic scale
+    let logMin = log10(minFreq)
+    let logMax = log10(maxFreq)
+    let logFreq = log10(freq.clamped(to: minFreq ... maxFreq))
+    return CGFloat((logFreq - logMin) / (logMax - logMin)) * width
+  }
+
+  private func xToFreq(_ x: Float, width: Float) -> Float {
+    let logMin = log10(minFreq)
+    let logMax = log10(maxFreq)
+    let logFreq = logMin + (x / width) * (logMax - logMin)
+    return pow(10, logFreq).clamped(to: minFreq ... maxFreq)
+  }
+
+  private func gainToY(_ gain: Float, height: CGFloat) -> CGFloat {
+    // Linear scale, inverted (positive gain at top)
+    let normalizedGain = (gain - minGain) / (maxGain - minGain)
+    return CGFloat(1 - normalizedGain) * height
+  }
+
+  private func yToGain(_ y: Float, height: Float) -> Float {
+    let normalizedY = 1 - (y / height)
+    return (normalizedY * (maxGain - minGain) + minGain).clamped(to: minGain ... maxGain)
+  }
+
+  private func isNearAnyBand(location: CGPoint, size: CGSize) -> Bool {
+    let threshold: CGFloat = 20
+    for band in bands {
+      let x = freqToX(band.frequency, width: size.width)
+      let y = gainToY(band.gain, height: size.height)
+      let distance = sqrt(pow(location.x - x, 2) + pow(location.y - y, 2))
+      if distance < threshold {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/Amperfy/SwiftUI/Settings/Player/ParametricEQ/ParametricEQView.swift
+++ b/Amperfy/SwiftUI/Settings/Player/ParametricEQ/ParametricEQView.swift
@@ -1,0 +1,193 @@
+//
+//  ParametricEQView.swift
+//  Amperfy
+//
+//  Created by Maximilian Bauer on 19.07.25.
+//  Copyright (c) 2025 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+
+// MARK: - ParametricEQView
+
+struct ParametricEQView: View {
+  @ObservedObject
+  var viewModel: ParametricEQViewModel
+  var accentColor: Color
+  var onSettingChanged: (ParametricEqualizerSetting) -> ()
+
+  var body: some View {
+    VStack(spacing: 16) {
+      // Toolbar
+      EQToolbar(
+        canUndo: viewModel.canUndo,
+        canRedo: viewModel.canRedo,
+        canAddBand: viewModel.canAddBand,
+        globalBypass: viewModel.globalBypass,
+        isABCompareActive: viewModel.isABCompareActive,
+        currentABState: viewModel.currentABState,
+        accentColor: accentColor,
+        onUndo: {
+          viewModel.undo()
+          notifyChange()
+        },
+        onRedo: {
+          viewModel.redo()
+          notifyChange()
+        },
+        onAddBand: {
+          viewModel.addBand()
+          notifyChange()
+        },
+        onToggleBypass: {
+          viewModel.setGlobalBypass(!viewModel.globalBypass)
+          notifyChange()
+        },
+        onStartABCompare: {
+          viewModel.startABCompare()
+        },
+        onToggleAB: {
+          viewModel.toggleAB()
+          notifyChange()
+        },
+        onEndABCompare: { keepCurrent in
+          viewModel.endABCompare(keepCurrent: keepCurrent)
+          notifyChange()
+        },
+        onReset: {
+          viewModel.resetAllBands()
+          notifyChange()
+        }
+      )
+
+      // Frequency response curve
+      FrequencyResponseCurve(
+        bands: $viewModel.bands,
+        selectedBandId: $viewModel.selectedBandId,
+        globalBypass: viewModel.globalBypass,
+        accentColor: accentColor,
+        onBandDragStart: {
+          viewModel.beginDrag()
+        },
+        onBandDrag: { id, freq, gain in
+          viewModel.updateBand(id: id, frequency: freq, gain: gain)
+          notifyChange()
+        },
+        onBandDragEnd: {
+          viewModel.endDrag()
+        },
+        onBandSelect: { id in
+          viewModel.selectBand(id: id)
+        }
+      )
+      .padding(.horizontal)
+
+      // Band control panel
+      if let selectedBand = viewModel.selectedBand,
+         let index = viewModel.bands.firstIndex(where: { $0.id == selectedBand.id }) {
+        BandControlPanel(
+          band: Binding(
+            get: {
+              guard index < viewModel.bands.count else { return selectedBand }
+              return viewModel.bands[index]
+            },
+            set: { newValue in
+              guard index < viewModel.bands.count else { return }
+              viewModel.bands[index] = newValue
+              notifyChange()
+            }
+          ),
+          accentColor: accentColor,
+          onDelete: {
+            viewModel.removeBand(id: selectedBand.id)
+            notifyChange()
+          }
+        )
+        .padding(.horizontal)
+      } else {
+        NoBandSelectedView()
+          .padding(.horizontal)
+      }
+
+      // Band list (compact)
+      if !viewModel.bands.isEmpty {
+        bandListView
+          .padding(.horizontal)
+      }
+    }
+  }
+
+  // MARK: - Band List View
+
+  private var bandListView: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(viewModel.bands) { band in
+          bandChip(band: band)
+        }
+      }
+      .padding(.vertical, 4)
+    }
+  }
+
+  private func bandChip(band: ParametricBand) -> some View {
+    let isSelected = band.id == viewModel.selectedBandId
+
+    return Button {
+      viewModel.selectBand(id: band.id)
+    } label: {
+      VStack(spacing: 2) {
+        Text(formatFrequency(band.frequency))
+          .font(.caption2)
+        Text(formatGain(band.gain))
+          .font(.caption.bold())
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 6)
+      .background(
+        RoundedRectangle(cornerRadius: 8)
+          .fill(isSelected ? accentColor : Color(.tertiarySystemBackground))
+      )
+      .foregroundColor(isSelected ? .white : (band.bypass ? .secondary : .primary))
+      .overlay(
+        RoundedRectangle(cornerRadius: 8)
+          .stroke(band.bypass ? Color.orange : Color.clear, lineWidth: 1)
+      )
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: - Helpers
+
+  private func notifyChange() {
+    let setting = viewModel.toSetting()
+    onSettingChanged(setting)
+  }
+
+  private func formatFrequency(_ freq: Float) -> String {
+    if freq >= 1000 {
+      return String(format: "%.1fk", freq / 1000)
+    } else {
+      return String(format: "%.0f", freq)
+    }
+  }
+
+  private func formatGain(_ gain: Float) -> String {
+    let sign = gain >= 0 ? "+" : ""
+    return String(format: "%@%.1f", sign, gain)
+  }
+}

--- a/Amperfy/SwiftUI/Settings/Player/ParametricEQ/ParametricEQViewModel.swift
+++ b/Amperfy/SwiftUI/Settings/Player/ParametricEQ/ParametricEQViewModel.swift
@@ -1,0 +1,313 @@
+//
+//  ParametricEQViewModel.swift
+//  Amperfy
+//
+//  Created by Maximilian Bauer on 19.07.25.
+//  Copyright (c) 2025 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import Combine
+import SwiftUI
+
+// MARK: - ParametricEQViewModel
+
+@MainActor
+final class ParametricEQViewModel: ObservableObject {
+  // MARK: - Published State
+
+  @Published
+  var bands: [ParametricBand] = []
+  @Published
+  var selectedBandId: UUID?
+  @Published
+  var globalBypass: Bool = false
+  @Published
+  var name: String = ""
+
+  // A-B Comparison State
+  @Published
+  var isABCompareActive: Bool = false
+  @Published
+  private(set) var currentABState: ABState = .a
+
+  // MARK: - Private State
+
+  private var undoStack: [EQSnapshot] = []
+  private var redoStack: [EQSnapshot] = []
+  private let maxUndoLevels = 50
+
+  private var stateA: EQSnapshot?
+  private var stateB: EQSnapshot?
+
+  /// Tracks whether a drag operation is in progress (to avoid saving undo state on every frame)
+  private var isDragging: Bool = false
+
+  // MARK: - Types
+
+  enum ABState {
+    case a, b
+  }
+
+  struct EQSnapshot: Equatable {
+    let bands: [ParametricBand]
+    let globalBypass: Bool
+  }
+
+  // MARK: - Computed Properties
+
+  var selectedBand: ParametricBand? {
+    guard let id = selectedBandId else { return nil }
+    return bands.first { $0.id == id }
+  }
+
+  var canUndo: Bool { !undoStack.isEmpty }
+  var canRedo: Bool { !redoStack.isEmpty }
+  var canAddBand: Bool { bands.count < ParametricEqualizerSetting.maxBands }
+
+  var currentSnapshot: EQSnapshot {
+    EQSnapshot(bands: bands, globalBypass: globalBypass)
+  }
+
+  // MARK: - Initialization
+
+  func load(from setting: ParametricEqualizerSetting) {
+    bands = setting.bands
+    globalBypass = setting.globalBypass
+    name = setting.name
+    selectedBandId = bands.first?.id
+
+    // Clear history when loading new preset
+    undoStack.removeAll()
+    redoStack.removeAll()
+    isABCompareActive = false
+    stateA = nil
+    stateB = nil
+  }
+
+  func toSetting(withId id: UUID = UUID()) -> ParametricEqualizerSetting {
+    ParametricEqualizerSetting(
+      id: id,
+      name: name,
+      bands: bands,
+      globalBypass: globalBypass
+    )
+  }
+
+  // MARK: - Band Management
+
+  func addBand() {
+    guard canAddBand else { return }
+    saveUndoState()
+
+    // Find a frequency that's not too close to existing bands
+    let existingFreqs = Set(bands.map { Int($0.frequency) })
+    let defaultFreqs = ParametricBand.defaultFrequencies
+    var newFreq: Float = 1000
+
+    for freq in defaultFreqs where !existingFreqs.contains(Int(freq)) {
+      newFreq = freq
+      break
+    }
+
+    let newBand = ParametricBand(
+      frequency: newFreq,
+      gain: 0,
+      q: 1.0,
+      filterType: .bell,
+      bypass: false
+    )
+    bands.append(newBand)
+    selectedBandId = newBand.id
+  }
+
+  func removeBand(id: UUID) {
+    guard let index = bands.firstIndex(where: { $0.id == id }) else { return }
+    saveUndoState()
+
+    bands.remove(at: index)
+
+    // Select adjacent band or nil
+    if selectedBandId == id {
+      if !bands.isEmpty {
+        let newIndex = min(index, bands.count - 1)
+        selectedBandId = bands[newIndex].id
+      } else {
+        selectedBandId = nil
+      }
+    }
+  }
+
+  func updateBand(
+    id: UUID,
+    frequency: Float? = nil,
+    gain: Float? = nil,
+    q: Float? = nil,
+    filterType: ParametricBandFilterType? = nil,
+    bypass: Bool? = nil
+  ) {
+    guard let index = bands.firstIndex(where: { $0.id == id }) else { return }
+    // Only save undo state if not in a drag operation (drag saves state at start)
+    if !isDragging {
+      saveUndoState()
+    }
+
+    var band = bands[index]
+    if let f = frequency { band.frequency = f.clamped(to: ParametricBand.frequencyRange) }
+    if let g = gain { band.gain = g.clamped(to: ParametricBand.gainRange) }
+    if let qVal = q { band.q = qVal.clamped(to: ParametricBand.qRange) }
+    if let ft = filterType { band.filterType = ft }
+    if let b = bypass { band.bypass = b }
+
+    bands[index] = band
+  }
+
+  func setGlobalBypass(_ bypass: Bool) {
+    saveUndoState()
+    globalBypass = bypass
+  }
+
+  func selectBand(id: UUID?) {
+    selectedBandId = id
+  }
+
+  // MARK: - Drag State Management
+
+  /// Call at the start of a drag operation to save undo state once
+  func beginDrag() {
+    guard !isDragging else { return }
+    isDragging = true
+    saveUndoState()
+  }
+
+  /// Call at the end of a drag operation
+  func endDrag() {
+    isDragging = false
+  }
+
+  // MARK: - Undo/Redo
+
+  private func saveUndoState() {
+    let snapshot = currentSnapshot
+
+    // Don't save if nothing changed
+    if undoStack.last == snapshot { return }
+
+    undoStack.append(snapshot)
+    if undoStack.count > maxUndoLevels {
+      undoStack.removeFirst()
+    }
+    redoStack.removeAll()
+  }
+
+  func undo() {
+    guard let previousState = undoStack.popLast() else { return }
+    redoStack.append(currentSnapshot)
+    applySnapshot(previousState)
+  }
+
+  func redo() {
+    guard let nextState = redoStack.popLast() else { return }
+    undoStack.append(currentSnapshot)
+    applySnapshot(nextState)
+  }
+
+  private func applySnapshot(_ snapshot: EQSnapshot) {
+    bands = snapshot.bands
+    globalBypass = snapshot.globalBypass
+
+    // Maintain selection if possible
+    if let selectedId = selectedBandId,
+       !bands.contains(where: { $0.id == selectedId }) {
+      selectedBandId = bands.first?.id
+    }
+  }
+
+  // MARK: - A-B Comparison
+
+  func startABCompare() {
+    stateA = currentSnapshot
+    stateB = currentSnapshot
+    currentABState = .a
+    isABCompareActive = true
+  }
+
+  func toggleAB() {
+    guard isABCompareActive else { return }
+
+    // Save current state to the active slot
+    switch currentABState {
+    case .a:
+      stateA = currentSnapshot
+      currentABState = .b
+      if let stateB { applySnapshot(stateB) }
+    case .b:
+      stateB = currentSnapshot
+      currentABState = .a
+      if let stateA { applySnapshot(stateA) }
+    }
+  }
+
+  func endABCompare(keepCurrent: Bool) {
+    if keepCurrent {
+      // Keep whatever is currently displayed
+    } else {
+      // Revert to state A
+      if let stateA { applySnapshot(stateA) }
+    }
+
+    isABCompareActive = false
+    stateA = nil
+    stateB = nil
+    currentABState = .a
+  }
+
+  // MARK: - Presets
+
+  func createDefaultBands() {
+    saveUndoState()
+
+    bands = ParametricBand.defaultFrequencies.enumerated().map { index, freq in
+      let filterType: ParametricBandFilterType
+      if index == 0 {
+        filterType = .lowShelf
+      } else if index == ParametricBand.defaultFrequencies.count - 1 {
+        filterType = .highShelf
+      } else {
+        filterType = .bell
+      }
+
+      return ParametricBand(
+        frequency: freq,
+        gain: 0,
+        q: 1.0,
+        filterType: filterType,
+        bypass: false
+      )
+    }
+
+    selectedBandId = bands.first?.id
+  }
+
+  func resetAllBands() {
+    saveUndoState()
+    for i in bands.indices {
+      bands[i].gain = 0
+      bands[i].bypass = false
+    }
+    globalBypass = false
+  }
+}

--- a/AmperfyKit/AmperfyKit.swift
+++ b/AmperfyKit/AmperfyKit.swift
@@ -119,6 +119,9 @@ public class AmperKit {
 
   @MainActor
   private func createPlayer() -> PlayerFacade {
+    // Migrate legacy EQ presets to parametric EQ (one-time)
+    migrateEqualizerSettingsIfNeeded()
+
     playerAudioSessionHandler = AudioSessionHandler()
     let backendAudioPlayer = BackendAudioPlayer(
       createAudioStreamingPlayerCB: { AudioStreamingPlayer() },
@@ -160,6 +163,11 @@ public class AmperKit {
     backendAudioPlayer.updateEqualizerEnabled(isEnabled: storage.settings.user.isEqualizerEnabled)
     backendAudioPlayer
       .updateEqualizerSetting(eqSetting: storage.settings.user.activeEqualizerSetting)
+    backendAudioPlayer
+      .updateParametricEqualizerSetting(
+        setting: storage.settings.user
+          .activeParametricEqualizerSetting
+      )
     backendAudioPlayer.updateReplayGainEnabled(isEnabled: storage.settings.user.isReplayGainEnabled)
     backendAudioPlayer.volume = storage.settings.user.playerVolume
 
@@ -225,4 +233,37 @@ public class AmperKit {
   public lazy var localNotificationManager = {
     LocalNotificationManager(userStatistics: userStatistics, storage: storage)
   }()
+
+  // MARK: - Equalizer Migration
+
+  private func migrateEqualizerSettingsIfNeeded() {
+    // Check if migration has already been completed
+    guard !storage.settings.user.equalizerMigrationCompleted else { return }
+
+    // Migrate all legacy EQ presets to parametric format
+    let legacySettings = storage.settings.user.equalizerSettings
+    let migratedSettings = legacySettings.map { legacySetting in
+      ParametricEqualizerSetting.migrate(from: legacySetting)
+    }
+
+    // Save migrated presets (only if there are legacy presets to migrate)
+    if !migratedSettings.isEmpty {
+      storage.settings.user.parametricEqualizerSettings = migratedSettings
+    }
+
+    // Migrate the active preset if it's not "Off"
+    let activeEQ = storage.settings.user.activeEqualizerSetting
+    if activeEQ.id != EqualizerSetting.off.id {
+      let migratedActive = ParametricEqualizerSetting.migrate(from: activeEQ)
+      // Find the matching preset in the migrated list (by name) or use the converted one
+      if let matchingPreset = migratedSettings.first(where: { $0.name == migratedActive.name }) {
+        storage.settings.user.activeParametricEqualizerSetting = matchingPreset
+      } else {
+        storage.settings.user.activeParametricEqualizerSetting = migratedActive
+      }
+    }
+
+    // Mark migration as completed
+    storage.settings.user.equalizerMigrationCompleted = true
+  }
 }

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -116,6 +116,8 @@ class BackendAudioPlayer: NSObject {
   private var equalizerVolumeCompensation: Float = 1.0
   private var isEqualizerEnabled: Bool = true
   private var currentEqualizerSetting: EqualizerSetting = .off
+  private var currentParametricEqualizerSetting: ParametricEqualizerSetting = .off
+  private var isUsingParametricEQ: Bool = true // Default to parametric EQ
 
   public var isOfflineMode: Bool = false
   public var isAutoCachePlayedItems: Bool = true
@@ -659,6 +661,7 @@ class BackendAudioPlayer: NSObject {
   func updateEqualizerSetting(eqSetting: EqualizerSetting) {
     let oldSetting = currentEqualizerSetting
     currentEqualizerSetting = eqSetting
+    isUsingParametricEQ = false
     os_log(
       .debug,
       "Equalizer changed from %s to %s",
@@ -668,11 +671,29 @@ class BackendAudioPlayer: NSObject {
     applyEqualizerToActiveContent()
   }
 
+  func updateParametricEqualizerSetting(setting: ParametricEqualizerSetting) {
+    let oldSetting = currentParametricEqualizerSetting
+    currentParametricEqualizerSetting = setting
+    isUsingParametricEQ = true
+    os_log(
+      .debug,
+      "Parametric Equalizer changed from %s to %s",
+      oldSetting.description,
+      setting.description
+    )
+    applyEqualizerToActiveContent()
+  }
+
   private func applyEqualizerToActiveContent() {
     if isEqualizerEnabled {
-      applyEqualizerSetting(eqSetting: currentEqualizerSetting)
+      if isUsingParametricEQ {
+        applyParametricEqualizerSetting(setting: currentParametricEqualizerSetting)
+      } else {
+        applyEqualizerSetting(eqSetting: currentEqualizerSetting)
+      }
     } else {
-      applyEqualizerSetting(eqSetting: .off)
+      // Apply flat EQ when disabled
+      applyParametricEqualizerSetting(setting: .off)
     }
     applyReplayGain()
   }
@@ -718,6 +739,48 @@ class BackendAudioPlayer: NSObject {
     os_log(.debug, "   EQ Gain Compensation: %.1f dB", eqSetting.gainCompensation)
     os_log(.debug, "   EQ linear Volume Compensation: %.2f", eqSetting.compensatedVolume)
     os_log(.debug, "   Active EQ linear Volume Compensation: %.2f", equalizerVolumeCompensation)
+  }
+
+  private func applyParametricEqualizerSetting(setting: ParametricEqualizerSetting) {
+    guard let equalizer else { return }
+
+    // First, bypass all bands
+    for band in equalizer.bands {
+      band.bypass = true
+      band.gain = 0.0
+    }
+
+    // Apply active bands from setting (respecting global bypass)
+    let shouldBypassAll = setting.globalBypass || !isEqualizerEnabled
+
+    for (index, parametricBand) in setting.bands.enumerated() {
+      guard index < equalizer.bands.count else { break }
+
+      let band = equalizer.bands[index]
+
+      band.frequency = parametricBand.frequency
+      band.gain = parametricBand.gain
+      band.bandwidth = parametricBand.bandwidth
+      band.filterType = parametricBand.filterType.avAudioUnitEQFilterType
+      band.bypass = shouldBypassAll || parametricBand.bypass
+    }
+
+    equalizerVolumeCompensation = isEqualizerEnabled && !setting.globalBypass
+      ? setting.compensatedVolume : 1.0
+
+    os_log(.debug, "   Parametric EQ '%s'", setting.description)
+    os_log(.debug, "   Active bands: %d", setting.bands.filter { !$0.bypass }.count)
+    os_log(.debug, "   Global bypass: %s", setting.globalBypass.description)
+    os_log(
+      .debug,
+      "   Parametric EQ Gain Compensation: %.1f dB",
+      setting.gainCompensation
+    )
+    os_log(
+      .debug,
+      "   Active EQ linear Volume Compensation: %.2f",
+      equalizerVolumeCompensation
+    )
   }
 
   // MARK: - ReplayGain Implementation

--- a/AmperfyKit/Player/PlayerFacade.swift
+++ b/AmperfyKit/Player/PlayerFacade.swift
@@ -229,6 +229,7 @@ public protocol PlayerFacade {
 
   func updateEqualizerEnabled(isEnabled: Bool)
   func updateEqualizerSetting(eqSetting: EqualizerSetting)
+  func updateParametricEqualizerSetting(setting: ParametricEqualizerSetting)
   func updateReplayGainEnabled(isEnabled: Bool)
 }
 
@@ -507,6 +508,10 @@ class PlayerFacadeImpl: PlayerFacade {
 
   public func updateEqualizerSetting(eqSetting: EqualizerSetting) {
     backendAudioPlayer.updateEqualizerSetting(eqSetting: eqSetting)
+  }
+
+  public func updateParametricEqualizerSetting(setting: ParametricEqualizerSetting) {
+    backendAudioPlayer.updateParametricEqualizerSetting(setting: setting)
   }
 
   public func updateReplayGainEnabled(isEnabled: Bool) {

--- a/AmperfyKit/Storage/DownloadRequestManager.swift
+++ b/AmperfyKit/Storage/DownloadRequestManager.swift
@@ -89,13 +89,17 @@ final class DownloadRequestManager: Sendable {
       return asyncRequests
     }
   }
-  
-  nonisolated private func addLowPrio(objects: [(DownloadElementInfo, Downloadable)], library: LibraryStorage) -> [(DownloadElementInfo, Downloadable, Download)] {
+
+  nonisolated private func addLowPrio(
+    objects: [(DownloadElementInfo, Downloadable)],
+    library: LibraryStorage
+  )
+    -> [(DownloadElementInfo, Downloadable, Download)] {
     var hasCoreDataChanges = false
     let account = library.getAccount(managedObjectId: accountObjectId)
-    let ids = Set(objects.compactMap{ $0.1.uniqueID })
+    let ids = Set(objects.compactMap { $0.1.uniqueID })
     let existingDownloadsDict = library.getDownloadsDict(account: account, ids: ids)
-    
+
     var downloadMapping = [(DownloadElementInfo, Downloadable, Download)]()
     for (info, object) in objects {
       if let existingDownload = existingDownloadsDict[object.uniqueID] {
@@ -113,7 +117,7 @@ final class DownloadRequestManager: Sendable {
         downloadMapping.append((info, object, newDownload))
       }
     }
-    
+
     if hasCoreDataChanges {
       library.saveContext()
     }

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -825,7 +825,7 @@ public class LibraryStorage: PlayableFileCachable {
     let downloadMOs = try? context.fetch(fetchRequest)
     return downloadMOs?.compactMap { Download(managedObject: $0) } ?? [Download]()
   }
-  
+
   func getDownloadsDict(
     account: Account,
     ids: Set<String>

--- a/AmperfyKit/Storage/SettingEnumerations.swift
+++ b/AmperfyKit/Storage/SettingEnumerations.swift
@@ -19,6 +19,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import AVFoundation
 import CoreData
 import Foundation
 import SwiftUI
@@ -402,5 +403,182 @@ extension UIUserInterfaceStyle: @retroactive Encodable, @retroactive Decodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(rawValue)
+  }
+}
+
+// MARK: - Float+Clamped
+
+extension Float {
+  public func clamped(to range: ClosedRange<Float>) -> Float {
+    min(max(self, range.lowerBound), range.upperBound)
+  }
+}
+
+// MARK: - ParametricBandFilterType
+
+public enum ParametricBandFilterType: Int, CaseIterable, Sendable, Codable {
+  case bell = 0
+  case lowShelf = 1
+  case highShelf = 2
+
+  public var description: String {
+    switch self {
+    case .bell: return "Bell"
+    case .lowShelf: return "Low Shelf"
+    case .highShelf: return "High Shelf"
+    }
+  }
+
+  public var avAudioUnitEQFilterType: AVAudioUnitEQFilterType {
+    switch self {
+    case .bell: return .parametric
+    case .lowShelf: return .lowShelf
+    case .highShelf: return .highShelf
+    }
+  }
+}
+
+// MARK: - ParametricBand
+
+public struct ParametricBand: Hashable, Sendable, Codable, Identifiable {
+  public static let frequencyRange: ClosedRange<Float> = 20 ... 20000
+  public static let gainRange: ClosedRange<Float> = -12 ... 12
+  public static let qRange: ClosedRange<Float> = 0.1 ... 10.0
+  public static let defaultFrequencies: [Float] = [
+    32,
+    64,
+    125,
+    250,
+    500,
+    1000,
+    2000,
+    4000,
+    8000,
+    16000,
+  ]
+
+  public let id: UUID
+  public var frequency: Float
+  public var gain: Float
+  public var q: Float
+  public var filterType: ParametricBandFilterType
+  public var bypass: Bool
+
+  public init(
+    id: UUID = UUID(),
+    frequency: Float = 1000,
+    gain: Float = 0,
+    q: Float = 1.0,
+    filterType: ParametricBandFilterType = .bell,
+    bypass: Bool = false
+  ) {
+    self.id = id
+    self.frequency = frequency.clamped(to: Self.frequencyRange)
+    self.gain = gain.clamped(to: Self.gainRange)
+    self.q = q.clamped(to: Self.qRange)
+    self.filterType = filterType
+    self.bypass = bypass
+  }
+
+  public var bandwidth: Float {
+    // Convert Q to bandwidth: bandwidth = 2 * asinh(1/(2*Q)) / ln(2)
+    let ln2 = Float(0.693147180559945)
+    return 2 * asinh(1 / (2 * q)) / ln2
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+
+  public static func == (lhs: ParametricBand, rhs: ParametricBand) -> Bool {
+    lhs.id == rhs.id
+  }
+}
+
+// MARK: - ParametricEqualizerSetting
+
+public struct ParametricEqualizerSetting: Hashable, Sendable, Codable, Identifiable {
+  public static let maxBands = 10
+
+  public let id: UUID
+  public var name: String
+  public var bands: [ParametricBand]
+  public var globalBypass: Bool
+
+  public init(
+    id: UUID = UUID(),
+    name: String,
+    bands: [ParametricBand] = [],
+    globalBypass: Bool = false
+  ) {
+    self.id = id
+    self.name = name
+    self.bands = Array(bands.prefix(Self.maxBands))
+    self.globalBypass = globalBypass
+  }
+
+  public var description: String {
+    name
+  }
+
+  public static let off: ParametricEqualizerSetting = .init(name: "Off", bands: [])
+
+  // Gain compensation to prevent clipping
+  public var gainCompensation: Float {
+    let activeGains = bands.filter { !$0.bypass }.map { $0.gain }
+    let positiveGains = activeGains.filter { $0 > 0 }
+    let avgBoost = positiveGains.isEmpty ? 0 : positiveGains
+      .reduce(0, +) / Float(positiveGains.count)
+    // Conservative compensation: half the average boost, max -12dB
+    return -min(avgBoost / 2.0, 12.0)
+  }
+
+  public var compensatedVolume: Float {
+    // Convert dB compensation to linear scale
+    let volume = pow(10.0, gainCompensation / 20.0)
+    // Ensure safe range (0.1 to 2.0)
+    return max(0.1, min(2.0, volume))
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+
+  public static func == (lhs: ParametricEqualizerSetting, rhs: ParametricEqualizerSetting) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  // Migrate from legacy graphic EQ preset
+  public static func migrate(from legacy: EqualizerSetting) -> ParametricEqualizerSetting {
+    let defaultFrequencies = ParametricBand.defaultFrequencies
+    var bands: [ParametricBand] = []
+
+    for (index, gain) in legacy.gains.enumerated() {
+      guard index < defaultFrequencies.count else { break }
+
+      let filterType: ParametricBandFilterType
+      if index == 0 {
+        filterType = .lowShelf
+      } else if index == legacy.gains.count - 1 {
+        filterType = .highShelf
+      } else {
+        filterType = .bell
+      }
+
+      let band = ParametricBand(
+        frequency: defaultFrequencies[index],
+        gain: gain,
+        q: 1.0,
+        filterType: filterType,
+        bypass: false
+      )
+      bands.append(band)
+    }
+
+    return ParametricEqualizerSetting(
+      name: legacy.name,
+      bands: bands,
+      globalBypass: false
+    )
   }
 }

--- a/AmperfyKit/Storage/Settings.swift
+++ b/AmperfyKit/Storage/Settings.swift
@@ -195,6 +195,24 @@ public struct UserSettings: Sendable, Codable {
     set { _isReplayGainEnabled = newValue }
   }
 
+  private var _parametricEqualizerSettings: [ParametricEqualizerSetting] = []
+  public var parametricEqualizerSettings: [ParametricEqualizerSetting] {
+    get { _parametricEqualizerSettings }
+    set { _parametricEqualizerSettings = newValue }
+  }
+
+  private var _activeParametricEqualizerSetting: ParametricEqualizerSetting = .off
+  public var activeParametricEqualizerSetting: ParametricEqualizerSetting {
+    get { _activeParametricEqualizerSetting }
+    set { _activeParametricEqualizerSetting = newValue }
+  }
+
+  private var _equalizerMigrationCompleted: Bool = false
+  public var equalizerMigrationCompleted: Bool {
+    get { _equalizerMigrationCompleted }
+    set { _equalizerMigrationCompleted = newValue }
+  }
+
   private var _playerVolume: Float = 1.0
   public var playerVolume: Float {
     get {

--- a/AmperfyKitTests/Cases/Player/ParametricEQTest.swift
+++ b/AmperfyKitTests/Cases/Player/ParametricEQTest.swift
@@ -1,0 +1,293 @@
+//
+//  ParametricEQTest.swift
+//  AmperfyKitTests
+//
+//  Created by Maximilian Bauer on 19.07.25.
+//  Copyright (c) 2025 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import AmperfyKit
+import XCTest
+
+// MARK: - ParametricBandTests
+
+final class ParametricBandTests: XCTestCase {
+  // MARK: - Frequency Clamping
+
+  func testFrequencyClampedToMinimum() {
+    let band = ParametricBand(frequency: 10) // Below minimum of 20
+    XCTAssertEqual(band.frequency, 20)
+  }
+
+  func testFrequencyClampedToMaximum() {
+    let band = ParametricBand(frequency: 25000) // Above maximum of 20000
+    XCTAssertEqual(band.frequency, 20000)
+  }
+
+  func testFrequencyWithinRange() {
+    let band = ParametricBand(frequency: 1000)
+    XCTAssertEqual(band.frequency, 1000)
+  }
+
+  // MARK: - Gain Clamping
+
+  func testGainClampedToMinimum() {
+    let band = ParametricBand(gain: -15) // Below minimum of -12
+    XCTAssertEqual(band.gain, -12)
+  }
+
+  func testGainClampedToMaximum() {
+    let band = ParametricBand(gain: 15) // Above maximum of 12
+    XCTAssertEqual(band.gain, 12)
+  }
+
+  func testGainWithinRange() {
+    let band = ParametricBand(gain: 6)
+    XCTAssertEqual(band.gain, 6)
+  }
+
+  // MARK: - Q Clamping
+
+  func testQClampedToMinimum() {
+    let band = ParametricBand(q: 0.05) // Below minimum of 0.1
+    XCTAssertEqual(band.q, 0.1)
+  }
+
+  func testQClampedToMaximum() {
+    let band = ParametricBand(q: 15) // Above maximum of 10
+    XCTAssertEqual(band.q, 10)
+  }
+
+  func testQWithinRange() {
+    let band = ParametricBand(q: 2.0)
+    XCTAssertEqual(band.q, 2.0)
+  }
+
+  // MARK: - Bandwidth Calculation
+
+  func testBandwidthCalculation() {
+    // Q = 1 should give bandwidth ≈ 1.386
+    let band = ParametricBand(q: 1.0)
+    XCTAssertEqual(band.bandwidth, 1.386, accuracy: 0.01)
+  }
+
+  func testBandwidthCalculationHighQ() {
+    // Higher Q = narrower bandwidth
+    let band = ParametricBand(q: 10.0)
+    XCTAssertLessThan(band.bandwidth, 0.15)
+  }
+
+  func testBandwidthCalculationLowQ() {
+    // Lower Q = wider bandwidth
+    let band = ParametricBand(q: 0.5)
+    XCTAssertGreaterThan(band.bandwidth, 2.0)
+  }
+
+  // MARK: - Default Values
+
+  func testDefaultFilterType() {
+    let band = ParametricBand()
+    XCTAssertEqual(band.filterType, .bell)
+  }
+
+  func testDefaultBypass() {
+    let band = ParametricBand()
+    XCTAssertFalse(band.bypass)
+  }
+}
+
+// MARK: - ParametricEqualizerSettingTests
+
+final class ParametricEqualizerSettingTests: XCTestCase {
+  // MARK: - Gain Compensation
+
+  func testGainCompensationWithNoBoost() {
+    let bands = [
+      ParametricBand(gain: 0),
+      ParametricBand(gain: -6),
+      ParametricBand(gain: -3),
+    ]
+    let setting = ParametricEqualizerSetting(name: "Test", bands: bands)
+
+    // No positive gains, so no compensation needed
+    XCTAssertEqual(setting.gainCompensation, 0)
+  }
+
+  func testGainCompensationWithBoost() {
+    let bands = [
+      ParametricBand(gain: 6),
+      ParametricBand(gain: 6),
+      ParametricBand(gain: 0),
+    ]
+    let setting = ParametricEqualizerSetting(name: "Test", bands: bands)
+
+    // Average boost is 6, so compensation should be -3 (half)
+    XCTAssertEqual(setting.gainCompensation, -3)
+  }
+
+  func testGainCompensationMaxCap() {
+    let bands = [
+      ParametricBand(gain: 12),
+      ParametricBand(gain: 12),
+      ParametricBand(gain: 12),
+    ]
+    let setting = ParametricEqualizerSetting(name: "Test", bands: bands)
+
+    // Max compensation is -12dB
+    XCTAssertGreaterThanOrEqual(setting.gainCompensation, -12)
+  }
+
+  func testGainCompensationIgnoresBypassedBands() {
+    let bands = [
+      ParametricBand(gain: 12, bypass: true),
+      ParametricBand(gain: 0),
+    ]
+    let setting = ParametricEqualizerSetting(name: "Test", bands: bands)
+
+    // Bypassed band should be ignored
+    XCTAssertEqual(setting.gainCompensation, 0)
+  }
+
+  // MARK: - Max Bands Limit
+
+  func testMaxBandsLimit() {
+    let bands = (0 ..< 15).map { _ in ParametricBand() }
+    let setting = ParametricEqualizerSetting(name: "Test", bands: bands)
+
+    XCTAssertEqual(setting.bands.count, 10)
+  }
+
+  // MARK: - Migration
+
+  func testMigrationFromLegacySetting() {
+    let legacy = EqualizerSetting(
+      name: "Legacy Preset",
+      gains: [3, 2, 1, 0, -1, -2, -3, -4, -5, -6]
+    )
+
+    let migrated = ParametricEqualizerSetting.migrate(from: legacy)
+
+    XCTAssertEqual(migrated.name, "Legacy Preset")
+    XCTAssertEqual(migrated.bands.count, 10)
+    XCTAssertFalse(migrated.globalBypass)
+  }
+
+  func testMigrationPreservesGains() {
+    let legacy = EqualizerSetting(
+      name: "Test",
+      gains: [6, 3, 0, -3, -6, 0, 0, 0, 0, 0]
+    )
+
+    let migrated = ParametricEqualizerSetting.migrate(from: legacy)
+
+    XCTAssertEqual(migrated.bands[0].gain, 6)
+    XCTAssertEqual(migrated.bands[1].gain, 3)
+    XCTAssertEqual(migrated.bands[2].gain, 0)
+    XCTAssertEqual(migrated.bands[3].gain, -3)
+    XCTAssertEqual(migrated.bands[4].gain, -6)
+  }
+
+  func testMigrationSetsFilterTypes() {
+    let legacy = EqualizerSetting(name: "Test", gains: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    let migrated = ParametricEqualizerSetting.migrate(from: legacy)
+
+    // First band should be low shelf
+    XCTAssertEqual(migrated.bands[0].filterType, .lowShelf)
+
+    // Middle bands should be bell
+    XCTAssertEqual(migrated.bands[1].filterType, .bell)
+    XCTAssertEqual(migrated.bands[5].filterType, .bell)
+
+    // Last band should be high shelf
+    XCTAssertEqual(migrated.bands[9].filterType, .highShelf)
+  }
+
+  func testMigrationSetsDefaultFrequencies() {
+    let legacy = EqualizerSetting(name: "Test", gains: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    let migrated = ParametricEqualizerSetting.migrate(from: legacy)
+
+    XCTAssertEqual(migrated.bands[0].frequency, 32)
+    XCTAssertEqual(migrated.bands[1].frequency, 64)
+    XCTAssertEqual(migrated.bands[2].frequency, 125)
+    XCTAssertEqual(migrated.bands[5].frequency, 1000)
+    XCTAssertEqual(migrated.bands[9].frequency, 16000)
+  }
+
+  func testMigrationSetsDefaultQ() {
+    let legacy = EqualizerSetting(name: "Test", gains: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    let migrated = ParametricEqualizerSetting.migrate(from: legacy)
+
+    for band in migrated.bands {
+      XCTAssertEqual(band.q, 1.0)
+    }
+  }
+}
+
+// MARK: - ParametricBandFilterTypeTests
+
+final class ParametricBandFilterTypeTests: XCTestCase {
+  func testBellFilterType() {
+    XCTAssertEqual(ParametricBandFilterType.bell.avAudioUnitEQFilterType, .parametric)
+  }
+
+  func testLowShelfFilterType() {
+    XCTAssertEqual(ParametricBandFilterType.lowShelf.avAudioUnitEQFilterType, .lowShelf)
+  }
+
+  func testHighShelfFilterType() {
+    XCTAssertEqual(ParametricBandFilterType.highShelf.avAudioUnitEQFilterType, .highShelf)
+  }
+
+  func testFilterTypeDescriptions() {
+    XCTAssertEqual(ParametricBandFilterType.bell.description, "Bell")
+    XCTAssertEqual(ParametricBandFilterType.lowShelf.description, "Low Shelf")
+    XCTAssertEqual(ParametricBandFilterType.highShelf.description, "High Shelf")
+  }
+}
+
+// MARK: - CompensatedVolumeTests
+
+final class CompensatedVolumeTests: XCTestCase {
+  func testCompensatedVolumeWithNoCompensation() {
+    let setting = ParametricEqualizerSetting(name: "Flat", bands: [])
+    XCTAssertEqual(setting.compensatedVolume, 1.0, accuracy: 0.01)
+  }
+
+  func testCompensatedVolumeWithNegativeCompensation() {
+    let bands = [
+      ParametricBand(gain: 12),
+      ParametricBand(gain: 12),
+    ]
+    let setting = ParametricEqualizerSetting(name: "Test", bands: bands)
+
+    // With -6dB compensation, volume should be reduced
+    XCTAssertLessThan(setting.compensatedVolume, 1.0)
+  }
+
+  func testCompensatedVolumeStaysInRange() {
+    // Test various gain configurations
+    let extremeBoost = ParametricEqualizerSetting(
+      name: "Extreme",
+      bands: (0 ..< 10).map { _ in ParametricBand(gain: 12) }
+    )
+
+    XCTAssertGreaterThanOrEqual(extremeBoost.compensatedVolume, 0.1)
+    XCTAssertLessThanOrEqual(extremeBoost.compensatedVolume, 2.0)
+  }
+}


### PR DESCRIPTION
I noticed a gap in the market for music players that have really decent, but easy to use, Parametric EQ capabilities. Amperfy is my go-to music player. So I wrote one!

This PR swaps the existing graphic EQ system for a comprehensive Parametric EQ system. 

I've run it through the testing and formatting tools in the Amperfy repo, all of which pass. I've built it locally on my Mac and tested using simulators, but would welcome on-device testing.

It would be great to be able to allow the user to switch between the existing graphic and Parametric EQ's. Happy to build this functionality out if useful.


- Replace fixed 10-band graphic EQ with fully parametric EQ
- Support Bell, Low Shelf, and High Shelf filter types
- Add interactive frequency response curve with draggable nodes
- Implement undo/redo stack
- Add automatic migration from legacy graphic EQ presets
- Include unit tests for band parameters and migration logic


### Features: 

- **Interactive frequency response curve** with draggable band nodes
- **Flexible filter types**: Bell (parametric), Low Shelf, High Shelf
- **Per-band controls**: Frequency (20Hz-20kHz), Gain (-12 to +12 dB), Q (0.1-10.0)
- **Professional features**: Undo/Redo, A-B comparison, global bypass
- **Automatic migration** from existing graphic EQ presets

## Changes

### New Files
- `Amperfy/SwiftUI/Settings/Player/ParametricEQ/` (5 files)
- `AmperfyKitTests/Cases/Player/ParametricEQTest.swift`

### Modified Files
- `AmperfyKit/Storage/PersistentStorage.swift` - New types and settings
- `AmperfyKit/AmperfyKit.swift` - Migration logic
- `AmperfyKit/Player/BackendAudioPlayer.swift` - Parametric EQ engine
- `AmperfyKit/Player/PlayerFacade.swift` - Protocol update
- `Amperfy/SwiftUI/Settings/ObservableSettings.swift` - Observable properties
- `Amperfy/SwiftUI/Settings/Player/EqualizerSettingsView.swift` - UI rewrite
- `Amperfy/Screens/ViewController/SettingsHostVC.swift` - Settings bindings

## Testing

- [x] Unit tests for band parameters and migration
- [x] Manual testing on device
- [x] Code formatted with `./BuildTools/applyFormat.sh`

## Screenshots
<img width="425" height="884" alt="image" src="https://github.com/user-attachments/assets/fc5e44de-ee85-4578-b884-dfe984ed7452" />
<img width="428" height="898" alt="image" src="https://github.com/user-attachments/assets/b4681393-98e0-4fea-aa3e-197ffed53561" />
