### PR TITLE
Feature: Share song

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -530,10 +530,10 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
-		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1148,12 +1148,12 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
-		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09EB5F102F93B96E00B1C71C /* ShareSongAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */; };
 		43FBE27F250D4DFD00D5F9B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43FBE27E250D4DFD00D5F9B3 /* LaunchScreen.storyboard */; };
 		5003D8FB267B3390006946BF /* LibrarySyncPopupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5003D8FA267B3390006946BF /* LibrarySyncPopupVC.swift */; };
 		5005938928E2D4EF008C8DF6 /* CommonCollectionSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5005938828E2D4EF008C8DF6 /* CommonCollectionSectionHeader.xib */; };
@@ -204,6 +205,7 @@
 		50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */; };
 		50BE5D542850F4E700156FC6 /* SubsonicVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */; };
 		50BE5D552850F4E700156FC6 /* UtilitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5090963726496A9500DD9826 /* UtilitiesTest.swift */; };
+		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
 		50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */; };
 		50BE5D572850F4F600156FC6 /* album_missing_artistId.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50ED2B9227BB932700331BF7 /* album_missing_artistId.xml */; };
 		50BE5D582850F4F600156FC6 /* artist_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AB92C526661F5800DCE45C /* artist_example_1.xml */; };
@@ -528,10 +530,10 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
-		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -592,6 +594,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongAction.swift; sourceTree = "<group>"; };
 		43FBE27E250D4DFD00D5F9B3 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5002565625E69DC700674CE1 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		5003D8F62678DD39006946BF /* SsAlbumParserPreCreatedArtistsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsAlbumParserPreCreatedArtistsTest.swift; sourceTree = "<group>"; };
@@ -837,6 +840,7 @@
 		509001C027182A1300A8056D /* CatalogParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserTest.swift; sourceTree = "<group>"; };
 		509001C227182A4700A8056D /* CatalogParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserDelegate.swift; sourceTree = "<group>"; };
 		5090963726496A9500DD9826 /* UtilitiesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTest.swift; sourceTree = "<group>"; };
+		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
 		509357512E3BF47800CD4075 /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
 		509362EC28E041FF005C2AAC /* Amperfy v28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v28.xcdatamodel"; sourceTree = "<group>"; };
 		50947E0227DA011F00C368D7 /* ScrobbleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleEntry.swift; sourceTree = "<group>"; };
@@ -1144,12 +1148,12 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
-		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1327,6 +1331,7 @@
 				50ED2B9027B7AE8500331BF7 /* EventNotificationHandler.swift */,
 				505CA1F42B848B8300AA81CD /* QuickActionsHandler.swift */,
 				5021B1272BC723F400893C33 /* FuzzySearcher.swift */,
