### PR TITLE
Fix: delete stale Download objects when clearing cache

### DIFF
--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -1677,7 +1677,6 @@ public class LibraryStorage: PlayableFileCachable {
       getFetchPredicate(forAccount: account),
       SongMO.excludeServerDeleteUncachedSongsFetchPredicate,
       NSPredicate(format: "%K == nil", #keyPath(SongMO.relFilePath)),
-      NSPredicate(format: "%K == nil", #keyPath(SongMO.download)),
     ])
     let foundSongs = try? context.fetch(fetchRequest)
     let songs = foundSongs?.compactMap { Song(managedObject: $0) }

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -690,6 +690,9 @@ public class LibraryStorage: PlayableFileCachable {
   private func deleteCacheFinalStep(playable: AbstractPlayable) {
     playable.contentTypeTranscoded = nil
     playable.relFilePath = nil
+    if let download = playable.playableManagedObject.download {
+      context.delete(download)
+    }
     playable.deleteCache()
   }
 


### PR DESCRIPTION
## Summary

- Fixes #662 — "Download all songs in library" silently does nothing after clearing cache or switching download format

## Root Cause

Two issues combine to produce the bug:

### 1. Stale DownloadMO after cache clear (preventive fix — commit 1)

`deleteCacheFinalStep` (called by "Delete downloaded songs and podcast episodes") sets `relFilePath = nil` but leaves the associated `DownloadMO` Core Data relationship intact. This follows the same pattern already used when resolving duplicate songs (line 185-186) and podcast episodes (line 217-218), which already delete the associated `DownloadMO` via `context.delete(download)`.

### 2. Overly restrictive fetch predicate (self-healing fix — commit 2)

`getSongsForCompleteLibraryDownload` requires **both** predicates to match:
```swift
NSPredicate(format: "%K == nil", #keyPath(SongMO.relFilePath)),  // ✅ cleared by cache delete
NSPredicate(format: "%K == nil", #keyPath(SongMO.download)),      // ❌ stale DownloadMO still present
```

The `download == nil` predicate is redundant with `DownloadRequestManager.addLowPrio`, which already correctly handles existing downloads: if the song is not cached (`!object.isCached`), it resets the download and re-queues it. Songs that are already cached are skipped. Removing this predicate allows `addLowPrio`'s own deduplication logic to handle both fresh and stale state.

## Why both commits

- **Commit 1** (preventive): Deletes `DownloadMO` during cache clear so the stale state is never created going forward.
- **Commit 2** (migratory): Removes the redundant `download == nil` predicate so users upgrading from older builds self-heal on next "Download all" without manual cleanup.

## Test Plan

- [x] Fresh account: sync library → "Download all songs in library" → downloads start normally
- [x] Cache clear cycle: let some downloads complete → "Delete downloaded songs and podcast episodes" → "Download all songs in library" → second run queues songs successfully
- [x] Already-broken account from older build: upgrade to patched build → "Download all songs in library" → stale state self-heals and downloads resume
- [x] Normal download flow (without cache clear) still works as before
- [x] Songs currently being downloaded are not disrupted by a concurrent "Download all"