### PR TITLE
adding always on top setting for mini player

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
@@ -1143,6 +1144,7 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
@@ -1459,6 +1461,7 @@
 				5059A31B28A9ED680068E4D2 /* SceneDelegate.swift */,
 				63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */,
 				637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */,
+				C0A1B0022EEE000000000002 /* MacWindowHelper.swift */,
 				50CFBC532E464EDE00EAA7BC /* AppDelegateMainMenuExtension.swift */,
 				509001B72716C8F400A8056D /* AppDelegateNotificationExtensions.swift */,
 				509001B52716C7F600A8056D /* AppDelegateAlertExtensions.swift */,
@@ -2485,6 +2488,7 @@
 				509001B82716C8F400A8056D /* AppDelegateNotificationExtensions.swift in Sources */,
 				50A30E5C2B7556FB00722894 /* PopupPlayer+TableViewExtension.swift in Sources */,
 				637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */,
+				C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */,
 				505CA2112B88ECC700AA81CD /* SingleFetchedResultsTableViewController.swift in Sources */,
 				50C9D717285075E3007F18D0 /* UtilitiesExtensions.swift in Sources */,
 				505CA2142B88ED6100AA81CD /* SingleSnapshotFetchedResultsTableViewController.swift in Sources */,

--- a/Amperfy/AppDelegateMainMenuExtension.swift
+++ b/Amperfy/AppDelegateMainMenuExtension.swift
@@ -349,6 +349,15 @@ extension AppDelegate {
       }
   }
 