+				09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1561,6 +1566,7 @@
 			isa = PBXGroup;
 			children = (
 				5090963726496A9500DD9826 /* UtilitiesTest.swift */,
+				B5A5CE010000000000000002 /* ShareSongActionTest.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -2766,6 +2772,7 @@
 				50C9D6B6284FAA87007F18D0 /* PodcastEpisode.swift in Sources */,
 				50C9D65D284FAA0B007F18D0 /* PlaylistParserDelegate.swift in Sources */,
 				50AD70DB2D5FBB0100E369BF /* AsyncOperation.swift in Sources */,
+				09EB5F102F93B96E00B1C71C /* ShareSongAction.swift in Sources */,
 				50C9D6C0284FAACE007F18D0 /* DownloadManagerSessionExtension.swift in Sources */,
 				50C9D6C4284FAB0C007F18D0 /* LocalNotificationManager.swift in Sources */,
 				50C9D654284FAA02007F18D0 /* SsPlayableParserDelegate.swift in Sources */,
@@ -2859,6 +2866,7 @@
 				50BE5D752850F4FB00156FC6 /* SsPlaylistSongsParserTest.swift in Sources */,
 				50AE79BC2C1F6ADF0085CBB3 /* SsOpenSubsonicExtensionsParserTest.swift in Sources */,
 				50BE5D552850F4E700156FC6 /* UtilitiesTest.swift in Sources */,
+				B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */,
 				50BE5D6A2850F4FB00156FC6 /* SsAlbumParserTest.swift in Sources */,
 				50BE5D702850F4FB00156FC6 /* SsIndexesParserTest.swift in Sources */,
 				50BE5D712850F4FB00156FC6 /* SsMusicFolderParserTest.swift in Sources */,

--- a/Amperfy/Screens/Common/ShareSongAction.swift
+++ b/Amperfy/Screens/Common/ShareSongAction.swift
@@ -1,0 +1,135 @@
+//
+//  ShareSongAction.swift
+//  Amperfy
+//
+//  Created by the Amperfy spike (Feature E — Share).
+//  Copyright (c) 2026 Olivier Butler. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import UIKit
+
+/// Presents the iOS share sheet for a single song. If the song is not yet
+/// cached locally, triggers a download first and shows a progress alert.
+/// See BACKLOG.md §PR 6.
+@MainActor
+enum ShareSongAction {
+  static func share(
+    song: AbstractPlayable,
+    from sourceView: UIView,
+    presenter: UIViewController,
+    appDelegate: AppDelegate
+  ) {
+    // Already cached — present immediately.
+    if let fileURL = cachedFileURL(for: song) {
+      presentActivityController(
+        for: song,
+        fileURL: fileURL,
+        sourceView: sourceView,
+        presenter: presenter
+      )
+      return
+    }
+
+    // Not cached — trigger download, poll for completion.
+    guard let accountInfo = song.account?.info else { return }
+
+    let progressAlert = UIAlertController(
+      title: "Downloading\u{2026}",
+      message: song.title,
+      preferredStyle: .alert
+    )
+    var cancelled = false
+    progressAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+      cancelled = true
+    })
+    presenter.present(progressAlert, animated: true)
+
+    appDelegate.getMeta(accountInfo).playableDownloadManager
+      .download(object: song)
+
+    // Poll for the file to appear on disk (download manager is fire-and-forget).
+    Task { @MainActor in
+      for _ in 0 ..< 120 { // up to ~60 seconds at 0.5s intervals
+        try? await Task.sleep(for: .milliseconds(500))
+        if cancelled { return }
+        if let fileURL = cachedFileURL(for: song) {
+          progressAlert.dismiss(animated: true) {
+            presentActivityController(
+              for: song,
+              fileURL: fileURL,
+              sourceView: sourceView,
+              presenter: presenter
+            )
+          }
+          return
+        }
+      }
+      // Timed out.
+      progressAlert.dismiss(animated: true) {
+        let errorAlert = UIAlertController(
+          title: "Download failed",
+          message: "Couldn't download this song. Please try again.",
+          preferredStyle: .alert
+        )
+        errorAlert.addAction(UIAlertAction(title: "OK", style: .default))
+        presenter.present(errorAlert, animated: true)
+      }
+    }
+  }
+
+  private static func cachedFileURL(for song: AbstractPlayable) -> URL? {
+    guard let relPath = song.relFilePath,
+          let absoluteURL = CacheFileManager.shared.getAbsoluteAmperfyPath(relFilePath: relPath),
+          FileManager.default.fileExists(atPath: absoluteURL.path)
+    else { return nil }
+    return absoluteURL
+  }
+
+  private static func presentActivityController(
+    for song: AbstractPlayable,
+    fileURL: URL,
+    sourceView: UIView,
+    presenter: UIViewController
+  ) {
+    let artistName = song.asSong?.artist?.name ?? "Unknown artist"
+    let textItem = "\(song.title) \u{2014} \(artistName)"
+
+    // Rename to "Song Title - Artist.ext" for a friendly filename in the share sheet
+    let safeFileName = "\(song.title) - \(artistName)"
+      .replacingOccurrences(of: "/", with: "-")
+      .replacingOccurrences(of: ":", with: "-")
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(safeFileName)
+      .appendingPathExtension(fileURL.pathExtension)
+    try? FileManager.default.removeItem(at: tempURL)
+    try? FileManager.default.copyItem(at: fileURL, to: tempURL)
+    let shareURL = FileManager.default.fileExists(atPath: tempURL.path) ? tempURL : fileURL
+
+    let activityVC = UIActivityViewController(
+      activityItems: [shareURL, textItem],
+      applicationActivities: nil
+    )
+    activityVC.popoverPresentationController?.sourceView = sourceView
+    activityVC.popoverPresentationController?.sourceRect = sourceView.bounds
+    if shareURL != fileURL {
+      activityVC.completionWithItemsHandler = { _, _, _, _ in
+        try? FileManager.default.removeItem(at: shareURL)
+      }
+    }
+    presenter.present(activityVC, animated: true)
+  }
+}

