### PR TITLE
Support GetSimilarSongs2 (aka Instant Mix) for Subsonic servers

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		50AE79B62C1F65850085CBB3 /* SsLyricsBySongId1ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79B52C1F65850085CBB3 /* SsLyricsBySongId1ParserTest.swift */; };
 		50AE79B82C1F68090085CBB3 /* SsLyricsBySongId2ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79B72C1F68080085CBB3 /* SsLyricsBySongId2ParserTest.swift */; };
 		50AE79BA2C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AE79B92C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml */; };
+		50F3A1C4308A1B8A00A1B2C3 /* similarSongs2_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */; };
 		50AE79BC2C1F6ADF0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79BB2C1F6ADE0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift */; };
 		50AE79C22C20709C0085CBB3 /* LyricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79C12C20709C0085CBB3 /* LyricsView.swift */; };
 		50AE79C32C2070F40085CBB3 /* LyricTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79BF2C206EF10085CBB3 /* LyricTableCell.swift */; };
@@ -919,6 +920,7 @@
 		50AE79B52C1F65850085CBB3 /* SsLyricsBySongId1ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsLyricsBySongId1ParserTest.swift; sourceTree = "<group>"; };
 		50AE79B72C1F68080085CBB3 /* SsLyricsBySongId2ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsLyricsBySongId2ParserTest.swift; sourceTree = "<group>"; };
 		50AE79B92C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = OpenSubsonicExtensions_example_1.xml; sourceTree = "<group>"; };
+		50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = similarSongs2_example_1.xml; sourceTree = "<group>"; };
 		50AE79BB2C1F6ADE0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsOpenSubsonicExtensionsParserTest.swift; sourceTree = "<group>"; };
 		50AE79BD2C1F704B0085CBB3 /* Amperfy v38.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v38.xcdatamodel"; sourceTree = "<group>"; };
 		50AE79BF2C206EF10085CBB3 /* LyricTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricTableCell.swift; sourceTree = "<group>"; };
@@ -2039,6 +2041,7 @@
 				50AE79B92C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml */,
 				50AE79B12C1F64E30085CBB3 /* getLyricsBySongId_example_1.xml */,
 				50AE79B32C1F64F50085CBB3 /* getLyricsBySongId_example_2.xml */,
+				50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */,
 				50CEC6392D1EDB0000D0E696 /* internetRadioStations_example_1.xml */,
 			);
 			path = Samples;
@@ -2380,6 +2383,7 @@
 				50BE5D602850F4F600156FC6 /* error_example_1.xml in Resources */,
 				50BE5D5D2850F4F600156FC6 /* ping_example_1.xml in Resources */,
 				50CEC63A2D1EDB0000D0E696 /* internetRadioStations_example_1.xml in Resources */,
+				50F3A1C4308A1B8A00A1B2C3 /* similarSongs2_example_1.xml in Resources */,
 				50BE5D592850F4F600156FC6 /* album_multidisc_example_1.xml in Resources */,
 				50BE5D7F2850F50700156FC6 /* error-4700.xml in Resources */,
 				50BE5D652850F4F600156FC6 /* artists_example_1.xml in Resources */,

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -173,7 +173,6 @@
 		50AE79B62C1F65850085CBB3 /* SsLyricsBySongId1ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79B52C1F65850085CBB3 /* SsLyricsBySongId1ParserTest.swift */; };
 		50AE79B82C1F68090085CBB3 /* SsLyricsBySongId2ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79B72C1F68080085CBB3 /* SsLyricsBySongId2ParserTest.swift */; };
 		50AE79BA2C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AE79B92C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml */; };
-		50F3A1C4308A1B8A00A1B2C3 /* similarSongs2_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */; };
 		50AE79BC2C1F6ADF0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79BB2C1F6ADE0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift */; };
 		50AE79C22C20709C0085CBB3 /* LyricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79C12C20709C0085CBB3 /* LyricsView.swift */; };
 		50AE79C32C2070F40085CBB3 /* LyricTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE79BF2C206EF10085CBB3 /* LyricTableCell.swift */; };
@@ -279,7 +278,6 @@
 		50C16C1A21E704EC00F086F0 /* ArtistDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C16C1921E704EC00F086F0 /* ArtistDetailVC.swift */; };
 		50C16C1C21E7051700F086F0 /* AlbumDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C16C1B21E7051700F086F0 /* AlbumDetailVC.swift */; };
 		50C16C1E21E7A35C00F086F0 /* GenericTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C16C1D21E7A35C00F086F0 /* GenericTableCell.swift */; };