+  func updateMiniPlayerAlwaysOnTop() {
+    #if targetEnvironment(macCatalyst)
+      MacWindowHelper.setAlwaysOnTop(
+        storage.settings.user.isMiniPlayerAlwaysOnTop,
+        sceneTitle: MiniPlayerSceneDelegate.sceneTitle
+      )
+    #endif
+  }
+
   func createSleepTimerMenu(refreshCB: VoidFunctionCallback?) -> UIMenuElement {
     if let timer = sleepTimer {
       let actionTitle = "Turn Off (Pause at: \(timer.fireDate.asShortHrMinString))"

--- a/Amperfy/MacWindowHelper.swift
+++ b/Amperfy/MacWindowHelper.swift
@@ -1,0 +1,75 @@
+//
+//  MacWindowHelper.swift
+//  Amperfy
+//
+//  Created by Mike Liddle on 04.03.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#if targetEnvironment(macCatalyst)
+
+  import ObjectiveC
+  import UIKit
+
+  // NSWindow.Level.floating = 3, NSWindow.Level.normal = 0 https://developer.apple.com/documentation/appkit/nswindow/level-swift.struct
+  private let nsWindowLevelFloating = 3
+  private let nsWindowLevelNormal = 0
+
+  enum MacWindowHelper {
+    static func setAlwaysOnTop(
+      _ alwaysOnTop: Bool,
+      sceneTitle: String
+    ) {
+      let level = alwaysOnTop ? nsWindowLevelFloating : nsWindowLevelNormal
+
+      guard let appClass = NSClassFromString("NSApplication")
+        as? NSObject.Type
+      else { return }
+
+      let sharedApp = appClass
+        .perform(NSSelectorFromString("sharedApplication"))?
+        .takeUnretainedValue()
+
+      guard let app = sharedApp,
+            let nsWindows = (app as AnyObject)
+            .perform(NSSelectorFromString("windows"))?
+            .takeUnretainedValue() as? [AnyObject]
+      else { return }
+
+      let setLevelSel = NSSelectorFromString("setLevel:")
+
+      for nsWindow in nsWindows {
+        guard let title = nsWindow
+          .perform(NSSelectorFromString("title"))?
+          .takeUnretainedValue() as? String,
+          title == sceneTitle
+        else { continue }
+
+        guard let method = class_getInstanceMethod(
+          type(of: nsWindow),
+          setLevelSel
+        ) else { continue }
+
+        typealias SetLevelFunc = @convention(c)
+          (AnyObject, Selector, Int) -> ()
+        let impl = method_getImplementation(method)
+        let setLevel = unsafeBitCast(impl, to: SetLevelFunc.self)
+        setLevel(nsWindow, setLevelSel, level)
+      }
+    }
+  }
+
+#endif

--- a/Amperfy/MiniPlayerSceneDelegate.swift
+++ b/Amperfy/MiniPlayerSceneDelegate.swift
@@ -25,6 +25,8 @@ import SwiftUI
 import UIKit
 
 class MiniPlayerSceneDelegate: UIResponder, UIWindowSceneDelegate {
+  static let sceneTitle = "Amperfy Mini Player"
+
   public lazy var log = {
     AmperKit.shared.log
   }()
@@ -47,6 +49,10 @@ class MiniPlayerSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     window = UIWindow(windowScene: windowScene)
     window?.backgroundColor = .secondarySystemBackground
+
+    #if targetEnvironment(macCatalyst)
+      windowScene.title = Self.sceneTitle
+    #endif
 
     window?.rootViewController = PopupPlayerVC()
     window?.makeKeyAndVisible()
@@ -79,6 +85,12 @@ class MiniPlayerSceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     os_log("MiniPlayer: sceneDidBecomeActive", log: self.log, type: .info)
     appDelegate.rebuildMainMenu()
+    #if targetEnvironment(macCatalyst)
+      MacWindowHelper.setAlwaysOnTop(
+        appDelegate.storage.settings.user.isMiniPlayerAlwaysOnTop,
+        sceneTitle: Self.sceneTitle
+      )
+    #endif
   }
 
   func sceneWillResignActive(_ scene: UIScene) {

--- a/Amperfy/Screens/ViewController/SettingsHostVC.swift
+++ b/Amperfy/Screens/ViewController/SettingsHostVC.swift
@@ -231,6 +231,15 @@ class SettingsHostVC: UIViewController {
       self.appDelegate.storage.settings.user.isHapticsEnabled = newValue
     }))
 
+    settings.isMiniPlayerAlwaysOnTop = appDelegate.storage.settings.user.isMiniPlayerAlwaysOnTop
+    changesAgent.append(settings.$isMiniPlayerAlwaysOnTop.sink(receiveValue: { newValue in
+      let hasValueChanged = self.appDelegate.storage.settings.user
+        .isMiniPlayerAlwaysOnTop != newValue
+      guard hasValueChanged else { return }
+      self.appDelegate.storage.settings.user.isMiniPlayerAlwaysOnTop = newValue
+      self.appDelegate.updateMiniPlayerAlwaysOnTop()
+    }))
+
     settings.appearanceMode = appDelegate.storage.settings.user.appearanceMode
     changesAgent.append(settings.$appearanceMode.sink(receiveValue: { newValue in
       self.appDelegate.storage.settings.user.appearanceMode = newValue

--- a/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
@@ -65,6 +65,19 @@ struct DisplaySettingsView: View {
           )
         #endif
 
+        #if targetEnvironment(macCatalyst)
+          SettingsSection(
+            content: {
+              SettingsCheckBoxRow(
+                title: "Mini Player Always on Top",
+                isOn: $settings.isMiniPlayerAlwaysOnTop
+              )
+            },
+            footer:
+            "Keep the mini player window floating above all other windows."
+          )
+        #endif
+
         SettingsSection(
           content: {
             SettingsCheckBoxRow(

--- a/Amperfy/SwiftUI/Settings/ObservableSettings.swift
+++ b/Amperfy/SwiftUI/Settings/ObservableSettings.swift
@@ -89,4 +89,7 @@ final class Settings: ObservableObject {
 
   @Published
   var isReplayGainEnabled = true
+
+  @Published
+  var isMiniPlayerAlwaysOnTop = false
 }

--- a/AmperfyKit/Storage/Settings.swift
+++ b/AmperfyKit/Storage/Settings.swift
@@ -201,6 +201,12 @@ public struct UserSettings: Sendable, Codable {
     set { _isReplayGainEnabled = newValue }
   }
 
+  private var _isMiniPlayerAlwaysOnTop: Bool = false
+  public var isMiniPlayerAlwaysOnTop: Bool {
+    get { _isMiniPlayerAlwaysOnTop }
+    set { _isMiniPlayerAlwaysOnTop = newValue }
+  }
+
   private var _playerVolume: Float = 1.0
   public var playerVolume: Float {
     get {


### PR DESCRIPTION
Spotify and some other media playing apps have an always on top feature for their mini players where you can see the album art and track title for what you're listening to without it disappearing behind other app windows. Having the controls there is good as well since it makes it easy to play/pause music quickly without needing the full window taking up a zone on your monitor or trying to pull up the window and pause (assuming you're not using media keys).

This change adds in a new setting, which for MacOS specifically, will allow users to set the mini player to always be on top. this won't apply when you're not using the mini player (seems like a bad experience to float the whole library view over top of things), and is turned off by default. I tried to make it minimally invasive.