### PR TITLE
Edit scrobble time to be in milliseconds

### DIFF
--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -865,7 +865,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
         id: id
       )
       if let date = date {
-        urlComp.addQueryItem(name: "time", value: Int(date.timeIntervalSince1970))
+        urlComp.addQueryItem(name: "time", value: Int(date.timeIntervalSince1970*1000))
       }
       urlComp.addQueryItem(name: "submission", value: submission.description)
       return try self.createUrl(from: urlComp)


### PR DESCRIPTION
The scrobble time used to be submitted in seconds since 1 Jan 1970, whereas Subsonic expects a value in milliseconds. Doing a simple multiplication by 1000 resolves this.

[API documentation](https://subsonic.org/pages/api.jsp#scrobble).