--- a/Amperfy/Screens/ViewController/EntityPreviewVC.swift
+++ b/Amperfy/Screens/ViewController/EntityPreviewVC.swift
@@ -70,6 +70,7 @@ class EntityPreviewActionBuilder {
   private var isShowPodcastDetails = false
   private var isShowSongDetails = false
   private var isInstantMix = false
+  private var isShareSong = false
 
   init(
     container: PlayableContainable,
@@ -159,6 +160,9 @@ class EntityPreviewActionBuilder {
     }
     if isDeleteOnServer {
       elementHandlingActions.append(createDeleteOnServerAction())
+    }
+    if isShareSong, let playable = entityContainer as? AbstractPlayable {
+      elementHandlingActions.append(createShareAction(playable: playable))
     }
     if isGoToSiteUrl, let url = (entityContainer as? AbstractPlayable)?.asRadio?.siteURL {
       elementHandlingActions.append(createGoToSiteUrl(url: url))
@@ -262,6 +266,7 @@ class EntityPreviewActionBuilder {
     isShowPodcastDetails = false
     isShowSongDetails = true
     isInstantMix = appDelegate.storage.settings.user.isOnlineMode
+    isShareSong = true
   }
 
   private func configureFor(podcastEpisode: PodcastEpisode) {
@@ -793,6 +798,20 @@ class EntityPreviewActionBuilder {
         // do nothing
       }))
       self.rootView.present(alert, animated: true, completion: nil)
+    }
+  }
+
+  private func createShareAction(playable: AbstractPlayable) -> UIAction {
+    UIAction(
+      title: "Share",
+      image: UIImage(systemName: "square.and.arrow.up")
+    ) { _ in
+      ShareSongAction.share(
+        song: playable,
+        from: self.rootView.view,
+        presenter: self.rootView,
+        appDelegate: self.appDelegate
+      )
     }
   }
 