-		50RA71NG2F5A01240085CBB3 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50RA71NG2F5A01230085CBB3 /* RatingView.swift */; };
 		50C16C2621E7CBA500F086F0 /* GenericTableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 50C16C2521E7CBA500F086F0 /* GenericTableCell.xib */; };
 		50C16C2821E8680A00F086F0 /* CommonScreenOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C16C2721E8680A00F086F0 /* CommonScreenOperations.swift */; };
 		50C171422D0E143200C0C53A /* PlaylistAddLibraryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C171412D0E143200C0C53A /* PlaylistAddLibraryVC.swift */; };
@@ -507,6 +505,8 @@
 		50E1D3982B8A82BB0001A572 /* KeyCommandTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1D3972B8A82BA0001A572 /* KeyCommandTableViewController.swift */; };
 		50E1D39A2B8BEA540001A572 /* SplitVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1D3992B8BEA540001A572 /* SplitVC.swift */; };
 		50E1D39C2B8BED4C0001A572 /* SideBarVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1D39B2B8BED4C0001A572 /* SideBarVC.swift */; };
+		50E520D42F65880B00667E0A /* get_similar.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50E520D32F65880B00667E0A /* get_similar.xml */; };
+		50E520D62F65886600667E0A /* GetSimiliarSongsParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E520D52F65886600667E0A /* GetSimiliarSongsParserTest.swift */; };
 		50E59A4B2ED747F000F2B65C /* HomeEditorVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E59A4A2ED747F000F2B65C /* HomeEditorVC.swift */; };
 		50E59A4D2ED7541900F2B65C /* HomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E59A4C2ED7541900F2B65C /* HomeSection.swift */; };
 		50E77DB428D1B63200BDF882 /* LibraryDisplaySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E77DB328D1B63200BDF882 /* LibraryDisplaySettings.swift */; };
@@ -516,8 +516,10 @@
 		50E936DB2F100C7800C1C504 /* RatingAppEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E936DA2F100C7800C1C504 /* RatingAppEnum.swift */; };
 		50ED03132E278C6B0092E6DC /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ED030C2E2788200092E6DC /* CoreAudio.framework */; };
 		50ED756628CBC5D200E5D347 /* LibrarySyncerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ED756528CBC5D200E5D347 /* LibrarySyncerProxy.swift */; };
+		50F3A1C4308A1B8A00A1B2C3 /* similarSongs2_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */; };
 		50F40A3B2C9088B30097FE63 /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 50F40A3A2C9088B30097FE63 /* IfritStatic */; };
 		50FF311B2BBC4D8000C2C3B9 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */; };
+		50RA71NG2F5A01240085CBB3 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50RA71NG2F5A01230085CBB3 /* RatingView.swift */; };
 		631C166B2C6D3D9A0085F62E /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631C166A2C6D3D9A0085F62E /* SettingsRow.swift */; };
 		631C166D2C6D61110085F62E /* NavigationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631C166C2C6D61110085F62E /* NavigationTarget.swift */; };
 		631C166F2C6D63510085F62E /* SettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631C166E2C6D63510085F62E /* SettingsSection.swift */; };
