### PR TITLE
Radio controls improvements

### DIFF
--- a/Amperfy/Screens/Player/PlayerUIHandler.swift
+++ b/Amperfy/Screens/Player/PlayerUIHandler.swift
@@ -144,6 +144,10 @@ class PlayerUIHandler: NSObject {
     case .music:
       previouseImg = UIImage.backwardFill
       nextImg = UIImage.forwardFill
+
+      let isRadio = player.currentlyPlaying?.isRadio ?? false
+      previousButton.isEnabled = !isRadio
+      nextButton.isEnabled = !isRadio
     case .podcast:
       previouseImg = UIImage.goBackward15
       nextImg = UIImage.goForward30

--- a/Amperfy/Screens/ViewController/RadiosVC.swift
+++ b/Amperfy/Screens/ViewController/RadiosVC.swift
@@ -184,11 +184,8 @@ class RadiosVC: SingleFetchedResultsTableViewController<RadioMO> {
   }
 
   func convertIndexPathToPlayContext(radioIndexPath: IndexPath) -> PlayContext? {
-    guard let radios = fetchedResultsController.getContextRadios()
-    else { return nil }
     let selectedRadio = fetchedResultsController.getWrappedEntity(at: radioIndexPath)
-    guard let playContextIndex = radios.firstIndex(of: selectedRadio) else { return nil }
-    return PlayContext(name: sceneTitle ?? "", index: playContextIndex, playables: radios)
+    return PlayContext(name: sceneTitle ?? "", index: 0, playables: [selectedRadio])
   }
 
   func convertCellViewToPlayContext(cell: UITableViewCell) -> PlayContext? {

--- a/AmperfyKit/Player/RemoteCommandCenterHandler.swift
+++ b/AmperfyKit/Player/RemoteCommandCenterHandler.swift
@@ -235,8 +235,8 @@ public class RemoteCommandCenterHandler {
       remoteCommandCenter.pauseCommand.isEnabled = false
       remoteCommandCenter.togglePlayPauseCommand.isEnabled = false
       remoteCommandCenter.stopCommand.isEnabled = true
-      remoteCommandCenter.previousTrackCommand.isEnabled = true
-      remoteCommandCenter.nextTrackCommand.isEnabled = true
+      remoteCommandCenter.previousTrackCommand.isEnabled = false
+      remoteCommandCenter.nextTrackCommand.isEnabled = false
       remoteCommandCenter.skipBackwardCommand.isEnabled = false
       remoteCommandCenter.skipForwardCommand.isEnabled = false
       remoteCommandCenter.changeShuffleModeCommand.isEnabled = true


### PR DESCRIPTION
A few enhancements to the controls when playing a radio station:
1. When you "play" a radio station, don't queue up all the other radio stations after it.
2. Disable the "next track" and "previous track" buttons when playing a radio station, as they don't make sense.