--- a/Amperfy/Screens/ViewController/EntityPreviewVC.swift
+++ b/Amperfy/Screens/ViewController/EntityPreviewVC.swift
@@ -70,7 +70,7 @@ class EntityPreviewActionBuilder {
   private var isShowPodcastDetails = false
   private var isShowSongDetails = false
   private var isInstantMix = false
-  private var isShareSong = false
+  private var isShareable = false
 
   init(
     container: PlayableContainable,
@@ -161,7 +161,7 @@ class EntityPreviewActionBuilder {
     if isDeleteOnServer {
       elementHandlingActions.append(createDeleteOnServerAction())
     }
-    if isShareSong, let playable = entityContainer as? AbstractPlayable {
+    if isShareable, let playable = entityContainer as? AbstractPlayable {
       elementHandlingActions.append(createShareAction(playable: playable))
     }
     if isGoToSiteUrl, let url = (entityContainer as? AbstractPlayable)?.asRadio?.siteURL {
@@ -266,7 +266,7 @@ class EntityPreviewActionBuilder {
     isShowPodcastDetails = false
     isShowSongDetails = true
     isInstantMix = appDelegate.storage.settings.user.isOnlineMode
-    isShareSong = song.isCached || appDelegate.storage.settings.user.isOnlineMode
+    isShareable = song.isCached || appDelegate.storage.settings.user.isOnlineMode
   }
 
   private func configureFor(podcastEpisode: PodcastEpisode) {
@@ -291,6 +291,7 @@ class EntityPreviewActionBuilder {
     isGoToSiteUrl = false
     isShowPodcastDetails = true
     isShowSongDetails = false
+    isShareable = podcastEpisode.isCached || appDelegate.storage.settings.user.isOnlineMode
   }
 
   private func configureFor(radio: Radio) {
@@ -818,7 +819,7 @@ class EntityPreviewActionBuilder {
 
       // Note: This is strongly coupled, I could protocolize and inject. But this is simplest and the project doesn't seem to do DI/tests for this target.
       ShareSongAction.share(
-        song: playable,
+        playable: playable,
         from: self.rootView.view,
         presenter: self.rootView,
         downloadManagerProvider: downloadManagerProvider

--- a/Amperfy/Screens/ViewController/EntityPreviewVC.swift
+++ b/Amperfy/Screens/ViewController/EntityPreviewVC.swift
@@ -266,7 +266,7 @@ class EntityPreviewActionBuilder {
     isShowPodcastDetails = false
     isShowSongDetails = true
     isInstantMix = appDelegate.storage.settings.user.isOnlineMode
-    isShareSong = true
+    isShareSong = song.isCached || appDelegate.storage.settings.user.isOnlineMode
   }
 
   private func configureFor(podcastEpisode: PodcastEpisode) {
@@ -806,11 +806,22 @@ class EntityPreviewActionBuilder {
       title: "Share",
       image: UIImage(systemName: "square.and.arrow.up")
     ) { _ in
+      // Used if the song is not cached, otherwise never called
+      let downloadManagerProvider: () -> DownloadManageable? = { [weak self] in
+        guard let self = self,
+              let accountInfo = playable.account?.info
+        else { return nil }
+        return appDelegate
+          .getMeta(accountInfo)
+          .playableDownloadManager
+      }
+
+      // Note: This is strongly coupled, I could protocolize and inject. But this is simplest and the project doesn't seem to do DI/tests for this target.
       ShareSongAction.share(
         song: playable,
         from: self.rootView.view,
         presenter: self.rootView,
-        appDelegate: self.appDelegate
+        downloadManagerProvider: downloadManagerProvider
       )
     }
   }

--- a/AmperfyKit/Common/ShareSongAction.swift
+++ b/AmperfyKit/Common/ShareSongAction.swift
@@ -22,6 +22,8 @@
 import LinkPresentation
 import UIKit
 
+// MARK: - ShareSongAction
+
 /// Presents the iOS share sheet for a single song. If the song is not yet
 /// cached locally, triggers a download first and shows a progress alert.
 ///
@@ -48,9 +50,12 @@ public enum ShareSongAction {
       return
     }
 
+    let artistName = song.asSong?.artist?.name
+    let message = shareTextItem(title: song.title, artistName: artistName)
+
     let progressAlert = UIAlertController(
-      title: "Downloading\u{2026}",
-      message: song.title,
+      title: "Downloading\(CommonString.ellipsis)",
+      message: message,
       preferredStyle: .alert
     )
     var cancelled = false
@@ -100,13 +105,13 @@ public enum ShareSongAction {
   }
 
   static func shareTextItem(title: String, artistName: String?) -> String {
-    let resolvedArtist = artistName ?? "Unknown artist"
-    return "\(title) \u{2014} \(resolvedArtist)"
+    let resolvedArtist = artistName ?? "Unknown Artist"
+    return "\(resolvedArtist) - \(title)"
   }
 
   static func sanitizedFileName(title: String, artistName: String?) -> String {
-    let resolvedArtist = artistName ?? "Unknown artist"
-    return "\(title) - \(resolvedArtist)"
+    let resolvedArtist = artistName ?? "Unknown Artist"
+    return "\(resolvedArtist) - \(title)"
       .replacingOccurrences(of: "/", with: "-")
       .replacingOccurrences(of: ":", with: "-")
   }
@@ -160,6 +165,8 @@ public enum ShareSongAction {
   }
 }
 
+// MARK: - SongShareItemSource
+
 private final class SongShareItemSource: NSObject, UIActivityItemSource {
   let fileURL: URL
   let title: String
@@ -179,14 +186,16 @@ private final class SongShareItemSource: NSObject, UIActivityItemSource {
   func activityViewController(
     _ activityViewController: UIActivityViewController,
     itemForActivityType activityType: UIActivity.ActivityType?
-  ) -> Any? {
+  )
+    -> Any? {
     fileURL
   }
 
   func activityViewController(
     _ activityViewController: UIActivityViewController,
     subjectForActivityType activityType: UIActivity.ActivityType?
-  ) -> String {
+  )
+    -> String {
     title
   }
 

--- a/AmperfyKit/Common/ShareSongAction.swift
+++ b/AmperfyKit/Common/ShareSongAction.swift
@@ -19,6 +19,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import LinkPresentation
 import UIKit
 
 /// Presents the iOS share sheet for a single song. If the song is not yet
@@ -126,8 +127,14 @@ public enum ShareSongAction {
     try? FileManager.default.copyItem(at: fileURL, to: tempURL)
     let shareURL = FileManager.default.fileExists(atPath: tempURL.path) ? tempURL : fileURL
 
+    let artwork = artworkImage(for: song)
+    let fileItemSource = SongShareItemSource(
+      fileURL: shareURL,
+      title: textItem,
+      artwork: artwork
+    )
     let activityVC = UIActivityViewController(
-      activityItems: [shareURL, textItem],
+      activityItems: [fileItemSource, textItem],
       applicationActivities: nil
     )
     activityVC.popoverPresentationController?.sourceView = sourceView
@@ -138,5 +145,58 @@ public enum ShareSongAction {
       }
     }
     presenter.present(activityVC, animated: true)
+  }
+
+  static func artworkImage(for song: AbstractPlayable) -> UIImage {
+    let settings = AmperKit.shared.storage.settings
+    let accountSettings = song.account.map { settings.accounts.getSetting($0.info) }
+      ?? settings.accounts.activeSetting
+    return LibraryEntityImage.getImageToDisplayImmediately(
+      libraryEntity: song,
+      themePreference: accountSettings.read.themePreference,
+      artworkDisplayPreference: accountSettings.read.artworkDisplayPreference,
+      useCache: false
+    )
+  }
+}
+
+private final class SongShareItemSource: NSObject, UIActivityItemSource {
+  let fileURL: URL
+  let title: String
+  let artwork: UIImage
+
+  init(fileURL: URL, title: String, artwork: UIImage) {
+    self.fileURL = fileURL
+    self.title = title
+    self.artwork = artwork
+  }
+
+  func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController)
+    -> Any {
+    fileURL
+  }
+
+  func activityViewController(
+    _ activityViewController: UIActivityViewController,
+    itemForActivityType activityType: UIActivity.ActivityType?
+  ) -> Any? {
+    fileURL
+  }
+
+  func activityViewController(
+    _ activityViewController: UIActivityViewController,
+    subjectForActivityType activityType: UIActivity.ActivityType?
+  ) -> String {
+    title
+  }
+
+  func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController)
+    -> LPLinkMetadata? {
+    let metadata = LPLinkMetadata()
+    metadata.title = title
+    metadata.originalURL = fileURL
+    metadata.iconProvider = NSItemProvider(object: artwork)
+    metadata.imageProvider = NSItemProvider(object: artwork)
+    return metadata
   }
 }

--- a/AmperfyKit/Common/ShareSongAction.swift
+++ b/AmperfyKit/Common/ShareSongAction.swift
@@ -31,15 +31,15 @@ import UIKit
 @MainActor
 public enum ShareSongAction {
   public static func share(
-    song: AbstractPlayable,
+    playable: AbstractPlayable,
     from sourceView: UIView,
     presenter: UIViewController,
     downloadManagerProvider: () -> DownloadManageable?
   ) {
     // Already cached — present immediately.
-    if let fileURL = cachedFileURL(for: song) {
+    if let fileURL = cachedFileURL(for: playable) {
       presentActivityController(
-        for: song,
+        for: playable,
         fileURL: fileURL,
         sourceView: sourceView,
         presenter: presenter
@@ -50,12 +50,9 @@ public enum ShareSongAction {
       return
     }
 
-    let artistName = song.asSong?.artist?.name
-    let message = shareTextItem(title: song.title, artistName: artistName)
-
     let progressAlert = UIAlertController(
       title: "Downloading\(CommonString.ellipsis)",
-      message: message,
+      message: playable.displayString,
       preferredStyle: .alert
     )
     var cancelled = false
@@ -64,17 +61,17 @@ public enum ShareSongAction {
     })
     presenter.present(progressAlert, animated: true)
 
-    downloadManager.download(object: song)
+    downloadManager.download(object: playable)
 
     // Poll for the file to appear on disk (download manager is fire-and-forget).
     Task { @MainActor in
       for _ in 0 ..< 120 { // up to ~60 seconds at 0.5s intervals
         try? await Task.sleep(for: .milliseconds(500))
         if cancelled { return }
-        if let fileURL = cachedFileURL(for: song) {
+        if let fileURL = cachedFileURL(for: playable) {
           progressAlert.dismiss(animated: true) {
             presentActivityController(
-              for: song,
+              for: playable,
               fileURL: fileURL,
               sourceView: sourceView,
               presenter: presenter
@@ -96,35 +93,28 @@ public enum ShareSongAction {
     }
   }
 
-  private static func cachedFileURL(for song: AbstractPlayable) -> URL? {
-    guard let relPath = song.relFilePath,
+  private static func cachedFileURL(for playable: AbstractPlayable) -> URL? {
+    guard let relPath = playable.relFilePath,
           let absoluteURL = CacheFileManager.shared.getAbsoluteAmperfyPath(relFilePath: relPath),
           FileManager.default.fileExists(atPath: absoluteURL.path)
     else { return nil }
     return absoluteURL
   }
 
-  static func shareTextItem(title: String, artistName: String?) -> String {
-    let resolvedArtist = artistName ?? "Unknown Artist"
-    return "\(resolvedArtist) - \(title)"
-  }
-
-  static func sanitizedFileName(title: String, artistName: String?) -> String {
-    let resolvedArtist = artistName ?? "Unknown Artist"
-    return "\(resolvedArtist) - \(title)"
+  static func sanitizedFileName(playable: AbstractPlayable) -> String {
+    playable.displayString
       .replacingOccurrences(of: "/", with: "-")
       .replacingOccurrences(of: ":", with: "-")
   }
 
   private static func presentActivityController(
-    for song: AbstractPlayable,
+    for playable: AbstractPlayable,
     fileURL: URL,
     sourceView: UIView,
     presenter: UIViewController
   ) {
-    let artistName = song.asSong?.artist?.name
-    let textItem = shareTextItem(title: song.title, artistName: artistName)
-    let safeFileName = sanitizedFileName(title: song.title, artistName: artistName)
+    let textItem = playable.displayString
+    let safeFileName = sanitizedFileName(playable: playable)
     let tempURL = FileManager.default.temporaryDirectory
       .appendingPathComponent(safeFileName)
       .appendingPathExtension(fileURL.pathExtension)
@@ -132,7 +122,7 @@ public enum ShareSongAction {
     try? FileManager.default.copyItem(at: fileURL, to: tempURL)
     let shareURL = FileManager.default.fileExists(atPath: tempURL.path) ? tempURL : fileURL
 
-    let artwork = artworkImage(for: song)
+    let artwork = artworkImage(for: playable)
     let fileItemSource = SongShareItemSource(
       fileURL: shareURL,
       title: textItem,
@@ -152,12 +142,12 @@ public enum ShareSongAction {
     presenter.present(activityVC, animated: true)
   }
 
-  static func artworkImage(for song: AbstractPlayable) -> UIImage {
+  static func artworkImage(for playable: AbstractPlayable) -> UIImage {
     let settings = AmperKit.shared.storage.settings
-    let accountSettings = song.account.map { settings.accounts.getSetting($0.info) }
+    let accountSettings = playable.account.map { settings.accounts.getSetting($0.info) }
       ?? settings.accounts.activeSetting
     return LibraryEntityImage.getImageToDisplayImmediately(
-      libraryEntity: song,
+      libraryEntity: playable,
       themePreference: accountSettings.read.themePreference,
       artworkDisplayPreference: accountSettings.read.artworkDisplayPreference,
       useCache: false

--- a/AmperfyKit/Common/ShareSongAction.swift
+++ b/AmperfyKit/Common/ShareSongAction.swift
@@ -2,7 +2,7 @@
 //  ShareSongAction.swift
 //  Amperfy
 //
-//  Created by the Amperfy spike (Feature E — Share).
+//  Created by the Olivier Butler 18.04.2026.
 //  Copyright (c) 2026 Olivier Butler. All rights reserved.
 //
 //  This program is free software: you can redistribute it and/or modify
@@ -19,19 +19,19 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import AmperfyKit
 import UIKit
 
 /// Presents the iOS share sheet for a single song. If the song is not yet
 /// cached locally, triggers a download first and shows a progress alert.
-/// See BACKLOG.md §PR 6.
+///
+/// No shared state between functions, one prepares the song, one cleans a URL, one presents the sharing activity VC.
 @MainActor
-enum ShareSongAction {
-  static func share(
+public enum ShareSongAction {
+  public static func share(
     song: AbstractPlayable,
     from sourceView: UIView,
     presenter: UIViewController,
-    appDelegate: AppDelegate
+    downloadManagerProvider: () -> DownloadManageable?
   ) {
     // Already cached — present immediately.
     if let fileURL = cachedFileURL(for: song) {
@@ -43,9 +43,9 @@ enum ShareSongAction {
       )
       return
     }
-
-    // Not cached — trigger download, poll for completion.
-    guard let accountInfo = song.account?.info else { return }
+    guard let downloadManager = downloadManagerProvider() else {
+      return
+    }
 
     let progressAlert = UIAlertController(
       title: "Downloading\u{2026}",
@@ -58,8 +58,7 @@ enum ShareSongAction {
     })
     presenter.present(progressAlert, animated: true)
 
-    appDelegate.getMeta(accountInfo).playableDownloadManager
-      .download(object: song)
+    downloadManager.download(object: song)
 
     // Poll for the file to appear on disk (download manager is fire-and-forget).
     Task { @MainActor in
@@ -78,11 +77,11 @@ enum ShareSongAction {
           return
         }
       }
-      // Timed out.
+      // Timed out, show error
       progressAlert.dismiss(animated: true) {
         let errorAlert = UIAlertController(
           title: "Download failed",
-          message: "Couldn't download this song. Please try again.",
+          message: "The download took too long. Please try again.",
           preferredStyle: .alert
         )
         errorAlert.addAction(UIAlertAction(title: "OK", style: .default))
@@ -99,19 +98,27 @@ enum ShareSongAction {
     return absoluteURL
   }
 
+  static func shareTextItem(title: String, artistName: String?) -> String {
+    let resolvedArtist = artistName ?? "Unknown artist"
+    return "\(title) \u{2014} \(resolvedArtist)"
+  }
+
+  static func sanitizedFileName(title: String, artistName: String?) -> String {
+    let resolvedArtist = artistName ?? "Unknown artist"
+    return "\(title) - \(resolvedArtist)"
+      .replacingOccurrences(of: "/", with: "-")
+      .replacingOccurrences(of: ":", with: "-")
+  }
+
   private static func presentActivityController(
     for song: AbstractPlayable,
     fileURL: URL,
     sourceView: UIView,
     presenter: UIViewController
   ) {
-    let artistName = song.asSong?.artist?.name ?? "Unknown artist"
-    let textItem = "\(song.title) \u{2014} \(artistName)"
-
-    // Rename to "Song Title - Artist.ext" for a friendly filename in the share sheet
-    let safeFileName = "\(song.title) - \(artistName)"
-      .replacingOccurrences(of: "/", with: "-")
-      .replacingOccurrences(of: ":", with: "-")
+    let artistName = song.asSong?.artist?.name
+    let textItem = shareTextItem(title: song.title, artistName: artistName)
+    let safeFileName = sanitizedFileName(title: song.title, artistName: artistName)
     let tempURL = FileManager.default.temporaryDirectory
       .appendingPathComponent(safeFileName)
       .appendingPathExtension(fileURL.pathExtension)

--- a/AmperfyKit/Screens/CommonString.swift
+++ b/AmperfyKit/Screens/CommonString.swift
@@ -23,5 +23,7 @@ import Foundation
 
 public class CommonString {
   public static let oneMiddleDot: String = "\u{00B7}"
-  public static let threeMiddleDots: String = "\u{00B7}\u{00B7}\u{00B7}" // ellipsis
+  public static let threeMiddleDots: String =
+    "\u{00B7}\u{00B7}\u{00B7}" // ellipsis vertically centered
+  public static let ellipsis: String = "\u{2026}" // ellipsis
 }

--- a/AmperfyKitTests/Cases/Common/ShareSongActionTest.swift
+++ b/AmperfyKitTests/Cases/Common/ShareSongActionTest.swift
@@ -42,28 +42,28 @@ class ShareSongActionTest: XCTestCase {
   func testShareTextItemJoinsTitleAndArtistWithEmDash() {
     XCTAssertEqual(
       ShareSongAction.shareTextItem(title: "Song", artistName: "Artist"),
-      "Song \u{2014} Artist"
+      "Artist - Song"
     )
   }
 
   func testShareTextItemFallsBackWhenArtistNil() {
     XCTAssertEqual(
       ShareSongAction.shareTextItem(title: "Song", artistName: nil),
-      "Song \u{2014} Unknown artist"
+      "Unknown Artist - Song"
     )
   }
 
   func testSanitizedFileNameReplacesSlashAndColon() {
     XCTAssertEqual(
       ShareSongAction.sanitizedFileName(title: "A/B:C", artistName: "D/E:F"),
-      "A-B-C - D-E-F"
+      "D-E-F - A-B-C"
     )
   }
 
   func testSanitizedFileNameFallsBackWhenArtistNil() {
     XCTAssertEqual(
       ShareSongAction.sanitizedFileName(title: "Song", artistName: nil),
-      "Song - Unknown artist"
+      "Unknown Artist - Song"
     )
   }
 

--- a/AmperfyKitTests/Cases/Common/ShareSongActionTest.swift
+++ b/AmperfyKitTests/Cases/Common/ShareSongActionTest.swift
@@ -39,31 +39,16 @@ class ShareSongActionTest: XCTestCase {
 
   // MARK: - Pure helpers
 
-  func testShareTextItemJoinsTitleAndArtistWithEmDash() {
-    XCTAssertEqual(
-      ShareSongAction.shareTextItem(title: "Song", artistName: "Artist"),
-      "Artist - Song"
-    )
-  }
-
-  func testShareTextItemFallsBackWhenArtistNil() {
-    XCTAssertEqual(
-      ShareSongAction.shareTextItem(title: "Song", artistName: nil),
-      "Unknown Artist - Song"
-    )
-  }
-
   func testSanitizedFileNameReplacesSlashAndColon() {
+    guard let cachedSong = library.getSong(for: account, id: "36") else {
+      XCTFail("Seeded cached song \"36\" not found")
+      return
+    }
+    cachedSong.title = "A/B:C"
+    cachedSong.artist?.name = "D/E:F"
     XCTAssertEqual(
-      ShareSongAction.sanitizedFileName(title: "A/B:C", artistName: "D/E:F"),
+      ShareSongAction.sanitizedFileName(playable: cachedSong),
       "D-E-F - A-B-C"
-    )
-  }
-
-  func testSanitizedFileNameFallsBackWhenArtistNil() {
-    XCTAssertEqual(
-      ShareSongAction.sanitizedFileName(title: "Song", artistName: nil),
-      "Unknown Artist - Song"
     )
   }
 
@@ -75,7 +60,7 @@ class ShareSongActionTest: XCTestCase {
       return
     }
     ShareSongAction.share(
-      song: cachedSong,
+      playable: cachedSong,
       from: UIView(),
       presenter: UIViewController(),
       downloadManagerProvider: { self.songDownloader }
@@ -89,7 +74,7 @@ class ShareSongActionTest: XCTestCase {
       return
     }
     ShareSongAction.share(
-      song: uncachedSong,
+      playable: uncachedSong,
       from: UIView(),
       presenter: UIViewController(),
       downloadManagerProvider: { self.songDownloader }
@@ -105,7 +90,7 @@ class ShareSongActionTest: XCTestCase {
     }
     var providerInvocations = 0
     ShareSongAction.share(
-      song: uncachedSong,
+      playable: uncachedSong,
       from: UIView(),
       presenter: UIViewController(),
       downloadManagerProvider: {

--- a/AmperfyKitTests/Cases/Common/ShareSongActionTest.swift
+++ b/AmperfyKitTests/Cases/Common/ShareSongActionTest.swift
@@ -1,0 +1,119 @@
+//
+//  ShareSongActionTest.swift
+//  AmperfyKitTests
+//
+//  Created by Olivier Butler on 19.04.26.
+//  Copyright (c) 2026 Olivier Butler. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import AmperfyKit
+import UIKit
+import XCTest
+
+@MainActor
+class ShareSongActionTest: XCTestCase {
+  var cdHelper: CoreDataHelper!
+  var library: LibraryStorage!
+  var account: Account!
+  var songDownloader: MOCK_SongDownloader!
+
+  override func setUp() async throws {
+    cdHelper = CoreDataHelper()
+    library = cdHelper.createSeededStorage()
+    account = library.getAccount(info: TestAccountInfo.create1())
+    songDownloader = MOCK_SongDownloader()
+  }
+
+  // MARK: - Pure helpers
+
+  func testShareTextItemJoinsTitleAndArtistWithEmDash() {
+    XCTAssertEqual(
+      ShareSongAction.shareTextItem(title: "Song", artistName: "Artist"),
+      "Song \u{2014} Artist"
+    )
+  }
+
+  func testShareTextItemFallsBackWhenArtistNil() {
+    XCTAssertEqual(
+      ShareSongAction.shareTextItem(title: "Song", artistName: nil),
+      "Song \u{2014} Unknown artist"
+    )
+  }
+
+  func testSanitizedFileNameReplacesSlashAndColon() {
+    XCTAssertEqual(
+      ShareSongAction.sanitizedFileName(title: "A/B:C", artistName: "D/E:F"),
+      "A-B-C - D-E-F"
+    )
+  }
+
+  func testSanitizedFileNameFallsBackWhenArtistNil() {
+    XCTAssertEqual(
+      ShareSongAction.sanitizedFileName(title: "Song", artistName: nil),
+      "Song - Unknown artist"
+    )
+  }
+
+  // MARK: - Branching behaviour
+
+  func testShareWithCachedSongDoesNotCallDownloader() {
+    guard let cachedSong = library.getSong(for: account, id: "36") else {
+      XCTFail("Seeded cached song \"36\" not found")
+      return
+    }
+    ShareSongAction.share(
+      song: cachedSong,
+      from: UIView(),
+      presenter: UIViewController(),
+      downloadManagerProvider: { self.songDownloader }
+    )
+    XCTAssertTrue(songDownloader.isNoDownloadRequested())
+  }
+
+  func testShareWithUncachedSongCallsDownloader() {
+    guard let uncachedSong = library.getSong(for: account, id: "3") else {
+      XCTFail("Seeded uncached song \"3\" not found")
+      return
+    }
+    ShareSongAction.share(
+      song: uncachedSong,
+      from: UIView(),
+      presenter: UIViewController(),
+      downloadManagerProvider: { self.songDownloader }
+    )
+    XCTAssertFalse(songDownloader.isNoDownloadRequested())
+    XCTAssertEqual(songDownloader.downloadables.count, 1)
+  }
+
+  func testShareWithNilDownloadManagerProviderReturnsEarly() {
+    guard let uncachedSong = library.getSong(for: account, id: "3") else {
+      XCTFail("Seeded uncached song \"3\" not found")
+      return
+    }
+    var providerInvocations = 0
+    ShareSongAction.share(
+      song: uncachedSong,
+      from: UIView(),
+      presenter: UIViewController(),
+      downloadManagerProvider: {
+        providerInvocations += 1
+        return nil
+      }
+    )
+    XCTAssertEqual(providerInvocations, 1)
+    XCTAssertTrue(songDownloader.isNoDownloadRequested())
+  }
+}


### PR DESCRIPTION
This is a little feature I added to my own build, it allows you to share the original file for a song in your library via the built in iOS/Mac OS sharing API.

- Adds share row to the entity preview VC
- Downloads song if it is not cached (uses pre-existing download tooling)
- Renames a temp copy of the song to a friendly sharing name
- Sends audio file to native sharing API
- Adds album art to the share preview (uses pre-existing helper)

<img width="361" height="200" alt="image" src="https://github.com/user-attachments/assets/bad2d932-cefe-478f-9fbd-48a09b6b9f5a" />

### Notes

- A side effect of this is you end up with a cached version of the song you share.
- If a song takes more than 60s to download, the process cancels
- For a freshly downloaded song, it may not have album art available and will use the helper's fallback.