@@ -920,7 +922,6 @@
 		50AE79B52C1F65850085CBB3 /* SsLyricsBySongId1ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsLyricsBySongId1ParserTest.swift; sourceTree = "<group>"; };
 		50AE79B72C1F68080085CBB3 /* SsLyricsBySongId2ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsLyricsBySongId2ParserTest.swift; sourceTree = "<group>"; };
 		50AE79B92C1F69A00085CBB3 /* OpenSubsonicExtensions_example_1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = OpenSubsonicExtensions_example_1.xml; sourceTree = "<group>"; };
-		50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = similarSongs2_example_1.xml; sourceTree = "<group>"; };
 		50AE79BB2C1F6ADE0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsOpenSubsonicExtensionsParserTest.swift; sourceTree = "<group>"; };
 		50AE79BD2C1F704B0085CBB3 /* Amperfy v38.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v38.xcdatamodel"; sourceTree = "<group>"; };
 		50AE79BF2C206EF10085CBB3 /* LyricTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricTableCell.swift; sourceTree = "<group>"; };
@@ -968,7 +969,6 @@
 		50C16C1921E704EC00F086F0 /* ArtistDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistDetailVC.swift; sourceTree = "<group>"; };
 		50C16C1B21E7051700F086F0 /* AlbumDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailVC.swift; sourceTree = "<group>"; };
 		50C16C1D21E7A35C00F086F0 /* GenericTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericTableCell.swift; sourceTree = "<group>"; };
-		50RA71NG2F5A01230085CBB3 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		50C16C2121E7A38A00F086F0 /* Identifyable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifyable.swift; sourceTree = "<group>"; };
 		50C16C2321E7A3AC00F086F0 /* ClockTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClockTime.swift; sourceTree = "<group>"; };
 		50C16C2521E7CBA500F086F0 /* GenericTableCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GenericTableCell.xib; sourceTree = "<group>"; };
@@ -1086,6 +1086,8 @@
 		50E1D3972B8A82BA0001A572 /* KeyCommandTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCommandTableViewController.swift; sourceTree = "<group>"; };
 		50E1D3992B8BEA540001A572 /* SplitVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitVC.swift; sourceTree = "<group>"; };
 		50E1D39B2B8BED4C0001A572 /* SideBarVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarVC.swift; sourceTree = "<group>"; };
+		50E520D32F65880B00667E0A /* get_similar.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = get_similar.xml; sourceTree = "<group>"; };
+		50E520D52F65886600667E0A /* GetSimiliarSongsParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSimiliarSongsParserTest.swift; sourceTree = "<group>"; };
 		50E59A4A2ED747F000F2B65C /* HomeEditorVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeEditorVC.swift; sourceTree = "<group>"; };
 		50E59A4C2ED7541900F2B65C /* HomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSection.swift; sourceTree = "<group>"; };
 		50E77DB328D1B63200BDF882 /* LibraryDisplaySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryDisplaySettings.swift; sourceTree = "<group>"; };
@@ -1100,6 +1102,7 @@
 		50ED2B9227BB932700331BF7 /* album_missing_artistId.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = album_missing_artistId.xml; sourceTree = "<group>"; };
 		50ED2B9427BB938500331BF7 /* SsAlbumMissingArtistsIdParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsAlbumMissingArtistsIdParserTest.swift; sourceTree = "<group>"; };
 		50ED756528CBC5D200E5D347 /* LibrarySyncerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySyncerProxy.swift; sourceTree = "<group>"; };
+		50F3A1C3308A1B8A00A1B2C3 /* similarSongs2_example_1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = similarSongs2_example_1.xml; sourceTree = "<group>"; };
 		50F800202685B8DA0015844D /* Amperfy v10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v10.xcdatamodel"; sourceTree = "<group>"; };
 		50F81E8523BAF25900EAAC3E /* Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Album.swift; sourceTree = "<group>"; };
 		50F81E8723BB29CD00EAAC3E /* AlbumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTest.swift; sourceTree = "<group>"; };
@@ -1130,6 +1133,7 @@
 		50FE808D26A55CEA00CB434D /* DownloadMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		50FF31192BBB27AC00C2C3B9 /* Amperfy v36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v36.xcdatamodel"; sourceTree = "<group>"; };
 		50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		50RA71NG2F5A01230085CBB3 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		631C166A2C6D3D9A0085F62E /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		631C166C2C6D61110085F62E /* NavigationTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTarget.swift; sourceTree = "<group>"; };
 		631C166E2C6D63510085F62E /* SettingsSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
@@ -1957,6 +1961,7 @@
 				509001C027182A1300A8056D /* CatalogParserTest.swift */,
 				50DB118A266511030033BFFA /* AlbumParserTest.swift */,
 				50DB1192266522F60033BFFA /* SongParserTest.swift */,
+				50E520D52F65886600667E0A /* GetSimiliarSongsParserTest.swift */,
 				50DB119E26652E090033BFFA /* PlaylistsParserTest.swift */,
 				50DB119726652B720033BFFA /* PlaylistSongsParserTest.swift */,
 				501A7D2226808AC10055A51B /* PodcastsParserTest.swift */,
@@ -1983,6 +1988,7 @@
 				501A7D1E26808A9D0055A51B /* podcast_episodes.xml */,
 				50048F9A275A4B560087EDFB /* podcast_episodes_example_2.xml */,
 				50CEC6362D1EDA6B00D0E696 /* live_streams.xml */,
+				50E520D32F65880B00667E0A /* get_similar.xml */,
 			);
 			path = Samples;
 			sourceTree = "<group>";
@@ -2369,6 +2375,7 @@
 				50BE5D7B2850F50700156FC6 /* artists.xml in Resources */,
 				50BE5D5C2850F4F600156FC6 /* podcasts_example_1.xml in Resources */,
 				50BE5D7A2850F50700156FC6 /* podcasts.xml in Resources */,
+				50E520D42F65880B00667E0A /* get_similar.xml in Resources */,
 				50BE5D582850F4F600156FC6 /* artist_example_1.xml in Resources */,
 				50BE5D812850F50700156FC6 /* handshake.xml in Resources */,
 				50BE5D5A2850F4F600156FC6 /* album_example_1.xml in Resources */,
@@ -2860,6 +2867,7 @@
 				50BE5D4D2850F4C900156FC6 /* ArtworkTest.swift in Sources */,
 				50BE5D932850F51E00156FC6 /* CoreDataSeeder.swift in Sources */,
 				50BE5D922850F50F00156FC6 /* PlaylistsParserTest.swift in Sources */,
+				50E520D62F65886600667E0A /* GetSimiliarSongsParserTest.swift in Sources */,
 				50BE5D902850F50F00156FC6 /* PodcastEpisodesExample2ParserTest.swift in Sources */,
 				50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */,
 				50BE5D4A2850F4C900156FC6 /* SongTest.swift in Sources */,

--- a/Amperfy/Screens/ViewController/EntityPreviewVC.swift
+++ b/Amperfy/Screens/ViewController/EntityPreviewVC.swift
@@ -261,9 +261,7 @@ class EntityPreviewActionBuilder {
     isGoToSiteUrl = false
     isShowPodcastDetails = false
     isShowSongDetails = true
-    isInstantMix =
-      appDelegate.storage.settings.user.isOnlineMode &&
-      song.account?.apiType == .subsonic
+    isInstantMix = appDelegate.storage.settings.user.isOnlineMode
   }
 
   private func configureFor(podcastEpisode: PodcastEpisode) {
@@ -451,7 +449,7 @@ class EntityPreviewActionBuilder {
   }
 
   private func createInstantMixAction() -> UIAction {
-    UIAction(title: "Instant Mix", image: .shuffle) { [weak self] action in
+    UIAction(title: "Instant Mix", image: .instantMix) { [weak self] action in
       guard let self = self,
             let song = (entityContainer as? AbstractPlayable)?.asSong
       else { return }

--- a/Amperfy/Screens/ViewController/EntityPreviewVC.swift
+++ b/Amperfy/Screens/ViewController/EntityPreviewVC.swift
@@ -69,6 +69,7 @@ class EntityPreviewActionBuilder {
   private var isGoToSiteUrl = false
   private var isShowPodcastDetails = false
   private var isShowSongDetails = false
+  private var isInstantMix = false
 
   init(
     container: PlayableContainable,
@@ -102,6 +103,9 @@ class EntityPreviewActionBuilder {
     }
     if isShuffle {
       playActions.append(createPlayShuffledAction())
+    }
+    if isInstantMix {
+      playActions.append(createInstantMixAction())
     }
     if !playActions.isEmpty {
       menuActions.append(UIMenu(options: .displayInline, children: playActions))
@@ -257,6 +261,9 @@ class EntityPreviewActionBuilder {
     isGoToSiteUrl = false
     isShowPodcastDetails = false
     isShowSongDetails = true
+    isInstantMix =
+      appDelegate.storage.settings.user.isOnlineMode &&
+      song.account?.apiType == .subsonic
   }
 
   private func configureFor(podcastEpisode: PodcastEpisode) {
@@ -440,6 +447,63 @@ class EntityPreviewActionBuilder {
           playables: self.entityPlayables
         ))
       }
+    }
+  }
+
+  private func createInstantMixAction() -> UIAction {
+    UIAction(title: "Instant Mix", image: .shuffle) { [weak self] action in
+      guard let self = self,
+            let song = (entityContainer as? AbstractPlayable)?.asSong
+      else { return }
+
+      Task { @MainActor in
+        await self.createAndPlayInstantMix(for: song)
+      }
+    }
+  }
+
+  private func createAndPlayInstantMix(for song: Song) async {
+    do {
+      // Get the library syncer for the song's account
+      guard let account = song.account else {
+        appDelegate.eventLogger.error(
+          topic: "Instant Mix",
+          statusCode: .commonError,
+          message: "Song has no account",
+          displayPopup: true
+        )
+        return
+      }
+
+      let librarySyncer = appDelegate.getMeta(account.info).librarySyncer
+
+      // Fetch similar songs from backend
+      let similarSongs = try await librarySyncer.requestSimilarSongs(song: song, count: 99)
+
+      if similarSongs.isEmpty {
+        appDelegate.eventLogger.info(
+          topic: "Instant Mix",
+          message: "No similar songs found",
+          displayPopup: true
+        )
+        return
+      }
+
+      // Create playlist: seed song + similar songs
+      var allSongs = [song] + similarSongs
+
+      // Create play context and start playing
+      let context = PlayContext(name: "Instant Mix: \(song.title)", playables: allSongs)
+      appDelegate.player.play(context: context)
+
+      appDelegate.eventLogger.info(
+        topic: "Instant Mix",
+        message: "Playing instant mix with \(allSongs.count) songs",
+        displayPopup: true
+      )
+
+    } catch {
+      appDelegate.eventLogger.report(topic: "Instant Mix", error: error)
     }
   }
 

--- a/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
@@ -1008,6 +1008,13 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   }
 
   @MainActor
+  func requestSimilarSongs(song: Song, count: Int) async throws -> [Song] {
+    // Ampache does not support similar songs API
+    // Return empty array
+    []
+  }
+
+  @MainActor
   func requestPodcastEpisodeDelete(podcastEpisode: PodcastEpisode) async throws {
     guard isSyncAllowed else { return }
     let response = try await ampacheXmlServerApi.requestPodcastEpisodeDelete(id: podcastEpisode.id)

--- a/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
@@ -1009,9 +1009,35 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
 
   @MainActor
   func requestSimilarSongs(song: Song, count: Int) async throws -> [Song] {
-    // Ampache does not support similar songs API
-    // Return empty array
-    []
+    guard isSyncAllowed else { return [] }
+    let response = try await ampacheXmlServerApi.requestSimilarSongs(id: song.id, count: count)
+
+    let similarSongObjectIds: [NSManagedObjectID] = try await storage.async.performAndGet {
+      asyncCompanion in
+      let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
+      let idParserDelegate = IDsParserDelegate(performanceMonitor: self.performanceMonitor)
+      try self.parse(
+        response: response,
+        delegate: idParserDelegate,
+        isThrowingErrorsAllowed: false
+      )
+      let prefetch = asyncCompanion.library.getElements(
+        account: accountAsync,
+        prefetchIDs: idParserDelegate.prefetchIDs
+      )
+
+      let parserDelegate = SongParserDelegate(
+        performanceMonitor: self.performanceMonitor, prefetch: prefetch, account: accountAsync,
+        library: asyncCompanion.library,
+        parseNotifier: nil
+      )
+      try self.parse(response: response, delegate: parserDelegate)
+      return parserDelegate.parsedSongs.compactMap { $0.managedObject.objectID }
+    }
+
+    return try similarSongObjectIds.map {
+      Song(managedObject: try storage.main.context.existingObject(with: $0) as! SongMO)
+    }
   }
 
   @MainActor

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -721,6 +721,17 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     }
   }
 
+  public func requestSimilarSongs(id: String, count: Int = 50) async throws -> APIDataResponse {
+    try await request { auth in
+      var urlComp = try self.createAuthApiUrlComponent(auth: auth)
+      urlComp.addQueryItem(name: "action", value: "get_similar")
+      urlComp.addQueryItem(name: "type", value: "song")
+      urlComp.addQueryItem(name: "filter", value: id)
+      urlComp.addQueryItem(name: "limit", value: count)
+      return try self.createUrl(from: urlComp)
+    }
+  }
+
   private func createUrl(from urlComp: URLComponents) throws -> URL {
     if let url = urlComp.url {
       return url

--- a/AmperfyKit/Api/BackendApi.swift
+++ b/AmperfyKit/Api/BackendApi.swift
@@ -188,6 +188,8 @@ public protocol LibrarySyncer: Sendable {
   @MainActor
   func requestRandomSongs(playlist: Playlist, count: Int) async throws
   @MainActor
+  func requestSimilarSongs(song: Song, count: Int) async throws -> [Song]
+  @MainActor
   func requestPodcastEpisodeDelete(podcastEpisode: PodcastEpisode) async throws
   @MainActor
   func syncNowPlaying(song: Song, songPosition: NowPlayingSongPosition) async throws

--- a/AmperfyKit/Api/LibrarySyncerProxy.swift
+++ b/AmperfyKit/Api/LibrarySyncerProxy.swift
@@ -175,6 +175,11 @@ extension LibrarySyncerProxy: LibrarySyncer {
   }
 
   @MainActor
+  func requestSimilarSongs(song: Song, count: Int) async throws -> [Song] {
+    try await activeSyncer.requestSimilarSongs(song: song, count: count)
+  }
+
+  @MainActor
   func requestPodcastEpisodeDelete(podcastEpisode: PodcastEpisode) async throws {
     try await activeSyncer.requestPodcastEpisodeDelete(podcastEpisode: podcastEpisode)
   }

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -905,6 +905,40 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   }
 
   @MainActor
+  func requestSimilarSongs(song: Song, count: Int) async throws -> [Song] {
+    guard isSyncAllowed else { return [] }
+    let response = try await subsonicServerApi.requestSimilarSongs(id: song.id, count: count)
+
+    let similarSongObjectIds: [NSManagedObjectID] = try await storage.async.performAndGet {
+      asyncCompanion in
+      let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
+      let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)
+      try self.parse(
+        response: response,
+        delegate: idParserDelegate,
+        isThrowingErrorsAllowed: false
+      )
+      let prefetch = asyncCompanion.library.getElements(
+        account: accountAsync,
+        prefetchIDs: idParserDelegate.prefetchIDs
+      )
+
+      let parserDelegate = SsSongParserDelegate(
+        performanceMonitor: self.performanceMonitor,
+        prefetch: prefetch,
+        account: accountAsync,
+        library: asyncCompanion.library
+      )
+      try self.parse(response: response, delegate: parserDelegate)
+      return parserDelegate.parsedSongs.compactMap { $0.managedObject.objectID }
+    }
+
+    return try similarSongObjectIds.map {
+      Song(managedObject: try storage.main.context.existingObject(with: $0) as! SongMO)
+    }
+  }
+
+  @MainActor
   func requestPodcastEpisodeDelete(podcastEpisode: PodcastEpisode) async throws {
     guard isSyncAllowed else { return }
     let response = try await subsonicServerApi.requestPodcastEpisodeDelete(id: podcastEpisode.id)

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -929,6 +929,18 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     }
   }
 
+  public func requestSimilarSongs(id: String, count: Int = 50) async throws -> APIDataResponse {
+    try await request { version in
+      var urlComp = try self.createAuthApiUrlComponent(
+        version: version,
+        forAction: "getSimilarSongs2",
+        id: id
+      )
+      urlComp.addQueryItem(name: "count", value: count)
+      return try self.createUrl(from: urlComp)
+    }
+  }
+
   private func createUrl(from urlComp: URLComponents) throws -> URL {
     if let url = urlComp.url {
       return url

--- a/AmperfyKit/Assets/UIImageAssetsExtension.swift
+++ b/AmperfyKit/Assets/UIImageAssetsExtension.swift
@@ -225,6 +225,7 @@ public struct AmperfyImage: Sendable {
   public static let settings = Self("gear")
   public static let shuffle = Self("shuffle")
   public static let shuffleMenu = Self("shuffle")
+  public static let instantMix = Self("point.3.filled.connected.trianglepath.dotted")
   public static let skipBackward10 = Self("gobackward.10")
   public static let skipBackward15 = Self("gobackward.15")
   public static let skipBackwardMenu = Self("gobackward")
@@ -365,6 +366,7 @@ extension UIImage {
   public static let serverUrl = UIImage.create(systemName: AmperfyImage.serverUrl.systemName)
   public static let settings = UIImage.create(systemName: AmperfyImage.settings.systemName)
   public static let shuffle = UIImage.create(systemName: AmperfyImage.shuffle.systemName)
+  public static let instantMix = UIImage.create(systemName: AmperfyImage.instantMix.systemName)
   public static let shuffleMenu = UIImage.create(systemName: AmperfyImage.shuffleMenu.systemName)
   public static let skipBackward10 = UIImage
     .create(systemName: AmperfyImage.skipBackward10.systemName)

--- a/AmperfyKitTests/Cases/API/Ampache/GetSimiliarSongsParserTest.swift
+++ b/AmperfyKitTests/Cases/API/Ampache/GetSimiliarSongsParserTest.swift
@@ -1,0 +1,81 @@
+//
+//  GetSimiliarSongsParserTest.swift
+//  AmperfyKitTests
+//
+//  Created by Maximilian Bauer on 14.03.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import AmperfyKit
+import XCTest
+
+class GetSimiliarSongsParserTest: AbstractAmpacheTest {
+  override func setUp() async throws {
+    try await super.setUp()
+    xmlData = getTestFileData(name: "get_similar")
+  }
+
+  override func createParserDelegate() {
+    let prefetch = library.getElements(account: account, prefetchIDs: idParserDelegate.prefetchIDs)
+    parserDelegate = SongParserDelegate(
+      performanceMonitor: MOCK_PerformanceMonitor(), prefetch: prefetch, account: account,
+      library: library,
+      parseNotifier: nil
+    )
+  }
+
+  override func checkCorrectParsing() {
+    prefetchIdTester.checkPrefetchIdCounts(
+      artworkCount: 0,
+      genreIdCount: 0,
+      artistCount: 3,
+      albumCount: 3,
+      songCount: 5
+    )
+
+    let songs = library.getSongs(for: account).sorted(by: { Int($0.id)! < Int($1.id)! })
+    XCTAssertEqual(songs.count, 5)
+
+    var song = songs[1]
+    XCTAssertEqual(song.account?.serverHash, TestAccountInfo.test1ServerHash)
+    XCTAssertEqual(song.account?.userHash, TestAccountInfo.test1UserHash)
+    XCTAssertEqual(song.id, "41039")
+    XCTAssertEqual(song.title, "Somebody Told Me")
+    XCTAssertEqual(song.artist?.account?.serverHash, TestAccountInfo.test1ServerHash)
+    XCTAssertEqual(song.artist?.account?.userHash, TestAccountInfo.test1UserHash)
+    XCTAssertEqual(song.artist?.id, "2277")
+    XCTAssertEqual(song.artist?.name, "The Killers")
+    XCTAssertEqual(song.album?.account?.serverHash, TestAccountInfo.test1ServerHash)
+    XCTAssertEqual(song.album?.account?.userHash, TestAccountInfo.test1UserHash)
+    XCTAssertEqual(song.album?.id, "50260") // Album not pre created
+    XCTAssertEqual(song.album?.name, "Hot Fuss")
+    XCTAssertNil(song.genre)
+
+    song = songs[4]
+    XCTAssertEqual(song.account?.serverHash, TestAccountInfo.test1ServerHash)
+    XCTAssertEqual(song.account?.userHash, TestAccountInfo.test1UserHash)
+    XCTAssertEqual(song.id, "777754")
+    XCTAssertEqual(song.title, "Fluorescent Adolescent")
+    XCTAssertEqual(song.artist?.account?.serverHash, TestAccountInfo.test1ServerHash)
+    XCTAssertEqual(song.artist?.account?.userHash, TestAccountInfo.test1UserHash)
+    XCTAssertEqual(song.artist?.id, "10468")
+    XCTAssertEqual(song.artist?.name, "Arctic Monkeys")
+    XCTAssertEqual(song.album?.account?.serverHash, TestAccountInfo.test1ServerHash)
+    XCTAssertEqual(song.album?.account?.userHash, TestAccountInfo.test1UserHash)
+    XCTAssertEqual(song.album?.id, "84543")
+    XCTAssertEqual(song.album?.name, "Favourite Worst Nightmare")
+  }
+}

--- a/AmperfyKitTests/Cases/API/Ampache/Samples/get_similar.xml
+++ b/AmperfyKitTests/Cases/API/Ampache/Samples/get_similar.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+<total_count>5</total_count>
+<song id="41039">
+	<title><![CDATA[Somebody Told Me]]></title>
+	<name><![CDATA[Somebody Told Me]]></name>
+		<artist id="2277"><![CDATA[The Killers]]></artist>
+		<album id="50260"><![CDATA[Hot Fuss]]></album>
+</song>
+<song id="41037">
+	<title><![CDATA[Smile Like You Mean It]]></title>
+	<name><![CDATA[Smile Like You Mean It]]></name>
+		<artist id="2277"><![CDATA[The Killers]]></artist>
+		<album id="50260"><![CDATA[Hot Fuss]]></album>
+</song>
+<song id="169876">
+	<title><![CDATA[Sex on Fire]]></title>
+	<name><![CDATA[Sex on Fire]]></name>
+		<artist id="5774"><![CDATA[Kings of Leon]]></artist>
+		<album id="56356"><![CDATA[Only by the Night]]></album>
+</song>
+<song id="169866">
+	<title><![CDATA[Use Somebody]]></title>
+	<name><![CDATA[Use Somebody]]></name>
+		<artist id="5774"><![CDATA[Kings of Leon]]></artist>
+		<album id="56356"><![CDATA[Only by the Night]]></album>
+</song>
+<song id="777754">
+	<title><![CDATA[Fluorescent Adolescent]]></title>
+	<name><![CDATA[Fluorescent Adolescent]]></name>
+		<artist id="10468"><![CDATA[Arctic Monkeys]]></artist>
+		<album id="84543"><![CDATA[Favourite Worst Nightmare]]></album>
+</song>
+</root>

--- a/AmperfyKitTests/Cases/API/Subsonic/Samples/similarSongs2_example_1.xml
+++ b/AmperfyKitTests/Cases/API/Subsonic/Samples/similarSongs2_example_1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.16.1">
+  <similarSongs2>
+    <song id="71463" parent="71381" title="The Jack" album="High Voltage" artist="AC/DC" isDir="false" coverArt="71381" created="2004-11-08T23:36:11" duration="352" bitRate="128" size="5624132" suffix="mp3" contentType="audio/mpeg" isVideo="false" path="ACDC/High voltage/ACDC - The Jack.mp3" albumId="11053" artistId="5432" type="music"/>
+    <song id="71458" parent="71381" title="It's A Long Way To The Top" album="High Voltage" artist="AC/DC" isDir="false" coverArt="71381" created="2004-11-27T20:23:32" duration="315" bitRate="128" year="1976" genre="Rock" size="5037357" suffix="mp3" contentType="audio/mpeg" isVideo="false" path="ACDC/High voltage/ACDC - Its a long way to the top if you wanna rock n roll.mp3" albumId="11053" artistId="5432" type="music" userRating="1"/>
+  </similarSongs2>
+</subsonic-response>

--- a/AmperfyKitTests/Cases/API/Subsonic/SsSongExample1ParserTest.swift
+++ b/AmperfyKitTests/Cases/API/Subsonic/SsSongExample1ParserTest.swift
@@ -174,4 +174,34 @@ class SsSongExample1ParserTest: AbstractSsParserTest {
     XCTAssertEqual(song.artwork?.id, "71381")
     XCTAssertEqual(song.artwork, song1Artwork)
   }
+
+  func testSimilarSongs2WrapperParsing() {
+    let similarSongsData = getTestFileData(name: "similarSongs2_example_1")
+
+    let idParserDelegate = SsIDsParserDelegate(performanceMonitor: MOCK_PerformanceMonitor())
+    let idParser = XMLParser(data: similarSongsData)
+    idParser.delegate = idParserDelegate
+    idParser.parse()
+    XCTAssertNil(idParserDelegate.error)
+
+    let prefetch = library.getElements(account: account, prefetchIDs: idParserDelegate.prefetchIDs)
+    let parserDelegate = SsSongParserDelegate(
+      performanceMonitor: MOCK_PerformanceMonitor(),
+      prefetch: prefetch,
+      account: account,
+      library: library,
+      parseNotifier: nil
+    )
+    let parser = XMLParser(data: similarSongsData)
+    parser.delegate = parserDelegate
+    parser.parse()
+    XCTAssertNil(parserDelegate.error)
+
+    let songs = library.getSongs(for: account).sorted(by: { $0.id < $1.id })
+    XCTAssertEqual(songs.count, 2)
+    XCTAssertEqual(songs[0].id, "71458")
+    XCTAssertEqual(songs[0].title, "It's A Long Way To The Top")
+    XCTAssertEqual(songs[1].id, "71463")
+    XCTAssertEqual(songs[1].title, "The Jack")
+  }
 }

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -174,6 +174,7 @@ final class MOCK_LibrarySyncer: LibrarySyncer {
   func syncIndexes(musicFolder: MusicFolder) async throws {}
   func sync(directory: Directory) async throws {}
   func requestRandomSongs(playlist: Playlist, count: Int) async throws {}
+  func requestSimilarSongs(song: Song, count: Int) async throws -> [Song] { [] }
   func requestPodcastEpisodeDelete(podcastEpisode: PodcastEpisode) async throws {}
   func syncNowPlaying(song: Song, songPosition: NowPlayingSongPosition) async throws {}
   func scrobble(song: Song, date: Date?) async throws {}


### PR DESCRIPTION
Adds an "Instant Mix" option in the context menu for songs. Only works when online since this is a server-side feature. Implemented for Subsonic protocol only so far. Tried to follow the same coding style as the rest of amperfy.

Note: similar songs will only succeed once the library scan has finished in Amperfy, since the call can return any song that's present in the database. On the simulator, it can take a minute the first time after install, but it works perfectly afterwards.

This should address #613 