### PR TITLE
feat(auth): add mTLS client certificate support

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		5078AFB42B44AE260038FD17 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5078AFB32B44AE260038FD17 /* AppIntentVocabulary.plist */; };
 		50791E7828D25845006CE6E5 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7728D25845006CE6E5 /* AccountSettingsView.swift */; };
 		50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */; };
+		B5C8DE010000000000000005 /* ClientCertificateSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */; };
 		50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */; };
 		50791E7F28D363F0006CE6E5 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */; };
 		50791E8128D365E9006CE6E5 /* UpdatePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */; };
@@ -205,7 +206,6 @@
 		50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */; };
 		50BE5D542850F4E700156FC6 /* SubsonicVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */; };
 		50BE5D552850F4E700156FC6 /* UtilitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5090963726496A9500DD9826 /* UtilitiesTest.swift */; };
-		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
 		50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */; };
 		50BE5D572850F4F600156FC6 /* album_missing_artistId.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50ED2B9227BB932700331BF7 /* album_missing_artistId.xml */; };
 		50BE5D582850F4F600156FC6 /* artist_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AB92C526661F5800DCE45C /* artist_example_1.xml */; };
@@ -432,6 +432,8 @@
 		50C9D6C5284FAB0C007F18D0 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BA92FD21CED4AF00E5901D /* Utilities.swift */; };
 		50C9D6C7284FAB0C007F18D0 /* LogData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5029288626564C6800DA3A8F /* LogData.swift */; };
 		50C9D6C9284FAB0C007F18D0 /* EventNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ED2B9027B7AE8500331BF7 /* EventNotificationHandler.swift */; };
+		B5C8DE010000000000000001 /* ClientCertificateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000002 /* ClientCertificateManager.swift */; };
+		B5C8DE010000000000000003 /* ClientCertificateSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000004 /* ClientCertificateSession.swift */; };
 		50C9D6D2284FAB0C007F18D0 /* StringHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5086F87822397B2900546F5A /* StringHasher.swift */; };
 		50C9D6D3284FAB0C007F18D0 /* JSONConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5029288826564F3600DA3A8F /* JSONConverter.swift */; };
 		50C9D6D4284FAB88007F18D0 /* PlayerDownloadPreparationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50048F9427590FAD0087EDFB /* PlayerDownloadPreparationHandler.swift */; };
@@ -530,10 +532,11 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
-		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -840,7 +843,6 @@
 		509001C027182A1300A8056D /* CatalogParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserTest.swift; sourceTree = "<group>"; };
 		509001C227182A4700A8056D /* CatalogParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserDelegate.swift; sourceTree = "<group>"; };
 		5090963726496A9500DD9826 /* UtilitiesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTest.swift; sourceTree = "<group>"; };
-		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
 		509357512E3BF47800CD4075 /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
 		509362EC28E041FF005C2AAC /* Amperfy v28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v28.xcdatamodel"; sourceTree = "<group>"; };
 		50947E0227DA011F00C368D7 /* ScrobbleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleEntry.swift; sourceTree = "<group>"; };
@@ -1139,6 +1141,9 @@
 		50FE808C26A55CEA00CB434D /* DownloadMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		50FE808D26A55CEA00CB434D /* DownloadMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		50FF31192BBB27AC00C2C3B9 /* Amperfy v36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v36.xcdatamodel"; sourceTree = "<group>"; };
+		B5C8DE010000000000000002 /* ClientCertificateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateManager.swift; sourceTree = "<group>"; };
+		B5C8DE010000000000000004 /* ClientCertificateSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateSession.swift; sourceTree = "<group>"; };
+		B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateSettingsView.swift; sourceTree = "<group>"; };
 		50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		50RA71NG2F5A01230085CBB3 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		631C166A2C6D3D9A0085F62E /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
@@ -1148,12 +1153,13 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
-		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1332,6 +1338,7 @@
 				505CA1F42B848B8300AA81CD /* QuickActionsHandler.swift */,
 				5021B1272BC723F400893C33 /* FuzzySearcher.swift */,
 				09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */,
+				B5C8DE010000000000000002 /* ClientCertificateManager.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1434,6 +1441,7 @@
 				50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */,
 				50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */,
 				50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */,
+				B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -1500,6 +1508,7 @@
 				509A7D832806A232009791D1 /* AutoDownloadLibrarySyncer.swift */,
 				50ED756528CBC5D200E5D347 /* LibrarySyncerProxy.swift */,
 				504262A42BF48ADF00B5EF38 /* CommonLibrarySyncer.swift */,
+				B5C8DE010000000000000004 /* ClientCertificateSession.swift */,
 			);
 			path = Api;
 			sourceTree = "<group>";
@@ -2514,6 +2523,7 @@
 				50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */,
 				502E56BC27561AD900638BD2 /* UserQueueSectionHeader.swift in Sources */,
 				50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */,
+				B5C8DE010000000000000005 /* ClientCertificateSettingsView.swift in Sources */,
 				50C16C0621E241B200F086F0 /* SearchVC.swift in Sources */,
 				502041A12E2A3CDB003CE29A /* SliderView.swift in Sources */,
 				502041A22E2A3CDB003CE29A /* EquilizerView.swift in Sources */,
@@ -2719,6 +2729,8 @@
 				50C9D64B284FAA02007F18D0 /* SubsonicServerApi.swift in Sources */,
 				50C9D65C284FAA0B007F18D0 /* GenreParserDelegate.swift in Sources */,
 				50C9D6D2284FAB0C007F18D0 /* StringHasher.swift in Sources */,
+				B5C8DE010000000000000001 /* ClientCertificateManager.swift in Sources */,
+				B5C8DE010000000000000003 /* ClientCertificateSession.swift in Sources */,
 				50C9D667284FAA0B007F18D0 /* PlaylistSongsParserDelegate.swift in Sources */,
 				50FF311B2BBC4D8000C2C3B9 /* NetworkMonitor.swift in Sources */,
 				5087DE392EF0437F00644893 /* MetaManager.swift in Sources */,

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -2331,7 +2331,7 @@
 				50F40A392C9088B30097FE63 /* XCRemoteSwiftPackageReference "Ifrit" */,
 				505249792D10CBC70005EEB0 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				500E70D02E2FD63900636770 /* XCRemoteSwiftPackageReference "DominantColors" */,
-				50B166A82ED071A100F7A1D6 /* XCRemoteSwiftPackageReference "AudioStreaming" */,
+				50B166A82ED071A100F7A1D6 /* XCLocalSwiftPackageReference "AudioStreaming" */,
 			);
 			productRefGroup = 508385E521C5965B00C4BB32 /* Products */;
 			projectDirPath = "";
@@ -3093,6 +3093,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = S6X4T6ZQ98;
 				INFOPLIST_FILE = Amperfy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3101,7 +3102,7 @@
 				);
 				MARKETING_VERSION = 2.1.1;
 				"MARKETING_VERSION[sdk=macosx*]" = 2.1.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "de.familie-zimba.amperfy-music";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.krolakj.amperfy-music";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -3132,6 +3133,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = S6X4T6ZQ98;
 				INFOPLIST_FILE = Amperfy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3140,7 +3142,7 @@
 				);
 				MARKETING_VERSION = 2.1.1;
 				"MARKETING_VERSION[sdk=macosx*]" = 2.1.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "de.familie-zimba.amperfy-music";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.krolakj.amperfy-music";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -3427,13 +3429,9 @@
 				version = 1.5.4;
 			};
 		};
-		50B166A82ED071A100F7A1D6 /* XCRemoteSwiftPackageReference "AudioStreaming" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/dimitris-c/AudioStreaming/";
-			requirement = {
-				kind = exactVersion;
-				version = 1.4.4;
-			};
+		50B166A82ED071A100F7A1D6 /* XCLocalSwiftPackageReference "AudioStreaming" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../AudioStreaming;
 		};
 		50BE5DA3285713B100156FC6 /* XCRemoteSwiftPackageReference "CallbackURLKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3461,7 +3459,7 @@
 		};
 		502B8A4C2EE0CE40004CA3AD /* AudioStreaming */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 50B166A82ED071A100F7A1D6 /* XCRemoteSwiftPackageReference "AudioStreaming" */;
+			package = 50B166A82ED071A100F7A1D6 /* XCLocalSwiftPackageReference "AudioStreaming" */;
 			productName = AudioStreaming;
 		};
 		5052497A2D10CBC70005EEB0 /* Collections */ = {
@@ -3476,7 +3474,7 @@
 		};
 		50699C812ED859B20039BECD /* AudioStreaming */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 50B166A82ED071A100F7A1D6 /* XCRemoteSwiftPackageReference "AudioStreaming" */;
+			package = 50B166A82ED071A100F7A1D6 /* XCLocalSwiftPackageReference "AudioStreaming" */;
 			productName = AudioStreaming;
 		};
 		507DFE4B2B1E57BE002BBB1D /* MarqueeLabel */ = {
@@ -3521,7 +3519,7 @@
 		};
 		50B166A92ED071EC00F7A1D6 /* AudioStreaming */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 50B166A82ED071A100F7A1D6 /* XCRemoteSwiftPackageReference "AudioStreaming" */;
+			package = 50B166A82ED071A100F7A1D6 /* XCLocalSwiftPackageReference "AudioStreaming" */;
 			productName = AudioStreaming;
 		};
 		50BE5DA6285714A200156FC6 /* CallbackURLKit */ = {

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		50791E7828D25845006CE6E5 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7728D25845006CE6E5 /* AccountSettingsView.swift */; };
 		50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */; };
 		50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */; };
+		B5C8DE010000000000000005 /* ClientCertificateSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */; };
 		50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */; };
 		50791E7F28D363F0006CE6E5 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */; };
 		50791E8128D365E9006CE6E5 /* UpdatePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */; };
@@ -207,7 +208,6 @@
 		50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */; };
 		50BE5D542850F4E700156FC6 /* SubsonicVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */; };
 		50BE5D552850F4E700156FC6 /* UtilitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5090963726496A9500DD9826 /* UtilitiesTest.swift */; };
-		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
 		50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */; };
 		50BE5D572850F4F600156FC6 /* album_missing_artistId.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50ED2B9227BB932700331BF7 /* album_missing_artistId.xml */; };
 		50BE5D582850F4F600156FC6 /* artist_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AB92C526661F5800DCE45C /* artist_example_1.xml */; };
@@ -434,6 +434,8 @@
 		50C9D6C5284FAB0C007F18D0 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BA92FD21CED4AF00E5901D /* Utilities.swift */; };
 		50C9D6C7284FAB0C007F18D0 /* LogData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5029288626564C6800DA3A8F /* LogData.swift */; };
 		50C9D6C9284FAB0C007F18D0 /* EventNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ED2B9027B7AE8500331BF7 /* EventNotificationHandler.swift */; };
+		B5C8DE010000000000000001 /* ClientCertificateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000002 /* ClientCertificateManager.swift */; };
+		B5C8DE010000000000000003 /* ClientCertificateSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000004 /* ClientCertificateSession.swift */; };
 		50C9D6D2284FAB0C007F18D0 /* StringHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5086F87822397B2900546F5A /* StringHasher.swift */; };
 		50C9D6D3284FAB0C007F18D0 /* JSONConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5029288826564F3600DA3A8F /* JSONConverter.swift */; };
 		50C9D6D4284FAB88007F18D0 /* PlayerDownloadPreparationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50048F9427590FAD0087EDFB /* PlayerDownloadPreparationHandler.swift */; };
@@ -532,10 +534,11 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
-		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -844,7 +847,6 @@
 		509001C027182A1300A8056D /* CatalogParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserTest.swift; sourceTree = "<group>"; };
 		509001C227182A4700A8056D /* CatalogParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserDelegate.swift; sourceTree = "<group>"; };
 		5090963726496A9500DD9826 /* UtilitiesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTest.swift; sourceTree = "<group>"; };
-		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
 		509357512E3BF47800CD4075 /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
 		509362EC28E041FF005C2AAC /* Amperfy v28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v28.xcdatamodel"; sourceTree = "<group>"; };
 		50947E0227DA011F00C368D7 /* ScrobbleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleEntry.swift; sourceTree = "<group>"; };
@@ -1143,6 +1145,9 @@
 		50FE808C26A55CEA00CB434D /* DownloadMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		50FE808D26A55CEA00CB434D /* DownloadMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		50FF31192BBB27AC00C2C3B9 /* Amperfy v36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v36.xcdatamodel"; sourceTree = "<group>"; };
+		B5C8DE010000000000000002 /* ClientCertificateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateManager.swift; sourceTree = "<group>"; };
+		B5C8DE010000000000000004 /* ClientCertificateSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateSession.swift; sourceTree = "<group>"; };
+		B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateSettingsView.swift; sourceTree = "<group>"; };
 		50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		50RA71NG2F5A01230085CBB3 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		631C166A2C6D3D9A0085F62E /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
@@ -1152,12 +1157,13 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
-		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1336,6 +1342,7 @@
 				505CA1F42B848B8300AA81CD /* QuickActionsHandler.swift */,
 				5021B1272BC723F400893C33 /* FuzzySearcher.swift */,
 				09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */,
+				B5C8DE010000000000000002 /* ClientCertificateManager.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1440,6 +1447,7 @@
 				50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */,
 				50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */,
 				50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */,
+				B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -1506,6 +1514,7 @@
 				509A7D832806A232009791D1 /* AutoDownloadLibrarySyncer.swift */,
 				50ED756528CBC5D200E5D347 /* LibrarySyncerProxy.swift */,
 				504262A42BF48ADF00B5EF38 /* CommonLibrarySyncer.swift */,
+				B5C8DE010000000000000004 /* ClientCertificateSession.swift */,
 			);
 			path = Api;
 			sourceTree = "<group>";
@@ -2521,6 +2530,7 @@
 				502E56BC27561AD900638BD2 /* UserQueueSectionHeader.swift in Sources */,
 				50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */,
 				50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */,
+				B5C8DE010000000000000005 /* ClientCertificateSettingsView.swift in Sources */,
 				50C16C0621E241B200F086F0 /* SearchVC.swift in Sources */,
 				502041A12E2A3CDB003CE29A /* SliderView.swift in Sources */,
 				502041A22E2A3CDB003CE29A /* EquilizerView.swift in Sources */,
@@ -2727,6 +2737,8 @@
 				50C9D64B284FAA02007F18D0 /* SubsonicServerApi.swift in Sources */,
 				50C9D65C284FAA0B007F18D0 /* GenreParserDelegate.swift in Sources */,
 				50C9D6D2284FAB0C007F18D0 /* StringHasher.swift in Sources */,
+				B5C8DE010000000000000001 /* ClientCertificateManager.swift in Sources */,
+				B5C8DE010000000000000003 /* ClientCertificateSession.swift in Sources */,
 				50C9D667284FAA0B007F18D0 /* PlaylistSongsParserDelegate.swift in Sources */,
 				50FF311B2BBC4D8000C2C3B9 /* NetworkMonitor.swift in Sources */,
 				5087DE392EF0437F00644893 /* MetaManager.swift in Sources */,

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */; };
 		50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */; };
 		B5C8DE010000000000000005 /* ClientCertificateSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */; };
+		50C0FFEE0000000000A00003 /* AdvancedLoginOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C0FFEE0000000000A00004 /* AdvancedLoginOptionsView.swift */; };
 		50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */; };
 		50791E7F28D363F0006CE6E5 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */; };
 		50791E8128D365E9006CE6E5 /* UpdatePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */; };
@@ -1148,6 +1149,7 @@
 		B5C8DE010000000000000002 /* ClientCertificateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateManager.swift; sourceTree = "<group>"; };
 		B5C8DE010000000000000004 /* ClientCertificateSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateSession.swift; sourceTree = "<group>"; };
 		B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateSettingsView.swift; sourceTree = "<group>"; };
+		50C0FFEE0000000000A00004 /* AdvancedLoginOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedLoginOptionsView.swift; sourceTree = "<group>"; };
 		50FF311A2BBC4D8000C2C3B9 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		50RA71NG2F5A01230085CBB3 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		631C166A2C6D3D9A0085F62E /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
@@ -1448,6 +1450,7 @@
 				50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */,
 				50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */,
 				B5C8DE010000000000000006 /* ClientCertificateSettingsView.swift */,
+				50C0FFEE0000000000A00004 /* AdvancedLoginOptionsView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -2531,6 +2534,7 @@
 				50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */,
 				50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */,
 				B5C8DE010000000000000005 /* ClientCertificateSettingsView.swift in Sources */,
+				50C0FFEE0000000000A00003 /* AdvancedLoginOptionsView.swift in Sources */,
 				50C16C0621E241B200F086F0 /* SearchVC.swift in Sources */,
 				502041A12E2A3CDB003CE29A /* SliderView.swift in Sources */,
 				502041A22E2A3CDB003CE29A /* EquilizerView.swift in Sources */,

--- a/Amperfy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Amperfy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,15 +11,6 @@
       }
     },
     {
-      "identity" : "audiostreaming",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/dimitris-c/AudioStreaming",
-      "state" : {
-        "revision" : "a729ee28fece29d80a749419d96df0693200f124",
-        "version" : "1.4.4"
-      }
-    },
-    {
       "identity" : "callbackurlkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/phimage/CallbackURLKit",

--- a/Amperfy/Amperfy.entitlements
+++ b/Amperfy/Amperfy.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.carplay-audio</key>
-	<true/>
-	<key>com.apple.developer.siri</key>
-	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Amperfy/Info.plist
+++ b/Amperfy/Info.plist
@@ -59,6 +59,19 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>PKCS12 Certificate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.rsa.pkcs-12</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+		</dict>
+	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Amperfy/Info.plist
+++ b/Amperfy/Info.plist
@@ -14,6 +14,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+    <key>CFBundleDisplayName</key>
+    <string>Amperfy Dev</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -71,11 +73,45 @@
 			<key>LSHandlerRank</key>
 			<string>Alternate</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>PKCS12 Certificate (renamed for import)</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.amperfy.x-p12</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.amperfy.x-p12</string>
+			<key>UTTypeDescription</key>
+			<string>PKCS12 Certificate (renamed for import)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>x-p12</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIFileSharingEnabled</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -21,6 +21,7 @@
 
 import AmperfyKit
 import UIKit
+import UniformTypeIdentifiers
 
 extension String {
   var isHyperTextProtocolProvided: Bool {
@@ -166,6 +167,22 @@ class LoginVC: UIViewController {
     return button
   }()
 
+  fileprivate lazy var certificateLabel: UILabel = {
+    let label = UILabel()
+    label.text = "Certificate:"
+    label.font = .systemFont(ofSize: Self.fontSize)
+    label.textColor = .hardLabelColor
+    return label
+  }()
+
+  fileprivate lazy var certificateButton: UIButton = {
+    var config = UIButton.Configuration.glass()
+    let button = UIButton(configuration: config)
+    button.setTitle("None", for: .normal)
+    button.preferredBehavioralStyle = .pad
+    return button
+  }()
+
   fileprivate lazy var loginButton: UIButton = {
     var config = UIButton.Configuration.prominentGlass()
     config.image = .login
@@ -213,6 +230,8 @@ class LoginVC: UIViewController {
     self.passwordTF.translatesAutoresizingMaskIntoConstraints = false
     apiLabel.translatesAutoresizingMaskIntoConstraints = false
     self.apiSelectorButton.translatesAutoresizingMaskIntoConstraints = false
+    certificateLabel.translatesAutoresizingMaskIntoConstraints = false
+    self.certificateButton.translatesAutoresizingMaskIntoConstraints = false
 
     let view = UIView()
     view.addSubview(serverUrlTF)
@@ -220,6 +239,8 @@ class LoginVC: UIViewController {
     view.addSubview(passwordTF)
     view.addSubview(apiLabel)
     view.addSubview(apiSelectorButton)
+    view.addSubview(certificateLabel)
+    view.addSubview(certificateButton)
 
     let padding: CGFloat = 0
     let elementHeight: CGFloat = 40
@@ -288,8 +309,28 @@ class LoginVC: UIViewController {
       ),
       apiSelectorButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
+      certificateLabel.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: apiSelectorButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      certificateLabel.safeAreaLayoutGuide.leadingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+        constant: padding
+      ),
+      certificateLabel.heightAnchor.constraint(equalToConstant: elementHeight),
+
+      certificateButton.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: apiSelectorButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      certificateButton.safeAreaLayoutGuide.trailingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+        constant: -padding
+      ),
+      certificateButton.heightAnchor.constraint(equalToConstant: elementHeight),
+
       view.heightAnchor
-        .constraint(equalToConstant: (4 * elementHeight) + (3 * spaceInBetween) + (2 * padding)),
+        .constraint(equalToConstant: (5 * elementHeight) + (4 * spaceInBetween) + (2 * padding)),
     ])
 
     return view
@@ -411,6 +452,13 @@ class LoginVC: UIViewController {
         self.appDelegate.storage.settings.accounts.login(credentials)
         meta.backendApi.provideCredentials(credentials: credentials)
 
+        if ClientCertificateManager.shared.hasIdentity(tag: ClientCertificateManager.loginTag) {
+          let accountTag = ClientCertificateManager.accountTag(for: accountInfo.ident)
+          try? ClientCertificateManager.shared.migrateIdentity(
+            from: ClientCertificateManager.loginTag, to: accountTag
+          )
+        }
+
         self.appDelegate.notificationHandler.post(name: .accountAdded, object: nil, userInfo: nil)
         self.appDelegate.notificationHandler.post(
           name: .accountActiveChanged,
@@ -431,8 +479,12 @@ class LoginVC: UIViewController {
             .replaceMainRootViewController(vc: syncVC)
         }
       } catch {
-        if error is AuthenticationError {
-          self.showErrorMsg(message: error.localizedDescription)
+        if let authError = error as? AuthenticationError {
+          self.showErrorMsg(message: authError.localizedDescription)
+        } else if let certError = error as? ClientCertificateError {
+          self.showErrorMsg(message: certError.localizedDescription)
+        } else if let certSessionError = error as? ClientCertificateSessionError {
+          self.showErrorMsg(message: certSessionError.localizedDescription)
         } else {
           self.showErrorMsg(message: "Not able to login!")
         }
@@ -470,6 +522,8 @@ class LoginVC: UIViewController {
         self.updateApiSelectorText()
       }),
     ])
+
+    updateCertificateMenu()
 
     view.backgroundColor = .systemBackground
 
@@ -596,5 +650,113 @@ class LoginVC: UIViewController {
 
   func updateApiSelectorText() {
     apiSelectorButton.setTitle("\(selectedApiType.selectorDescription)", for: .normal)
+  }
+
+  // MARK: - Certificate Management
+
+  private func updateCertificateMenu() {
+    let tag = ClientCertificateManager.loginTag
+    let hasCert = ClientCertificateManager.shared.hasIdentity(tag: tag)
+
+    var menuItems: [UIMenuElement] = []
+
+    if hasCert {
+      let info = ClientCertificateManager.shared.getCertificateInfo(tag: tag)
+      var title = info?.subjectName ?? "Certificate"
+      if let info {
+        if info.isExpired {
+          title += " (Expired)"
+          certificateButton.setTitleColor(.systemRed, for: .normal)
+        } else if info.isExpiringSoon {
+          if let days = info.daysUntilExpiry {
+            title += " (\(days)d)"
+          }
+          certificateButton.setTitleColor(.systemOrange, for: .normal)
+        } else {
+          certificateButton.setTitleColor(.tintColor, for: .normal)
+        }
+      }
+      certificateButton.setTitle(title, for: .normal)
+
+      menuItems.append(UIAction(title: "Remove Certificate", attributes: .destructive) { _ in
+        try? ClientCertificateManager.shared.removeIdentity(tag: tag)
+        self.updateCertificateMenu()
+      })
+    } else {
+      certificateButton.setTitle("None", for: .normal)
+      certificateButton.setTitleColor(.tintColor, for: .normal)
+    }
+
+    menuItems.append(UIAction(title: "Import from Files…") { _ in
+      self.presentCertificatePicker()
+    })
+
+    certificateButton.showsMenuAsPrimaryAction = true
+    certificateButton.menu = UIMenu(title: "Client Certificate", children: menuItems)
+  }
+
+  private func presentCertificatePicker() {
+    let types: [UTType] = [UTType(filenameExtension: "p12")!, UTType(filenameExtension: "pfx")!]
+    let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
+    picker.delegate = self
+    picker.allowsMultipleSelection = false
+    present(picker, animated: true)
+  }
+
+  private func promptForPassword(fileURL: URL) {
+    guard fileURL.startAccessingSecurityScopedResource() else {
+      showErrorMsg(message: "Unable to access the selected file.")
+      return
+    }
+    defer { fileURL.stopAccessingSecurityScopedResource() }
+
+    guard let data = try? Data(contentsOf: fileURL) else {
+      showErrorMsg(message: "Unable to read the certificate file.")
+      return
+    }
+
+    let alert = UIAlertController(
+      title: "Certificate Password",
+      message: "Enter the password for this certificate.",
+      preferredStyle: .alert
+    )
+    alert.addTextField { textField in
+      textField.isSecureTextEntry = true
+      textField.placeholder = "Password"
+    }
+    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Import", style: .default) { _ in
+      let password = alert.textFields?.first?.text ?? ""
+      self.importCertificate(data: data, password: password)
+    })
+    present(alert, animated: true)
+  }
+
+  private func importCertificate(data: Data, password: String) {
+    do {
+      let (identity, _) = try ClientCertificateManager.shared.importPKCS12(
+        data: data, password: password
+      )
+      try ClientCertificateManager.shared.storeIdentity(
+        identity, tag: ClientCertificateManager.loginTag
+      )
+      updateCertificateMenu()
+    } catch let error as ClientCertificateError {
+      showErrorMsg(message: error.localizedDescription)
+    } catch {
+      showErrorMsg(message: "Failed to import certificate.")
+    }
+  }
+}
+
+// MARK: UIDocumentPickerDelegate
+
+extension LoginVC: UIDocumentPickerDelegate {
+  func documentPicker(
+    _ controller: UIDocumentPickerViewController,
+    didPickDocumentsAt urls: [URL]
+  ) {
+    guard let url = urls.first else { return }
+    promptForPassword(fileURL: url)
   }
 }

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -22,7 +22,6 @@
 import AmperfyKit
 import SwiftUI
 import UIKit
-import UniformTypeIdentifiers
 
 extension String {
   var isHyperTextProtocolProvided: Bool {
@@ -169,22 +168,6 @@ class LoginVC: UIViewController {
     return button
   }()
 
-  fileprivate lazy var certificateLabel: UILabel = {
-    let label = UILabel()
-    label.text = "Certificate:"
-    label.font = .systemFont(ofSize: Self.fontSize)
-    label.textColor = .hardLabelColor
-    return label
-  }()
-
-  fileprivate lazy var certificateButton: UIButton = {
-    var config = UIButton.Configuration.glass()
-    let button = UIButton(configuration: config)
-    button.setTitle("None", for: .normal)
-    button.preferredBehavioralStyle = .pad
-    return button
-  }()
-
   fileprivate lazy var loginButton: UIButton = {
     var config = UIButton.Configuration.prominentGlass()
     config.image = .login
@@ -197,24 +180,53 @@ class LoginVC: UIViewController {
     return button
   }()
 
-  fileprivate lazy var httpHeadersButton: UIButton = {
+  fileprivate lazy var advancedLabel: UILabel = {
+    let label = UILabel()
+    label.text = "Advanced:"
+    label.font = .systemFont(ofSize: Self.fontSize)
+    label.textColor = .hardLabelColor
+    return label
+  }()
+
+  fileprivate lazy var advancedButton: UIButton = {
     var config = UIButton.Configuration.glass()
     let button = UIButton(configuration: config)
-    button.setTitle("Custom HTTP Headers", for: .normal)
-    button.accessibilityLabel = "Custom HTTP Headers"
-    button.addTarget(self, action: #selector(Self.httpHeadersPressed), for: .touchUpInside)
+    button.setTitle("None", for: .normal)
+    button.accessibilityLabel = "Advanced network access options"
+    button.addTarget(self, action: #selector(Self.advancedPressed), for: .touchUpInside)
     button.preferredBehavioralStyle = .pad
     return button
   }()
 
   @IBAction
-  func httpHeadersPressed() {
-    let editor = CustomHTTPHeadersView(headers: httpHeaders) { [weak self] updated in
-      self?.httpHeaders = updated
-    }
-    let hostingController = UIHostingController(rootView: NavigationView { editor })
+  func advancedPressed() {
+    let root = AdvancedLoginOptionsView(
+      headers: httpHeaders,
+      onHeadersChange: { [weak self] updated in self?.httpHeaders = updated },
+      onDismiss: { [weak self] in self?.updateAdvancedSummary() }
+    )
+    .environmentObject(Settings())
+    let hostingController = UIHostingController(rootView: root)
     hostingController.modalPresentationStyle = .formSheet
     present(hostingController, animated: true)
+  }
+
+  static func advancedSummaryTitle(hasHeaders: Bool, hasCertificate: Bool) -> String {
+    switch (hasHeaders, hasCertificate) {
+    case (false, false): "None"
+    case (true, false): "Headers"
+    case (false, true): "Certificate"
+    case (true, true): "Headers + Certificate"
+    }
+  }
+
+  func updateAdvancedSummary() {
+    let hasCert = ClientCertificateManager.shared
+      .hasIdentity(tag: ClientCertificateManager.loginTag)
+    advancedButton.setTitle(
+      Self.advancedSummaryTitle(hasHeaders: !httpHeaders.isEmpty, hasCertificate: hasCert),
+      for: .normal
+    )
   }
 
   // Close button shown when presented as a sheet/modal
@@ -252,9 +264,8 @@ class LoginVC: UIViewController {
     self.passwordTF.translatesAutoresizingMaskIntoConstraints = false
     apiLabel.translatesAutoresizingMaskIntoConstraints = false
     self.apiSelectorButton.translatesAutoresizingMaskIntoConstraints = false
-    self.httpHeadersButton.translatesAutoresizingMaskIntoConstraints = false
-    certificateLabel.translatesAutoresizingMaskIntoConstraints = false
-    self.certificateButton.translatesAutoresizingMaskIntoConstraints = false
+    self.advancedButton.translatesAutoresizingMaskIntoConstraints = false
+    advancedLabel.translatesAutoresizingMaskIntoConstraints = false
 
     let view = UIView()
     view.addSubview(serverUrlTF)
@@ -262,9 +273,8 @@ class LoginVC: UIViewController {
     view.addSubview(passwordTF)
     view.addSubview(apiLabel)
     view.addSubview(apiSelectorButton)
-    view.addSubview(httpHeadersButton)
-    view.addSubview(certificateLabel)
-    view.addSubview(certificateButton)
+    view.addSubview(advancedLabel)
+    view.addSubview(advancedButton)
 
     let padding: CGFloat = 0
     let elementHeight: CGFloat = 40
@@ -333,42 +343,28 @@ class LoginVC: UIViewController {
       ),
       apiSelectorButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
-      httpHeadersButton.safeAreaLayoutGuide.topAnchor.constraint(
+      advancedLabel.safeAreaLayoutGuide.topAnchor.constraint(
         equalTo: apiSelectorButton.bottomAnchor,
         constant: spaceInBetween
       ),
-      httpHeadersButton.safeAreaLayoutGuide.leadingAnchor.constraint(
+      advancedLabel.safeAreaLayoutGuide.leadingAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.leadingAnchor,
         constant: padding
       ),
-      httpHeadersButton.safeAreaLayoutGuide.trailingAnchor.constraint(
+      advancedLabel.heightAnchor.constraint(equalToConstant: elementHeight),
+
+      advancedButton.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: apiSelectorButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      advancedButton.safeAreaLayoutGuide.trailingAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.trailingAnchor,
         constant: -padding
       ),
-      httpHeadersButton.heightAnchor.constraint(equalToConstant: elementHeight),
-
-      certificateLabel.safeAreaLayoutGuide.topAnchor.constraint(
-        equalTo: httpHeadersButton.bottomAnchor,
-        constant: spaceInBetween
-      ),
-      certificateLabel.safeAreaLayoutGuide.leadingAnchor.constraint(
-        equalTo: view.safeAreaLayoutGuide.leadingAnchor,
-        constant: padding
-      ),
-      certificateLabel.heightAnchor.constraint(equalToConstant: elementHeight),
-
-      certificateButton.safeAreaLayoutGuide.topAnchor.constraint(
-        equalTo: httpHeadersButton.bottomAnchor,
-        constant: spaceInBetween
-      ),
-      certificateButton.safeAreaLayoutGuide.trailingAnchor.constraint(
-        equalTo: view.safeAreaLayoutGuide.trailingAnchor,
-        constant: -padding
-      ),
-      certificateButton.heightAnchor.constraint(equalToConstant: elementHeight),
+      advancedButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
       view.heightAnchor
-        .constraint(equalToConstant: (6 * elementHeight) + (5 * spaceInBetween) + (2 * padding)),
+        .constraint(equalToConstant: (5 * elementHeight) + (4 * spaceInBetween) + (2 * padding)),
     ])
 
     return view
@@ -562,7 +558,7 @@ class LoginVC: UIViewController {
       }),
     ])
 
-    updateCertificateMenu()
+    updateAdvancedSummary()
 
     view.backgroundColor = .systemBackground
 
@@ -679,6 +675,7 @@ class LoginVC: UIViewController {
       usernameTF.text = credentials.username
       httpHeaders = credentials.httpHeaders
     }
+    updateAdvancedSummary()
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -690,113 +687,5 @@ class LoginVC: UIViewController {
 
   func updateApiSelectorText() {
     apiSelectorButton.setTitle("\(selectedApiType.selectorDescription)", for: .normal)
-  }
-
-  // MARK: - Certificate Management
-
-  private func updateCertificateMenu() {
-    let tag = ClientCertificateManager.loginTag
-    let hasCert = ClientCertificateManager.shared.hasIdentity(tag: tag)
-
-    var menuItems: [UIMenuElement] = []
-
-    if hasCert {
-      let info = ClientCertificateManager.shared.getCertificateInfo(tag: tag)
-      var title = info?.subjectName ?? "Certificate"
-      if let info {
-        if info.isExpired {
-          title += " (Expired)"
-          certificateButton.setTitleColor(.systemRed, for: .normal)
-        } else if info.isExpiringSoon {
-          if let days = info.daysUntilExpiry {
-            title += " (\(days)d)"
-          }
-          certificateButton.setTitleColor(.systemOrange, for: .normal)
-        } else {
-          certificateButton.setTitleColor(.tintColor, for: .normal)
-        }
-      }
-      certificateButton.setTitle(title, for: .normal)
-
-      menuItems.append(UIAction(title: "Remove Certificate", attributes: .destructive) { _ in
-        try? ClientCertificateManager.shared.removeIdentity(tag: tag)
-        self.updateCertificateMenu()
-      })
-    } else {
-      certificateButton.setTitle("None", for: .normal)
-      certificateButton.setTitleColor(.tintColor, for: .normal)
-    }
-
-    menuItems.append(UIAction(title: "Import from Files…") { _ in
-      self.presentCertificatePicker()
-    })
-
-    certificateButton.showsMenuAsPrimaryAction = true
-    certificateButton.menu = UIMenu(title: "Client Certificate", children: menuItems)
-  }
-
-  private func presentCertificatePicker() {
-    let types: [UTType] = [UTType(filenameExtension: "p12")!, UTType(filenameExtension: "pfx")!]
-    let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
-    picker.delegate = self
-    picker.allowsMultipleSelection = false
-    present(picker, animated: true)
-  }
-
-  private func promptForPassword(fileURL: URL) {
-    guard fileURL.startAccessingSecurityScopedResource() else {
-      showErrorMsg(message: "Unable to access the selected file.")
-      return
-    }
-    defer { fileURL.stopAccessingSecurityScopedResource() }
-
-    guard let data = try? Data(contentsOf: fileURL) else {
-      showErrorMsg(message: "Unable to read the certificate file.")
-      return
-    }
-
-    let alert = UIAlertController(
-      title: "Certificate Password",
-      message: "Enter the password for this certificate.",
-      preferredStyle: .alert
-    )
-    alert.addTextField { textField in
-      textField.isSecureTextEntry = true
-      textField.placeholder = "Password"
-    }
-    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-    alert.addAction(UIAlertAction(title: "Import", style: .default) { _ in
-      let password = alert.textFields?.first?.text ?? ""
-      self.importCertificate(data: data, password: password)
-    })
-    present(alert, animated: true)
-  }
-
-  private func importCertificate(data: Data, password: String) {
-    do {
-      let (identity, _) = try ClientCertificateManager.shared.importPKCS12(
-        data: data, password: password
-      )
-      try ClientCertificateManager.shared.storeIdentity(
-        identity, tag: ClientCertificateManager.loginTag
-      )
-      updateCertificateMenu()
-    } catch let error as ClientCertificateError {
-      showErrorMsg(message: error.localizedDescription)
-    } catch {
-      showErrorMsg(message: "Failed to import certificate.")
-    }
-  }
-}
-
-// MARK: UIDocumentPickerDelegate
-
-extension LoginVC: UIDocumentPickerDelegate {
-  func documentPicker(
-    _ controller: UIDocumentPickerViewController,
-    didPickDocumentsAt urls: [URL]
-  ) {
-    guard let url = urls.first else { return }
-    promptForPassword(fileURL: url)
   }
 }

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -22,6 +22,7 @@
 import AmperfyKit
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 extension String {
   var isHyperTextProtocolProvided: Bool {
@@ -168,6 +169,22 @@ class LoginVC: UIViewController {
     return button
   }()
 
+  fileprivate lazy var certificateLabel: UILabel = {
+    let label = UILabel()
+    label.text = "Certificate:"
+    label.font = .systemFont(ofSize: Self.fontSize)
+    label.textColor = .hardLabelColor
+    return label
+  }()
+
+  fileprivate lazy var certificateButton: UIButton = {
+    var config = UIButton.Configuration.glass()
+    let button = UIButton(configuration: config)
+    button.setTitle("None", for: .normal)
+    button.preferredBehavioralStyle = .pad
+    return button
+  }()
+
   fileprivate lazy var loginButton: UIButton = {
     var config = UIButton.Configuration.prominentGlass()
     config.image = .login
@@ -236,6 +253,8 @@ class LoginVC: UIViewController {
     apiLabel.translatesAutoresizingMaskIntoConstraints = false
     self.apiSelectorButton.translatesAutoresizingMaskIntoConstraints = false
     self.httpHeadersButton.translatesAutoresizingMaskIntoConstraints = false
+    certificateLabel.translatesAutoresizingMaskIntoConstraints = false
+    self.certificateButton.translatesAutoresizingMaskIntoConstraints = false
 
     let view = UIView()
     view.addSubview(serverUrlTF)
@@ -244,6 +263,8 @@ class LoginVC: UIViewController {
     view.addSubview(apiLabel)
     view.addSubview(apiSelectorButton)
     view.addSubview(httpHeadersButton)
+    view.addSubview(certificateLabel)
+    view.addSubview(certificateButton)
 
     let padding: CGFloat = 0
     let elementHeight: CGFloat = 40
@@ -326,8 +347,28 @@ class LoginVC: UIViewController {
       ),
       httpHeadersButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
+      certificateLabel.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: httpHeadersButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      certificateLabel.safeAreaLayoutGuide.leadingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+        constant: padding
+      ),
+      certificateLabel.heightAnchor.constraint(equalToConstant: elementHeight),
+
+      certificateButton.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: httpHeadersButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      certificateButton.safeAreaLayoutGuide.trailingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+        constant: -padding
+      ),
+      certificateButton.heightAnchor.constraint(equalToConstant: elementHeight),
+
       view.heightAnchor
-        .constraint(equalToConstant: (5 * elementHeight) + (4 * spaceInBetween) + (2 * padding)),
+        .constraint(equalToConstant: (6 * elementHeight) + (5 * spaceInBetween) + (2 * padding)),
     ])
 
     return view
@@ -450,6 +491,13 @@ class LoginVC: UIViewController {
         self.appDelegate.storage.settings.accounts.login(credentials)
         meta.backendApi.provideCredentials(credentials: credentials)
 
+        if ClientCertificateManager.shared.hasIdentity(tag: ClientCertificateManager.loginTag) {
+          let accountTag = ClientCertificateManager.accountTag(for: accountInfo.ident)
+          try? ClientCertificateManager.shared.migrateIdentity(
+            from: ClientCertificateManager.loginTag, to: accountTag
+          )
+        }
+
         self.appDelegate.notificationHandler.post(name: .accountAdded, object: nil, userInfo: nil)
         self.appDelegate.notificationHandler.post(
           name: .accountActiveChanged,
@@ -470,8 +518,12 @@ class LoginVC: UIViewController {
             .replaceMainRootViewController(vc: syncVC)
         }
       } catch {
-        if error is AuthenticationError {
-          self.showErrorMsg(message: error.localizedDescription)
+        if let authError = error as? AuthenticationError {
+          self.showErrorMsg(message: authError.localizedDescription)
+        } else if let certError = error as? ClientCertificateError {
+          self.showErrorMsg(message: certError.localizedDescription)
+        } else if let certSessionError = error as? ClientCertificateSessionError {
+          self.showErrorMsg(message: certSessionError.localizedDescription)
         } else {
           self.showErrorMsg(message: "Not able to login!")
         }
@@ -509,6 +561,8 @@ class LoginVC: UIViewController {
         self.updateApiSelectorText()
       }),
     ])
+
+    updateCertificateMenu()
 
     view.backgroundColor = .systemBackground
 
@@ -636,5 +690,113 @@ class LoginVC: UIViewController {
 
   func updateApiSelectorText() {
     apiSelectorButton.setTitle("\(selectedApiType.selectorDescription)", for: .normal)
+  }
+
+  // MARK: - Certificate Management
+
+  private func updateCertificateMenu() {
+    let tag = ClientCertificateManager.loginTag
+    let hasCert = ClientCertificateManager.shared.hasIdentity(tag: tag)
+
+    var menuItems: [UIMenuElement] = []
+
+    if hasCert {
+      let info = ClientCertificateManager.shared.getCertificateInfo(tag: tag)
+      var title = info?.subjectName ?? "Certificate"
+      if let info {
+        if info.isExpired {
+          title += " (Expired)"
+          certificateButton.setTitleColor(.systemRed, for: .normal)
+        } else if info.isExpiringSoon {
+          if let days = info.daysUntilExpiry {
+            title += " (\(days)d)"
+          }
+          certificateButton.setTitleColor(.systemOrange, for: .normal)
+        } else {
+          certificateButton.setTitleColor(.tintColor, for: .normal)
+        }
+      }
+      certificateButton.setTitle(title, for: .normal)
+
+      menuItems.append(UIAction(title: "Remove Certificate", attributes: .destructive) { _ in
+        try? ClientCertificateManager.shared.removeIdentity(tag: tag)
+        self.updateCertificateMenu()
+      })
+    } else {
+      certificateButton.setTitle("None", for: .normal)
+      certificateButton.setTitleColor(.tintColor, for: .normal)
+    }
+
+    menuItems.append(UIAction(title: "Import from Files…") { _ in
+      self.presentCertificatePicker()
+    })
+
+    certificateButton.showsMenuAsPrimaryAction = true
+    certificateButton.menu = UIMenu(title: "Client Certificate", children: menuItems)
+  }
+
+  private func presentCertificatePicker() {
+    let types: [UTType] = [UTType(filenameExtension: "p12")!, UTType(filenameExtension: "pfx")!]
+    let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
+    picker.delegate = self
+    picker.allowsMultipleSelection = false
+    present(picker, animated: true)
+  }
+
+  private func promptForPassword(fileURL: URL) {
+    guard fileURL.startAccessingSecurityScopedResource() else {
+      showErrorMsg(message: "Unable to access the selected file.")
+      return
+    }
+    defer { fileURL.stopAccessingSecurityScopedResource() }
+
+    guard let data = try? Data(contentsOf: fileURL) else {
+      showErrorMsg(message: "Unable to read the certificate file.")
+      return
+    }
+
+    let alert = UIAlertController(
+      title: "Certificate Password",
+      message: "Enter the password for this certificate.",
+      preferredStyle: .alert
+    )
+    alert.addTextField { textField in
+      textField.isSecureTextEntry = true
+      textField.placeholder = "Password"
+    }
+    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Import", style: .default) { _ in
+      let password = alert.textFields?.first?.text ?? ""
+      self.importCertificate(data: data, password: password)
+    })
+    present(alert, animated: true)
+  }
+
+  private func importCertificate(data: Data, password: String) {
+    do {
+      let (identity, _) = try ClientCertificateManager.shared.importPKCS12(
+        data: data, password: password
+      )
+      try ClientCertificateManager.shared.storeIdentity(
+        identity, tag: ClientCertificateManager.loginTag
+      )
+      updateCertificateMenu()
+    } catch let error as ClientCertificateError {
+      showErrorMsg(message: error.localizedDescription)
+    } catch {
+      showErrorMsg(message: "Failed to import certificate.")
+    }
+  }
+}
+
+// MARK: UIDocumentPickerDelegate
+
+extension LoginVC: UIDocumentPickerDelegate {
+  func documentPicker(
+    _ controller: UIDocumentPickerViewController,
+    didPickDocumentsAt urls: [URL]
+  ) {
+    guard let url = urls.first else { return }
+    promptForPassword(fileURL: url)
   }
 }

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -75,6 +75,13 @@ struct AccountSettingsView: View {
     meta.stopManager()
     appDelegate.resetMeta(accountInfo)
 
+    let accountCertTag = ClientCertificateManager.accountTag(for: accountInfo.ident)
+    if ClientCertificateManager.shared.hasIdentity(tag: accountCertTag) {
+      try? ClientCertificateManager.shared.migrateIdentity(
+        from: accountCertTag, to: ClientCertificateManager.loginTag
+      )
+    }
+
     // delete cached files
     CacheFileManager.shared.deleteAccountCache(accountInfo: accountInfo)
     // reset login credentials -> at new start the login view is presented to auth and resync library
@@ -212,6 +219,12 @@ struct AccountSettingsView: View {
           SettingsSection {
             NavigationLink(destination: ServerURLsSettingsView()) {
               Text("Manage Server URLs")
+            }
+          }
+
+          SettingsSection {
+            NavigationLink(destination: ClientCertificateSettingsView()) {
+              Text("Client Certificate (mTLS)")
             }
           }
 

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -92,6 +92,13 @@ struct AccountSettingsView: View {
     meta.stopManager()
     appDelegate.resetMeta(accountInfo)
 
+    let accountCertTag = ClientCertificateManager.accountTag(for: accountInfo.ident)
+    if ClientCertificateManager.shared.hasIdentity(tag: accountCertTag) {
+      try? ClientCertificateManager.shared.migrateIdentity(
+        from: accountCertTag, to: ClientCertificateManager.loginTag
+      )
+    }
+
     // delete cached files
     CacheFileManager.shared.deleteAccountCache(accountInfo: accountInfo)
     // reset login credentials -> at new start the login view is presented to auth and resync library
@@ -236,6 +243,12 @@ struct AccountSettingsView: View {
               saveHTTPHeaders(updated, accountInfo: activeAccountInfo)
             }) {
               Text("Custom HTTP Headers")
+            }
+          }
+
+          SettingsSection {
+            NavigationLink(destination: ClientCertificateSettingsView()) {
+              Text("Client Certificate (mTLS)")
             }
           }
 

--- a/Amperfy/SwiftUI/Settings/Account/AdvancedLoginOptionsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AdvancedLoginOptionsView.swift
@@ -1,0 +1,113 @@
+//
+//  AdvancedLoginOptionsView.swift
+//  Amperfy
+//
+//  Created by Jerzy Królak on 10.07.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+
+// MARK: - AdvancedLoginOptionsView
+
+/// Combined entry point for the optional network-access layers shown during login:
+/// custom HTTP headers (e.g. a Cloudflare Access service token) and a client
+/// certificate for mTLS. Both are independent and layered on top of the regular
+/// username/password login.
+struct AdvancedLoginOptionsView: View {
+  @Environment(\.dismiss)
+  private var dismiss
+
+  @State
+  private var headers: [String: String]
+  @State
+  private var certInfo: ClientCertificateInfo?
+
+  private let onHeadersChange: ([String: String]) -> ()
+  private let onDismiss: () -> ()
+
+  init(
+    headers: [String: String],
+    onHeadersChange: @escaping ([String: String]) -> (),
+    onDismiss: @escaping () -> ()
+  ) {
+    _headers = State(initialValue: headers)
+    self.onHeadersChange = onHeadersChange
+    self.onDismiss = onDismiss
+  }
+
+  private var headersSubtitle: String {
+    guard !headers.isEmpty else { return "None" }
+    return headers.count == 1 ? "1 header" : "\(headers.count) headers"
+  }
+
+  private var certificateSubtitle: String {
+    guard let info = certInfo else { return "None" }
+    if info.isExpired {
+      return "\(info.subjectName) (Expired)"
+    }
+    return info.subjectName
+  }
+
+  private func reloadCertificate() {
+    certInfo = ClientCertificateManager.shared
+      .getCertificateInfo(tag: ClientCertificateManager.loginTag)
+  }
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Section(footer: Text(
+          "These options let you connect through a proxy or zero-trust gateway (e.g. Cloudflare Access) placed in front of your server. They are optional and applied on top of your username and password."
+        )) {
+          NavigationLink {
+            CustomHTTPHeadersView(headers: headers) { updated in
+              headers = updated
+              onHeadersChange(updated)
+            }
+          } label: {
+            optionRow(title: "Custom HTTP Headers", subtitle: headersSubtitle)
+          }
+
+          NavigationLink {
+            ClientCertificateSettingsView()
+          } label: {
+            optionRow(title: "Client Certificate", subtitle: certificateSubtitle)
+          }
+        }
+      }
+      .navigationTitle("Advanced")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Done") { dismiss() }
+        }
+      }
+      .onAppear { reloadCertificate() }
+    }
+    .onDisappear { onDismiss() }
+  }
+
+  private func optionRow(title: String, subtitle: String) -> some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(subtitle)
+        .foregroundColor(.secondary)
+    }
+  }
+}

--- a/Amperfy/SwiftUI/Settings/Account/ClientCertificateSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/ClientCertificateSettingsView.swift
@@ -1,0 +1,279 @@
+//
+//  ClientCertificateSettingsView.swift
+//  Amperfy
+//
+//  Created by Jerzy Królak on 08.05.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+// MARK: - ClientCertificateSettingsView
+
+struct ClientCertificateSettingsView: View {
+  @EnvironmentObject
+  var settings: Settings
+
+  @State
+  private var certInfo: ClientCertificateInfo?
+  @State
+  private var isShowRemoveAlert = false
+  @State
+  private var isShowFilePicker = false
+  @State
+  private var isShowPasswordPrompt = false
+  @State
+  private var selectedFileData: Data?
+  @State
+  private var errorMessage: String?
+
+  private var certTag: String {
+    guard let accountInfo = settings.activeAccountInfo else {
+      return ClientCertificateManager.loginTag
+    }
+    return ClientCertificateManager.accountTag(for: accountInfo.ident)
+  }
+
+  private func reload() {
+    certInfo = ClientCertificateManager.shared.getCertificateInfo(tag: certTag)
+  }
+
+  private func removeCertificate() {
+    try? ClientCertificateManager.shared.removeIdentity(tag: certTag)
+    reload()
+  }
+
+  var body: some View {
+    SettingsList {
+      if let info = certInfo {
+        SettingsSection(content: {
+          SettingsRow(title: "Subject", orientation: .vertical) {
+            SecondaryText(info.subjectName)
+          }
+          SettingsRow(title: "Issuer", orientation: .vertical) {
+            SecondaryText(info.issuerName)
+          }
+          if let expiry = info.expirationDate {
+            SettingsRow(title: "Expires") {
+              Text(expiry, style: .date)
+                .foregroundColor(info.isExpired ? .red : info.isExpiringSoon ? .orange : .secondary)
+            }
+          }
+        }, header: "Installed Certificate")
+
+        if info.isExpired {
+          SettingsSection {
+            Label(
+              "This certificate has expired. Replace it to maintain server access.",
+              systemImage: "exclamationmark.triangle.fill"
+            )
+            .foregroundColor(.red)
+            .font(.footnote)
+          }
+        } else if info.isExpiringSoon, let days = info.daysUntilExpiry {
+          SettingsSection {
+            Label(
+              "This certificate expires in \(days) day\(days == 1 ? "" : "s"). Consider replacing it soon.",
+              systemImage: "exclamationmark.triangle"
+            )
+            .foregroundColor(.orange)
+            .font(.footnote)
+          }
+        }
+
+        SettingsSection {
+          SettingsButtonRow(title: "Replace Certificate") {
+            isShowFilePicker = true
+          }
+          SettingsButtonRow(title: "Remove Certificate", actionType: .destructive) {
+            isShowRemoveAlert = true
+          }
+        }
+      } else {
+        SettingsSection(content: {
+          SecondaryText("No client certificate configured.")
+        }, header: "Client Certificate")
+
+        SettingsSection {
+          SettingsButtonRow(title: "Import Certificate") {
+            isShowFilePicker = true
+          }
+        }
+      }
+
+      if let errorMessage {
+        SettingsSection {
+          Text(errorMessage)
+            .foregroundColor(.red)
+            .font(.footnote)
+        }
+      }
+    }
+    .navigationTitle("Client Certificate")
+    .navigationBarTitleDisplayMode(.inline)
+    .alert(isPresented: $isShowRemoveAlert) {
+      Alert(
+        title: Text("Remove Certificate"),
+        message: Text(
+          "This will remove the client certificate. You may not be able to connect to the server without it."
+        ),
+        primaryButton: .destructive(Text("Remove")) {
+          removeCertificate()
+        },
+        secondaryButton: .cancel()
+      )
+    }
+    .sheet(isPresented: $isShowFilePicker) {
+      CertificateDocumentPicker(fileData: $selectedFileData)
+    }
+    .sheet(isPresented: $isShowPasswordPrompt) {
+      CertificatePasswordPrompt(
+        fileData: selectedFileData ?? Data(),
+        certTag: certTag,
+        onComplete: { success, error in
+          isShowPasswordPrompt = false
+          if success {
+            errorMessage = nil
+            reload()
+          } else {
+            errorMessage = error
+          }
+        }
+      )
+    }
+    .onChange(of: selectedFileData) { _, newValue in
+      if newValue != nil {
+        isShowPasswordPrompt = true
+      }
+    }
+    .onAppear { reload() }
+  }
+}
+
+// MARK: - CertificateDocumentPicker
+
+struct CertificateDocumentPicker: UIViewControllerRepresentable {
+  @Binding
+  var fileData: Data?
+  @Environment(\.dismiss)
+  var dismiss
+
+  func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+    let types: [UTType] = [
+      UTType(filenameExtension: "p12")!,
+      UTType(filenameExtension: "pfx")!,
+    ]
+    let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
+    picker.allowsMultipleSelection = false
+    picker.delegate = context.coordinator
+    return picker
+  }
+
+  func updateUIViewController(
+    _ uiViewController: UIDocumentPickerViewController,
+    context: Context
+  ) {}
+
+  func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+  class Coordinator: NSObject, UIDocumentPickerDelegate {
+    let parent: CertificateDocumentPicker
+
+    init(_ parent: CertificateDocumentPicker) {
+      self.parent = parent
+    }
+
+    func documentPicker(
+      _ controller: UIDocumentPickerViewController,
+      didPickDocumentsAt urls: [URL]
+    ) {
+      guard let url = urls.first else { return }
+      guard url.startAccessingSecurityScopedResource() else { return }
+      defer { url.stopAccessingSecurityScopedResource() }
+      parent.fileData = try? Data(contentsOf: url)
+      parent.dismiss()
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+      parent.dismiss()
+    }
+  }
+}
+
+// MARK: - CertificatePasswordPrompt
+
+struct CertificatePasswordPrompt: View {
+  let fileData: Data
+  let certTag: String
+  let onComplete: (Bool, String?) -> ()
+
+  @State
+  private var password = ""
+  @State
+  private var isImporting = false
+  @State
+  private var errorText: String?
+
+  var body: some View {
+    NavigationView {
+      Form {
+        Section(header: Text("Certificate Password")) {
+          SecureField("Password", text: $password)
+        }
+
+        if let errorText {
+          Section {
+            Text(errorText)
+              .foregroundColor(.red)
+              .font(.footnote)
+          }
+        }
+
+        Section {
+          Button("Import") {
+            importCertificate()
+          }
+          .disabled(isImporting)
+        }
+      }
+      .navigationTitle("Import Certificate")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") {
+            onComplete(false, nil)
+          }
+        }
+      }
+    }
+  }
+
+  private func importCertificate() {
+    isImporting = true
+    do {
+      let (identity, _) = try ClientCertificateManager.shared.importPKCS12(
+        data: fileData, password: password
+      )
+      try ClientCertificateManager.shared.storeIdentity(identity, tag: certTag)
+      onComplete(true, nil)
+    } catch {
+      errorText = error.localizedDescription
+      isImporting = false
+    }
+  }
+}

--- a/Amperfy/SwiftUI/Settings/Account/ClientCertificateSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/ClientCertificateSettingsView.swift
@@ -174,10 +174,15 @@ struct CertificateDocumentPicker: UIViewControllerRepresentable {
   var dismiss
 
   func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
-    let types: [UTType] = [
+    var types: [UTType] = [
       UTType(filenameExtension: "p12")!,
       UTType(filenameExtension: "pfx")!,
     ]
+    // Custom type for .p12 files renamed to .x-p12 so iOS doesn't intercept them as
+    // installable profiles (useful for getting a certificate into the Simulator).
+    if let renamedP12 = UTType("org.amperfy.x-p12") {
+      types.append(renamedP12)
+    }
     let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
     picker.allowsMultipleSelection = false
     picker.delegate = context.coordinator

--- a/AmperfyKit/AmperfyKit.swift
+++ b/AmperfyKit/AmperfyKit.swift
@@ -121,7 +121,11 @@ public class AmperKit {
   private func createPlayer() -> PlayerFacade {
     playerAudioSessionHandler = AudioSessionHandler()
     let backendAudioPlayer = BackendAudioPlayer(
-      createAudioStreamingPlayerCB: { AudioStreamingPlayer() },
+      createAudioStreamingPlayerCB: {
+        AudioStreamingPlayer(clientCertificateProvider: { _ in
+          ClientCertificateManager.shared.activeStreamingCredential()
+        })
+      },
       audioSessionHandler: playerAudioSessionHandler!,
       eventLogger: eventLogger,
       getBackendApiCB: { accountInfo in

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -740,7 +740,7 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     }
   }
 
-  private func request(url: URL) async throws -> APIDataResponse {
+  private func performAFRequest(url: URL) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
       AF.request(url, method: .get).validate().responseData { response in
 
@@ -754,6 +754,26 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
         }
         fatalError("should not get here")
       }
+    }
+  }
+
+  private func request(url: URL) async throws -> APIDataResponse {
+    do {
+      return try await performAFRequest(url: url)
+    } catch {
+      if let account,
+         let serverURLString = credentials.wrappedValue?.activeBackendServerUrl,
+         let serverURL = URL(string: serverURLString),
+         ClientCertificateManager.shared.hasIdentity(
+           tag: ClientCertificateManager.accountTag(for: account.ident)
+         ) {
+        try await ClientCertificateSession.shared.reauthenticateIfNeeded(
+          accountTag: ClientCertificateManager.accountTag(for: account.ident),
+          serverURL: serverURL
+        )
+        return try await performAFRequest(url: url)
+      }
+      throw error
     }
   }
 

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -752,7 +752,12 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
 
   private func performAFRequest(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
-      AF.request(url, method: .get, headers: headers).validate().responseData { response in
+      var afRequest = AF.request(url, method: .get, headers: headers)
+      if let credential = ClientCertificateManager.shared
+        .credentialForAccountOrLogin(accountIdent: account?.ident) {
+        afRequest = afRequest.authenticate(with: credential)
+      }
+      afRequest.validate().responseData { response in
 
         if let data = response.data {
           continuation.resume(returning: APIDataResponse(data: data, url: url))

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -750,7 +750,7 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     }
   }
 
-  private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
+  private func performAFRequest(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
       AF.request(url, method: .get, headers: headers).validate().responseData { response in
 
@@ -764,6 +764,26 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
         }
         fatalError("should not get here")
       }
+    }
+  }
+
+  private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
+    do {
+      return try await performAFRequest(url: url, headers: headers)
+    } catch {
+      if let account,
+         let serverURLString = credentials.wrappedValue?.activeBackendServerUrl,
+         let serverURL = URL(string: serverURLString),
+         ClientCertificateManager.shared.hasIdentity(
+           tag: ClientCertificateManager.accountTag(for: account.ident)
+         ) {
+        try await ClientCertificateSession.shared.reauthenticateIfNeeded(
+          accountTag: ClientCertificateManager.accountTag(for: account.ident),
+          serverURL: serverURL
+        )
+        return try await performAFRequest(url: url, headers: headers)
+      }
+      throw error
     }
   }
 

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -72,6 +72,8 @@ public enum AuthenticationError: LocalizedError {
   case invalidUrl
   case requestStatusError(message: String)
   case downloadError(message: String)
+  case clientCertificateRequired
+  case certificateExpired
 
   public var errorDescription: String? {
     var ret = ""
@@ -84,6 +86,12 @@ public enum AuthenticationError: LocalizedError {
       ret = "Requesting server URL finished with status response error code '\(message)'!"
     case let .downloadError(message: message):
       ret = message
+    case .clientCertificateRequired:
+      ret =
+        "This server requires a client certificate (mTLS). Import one using the Certificate option."
+    case .certificateExpired:
+      ret =
+        "The client certificate has expired. Please import a new certificate."
     }
     return ret
   }
@@ -317,17 +325,37 @@ public final class BackendProxy: Sendable {
       throw AuthenticationError.invalidUrl
     }
 
+    if let credential = ClientCertificateManager.shared.getCredential(
+      tag: ClientCertificateManager.loginTag
+    ) {
+      if let certInfo = ClientCertificateManager.shared.getCertificateInfo(
+        tag: ClientCertificateManager.loginTag
+      ), certInfo.isExpired {
+        throw AuthenticationError.certificateExpired
+      }
+      try await ClientCertificateSession.shared.performHandshake(
+        serverURL: activeBackendServerUrl, credential: credential
+      )
+      os_log("mTLS authentication succeeded.", log: self.log, type: .info)
+    }
+
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
       let sessionConfig = URLSessionConfiguration.default
       let session = URLSession(configuration: sessionConfig)
       let request = URLRequest(url: activeBackendServerUrl)
       let task = session.downloadTask(with: request) { tempLocalUrl, response, error in
         if let error = error {
-          continuation
-            .resume(
-              throwing: AuthenticationError
-                .downloadError(message: error.localizedDescription)
-            )
+          let nsError = error as NSError
+          if nsError.domain == NSURLErrorDomain,
+             nsError.code == NSURLErrorClientCertificateRequired {
+            continuation.resume(throwing: AuthenticationError.clientCertificateRequired)
+          } else {
+            continuation
+              .resume(
+                throwing: AuthenticationError
+                  .downloadError(message: error.localizedDescription)
+              )
+          }
         } else {
           if let statusCode = (response as? HTTPURLResponse)?.statusCode {
             if statusCode >= 400,

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -325,23 +325,32 @@ public final class BackendProxy: Sendable {
       throw AuthenticationError.invalidUrl
     }
 
-    if let credential = ClientCertificateManager.shared.getCredential(
+    let clientCredential = ClientCertificateManager.shared.getCredential(
       tag: ClientCertificateManager.loginTag
-    ) {
+    )
+    if let clientCredential {
       if let certInfo = ClientCertificateManager.shared.getCertificateInfo(
         tag: ClientCertificateManager.loginTag
       ), certInfo.isExpired {
         throw AuthenticationError.certificateExpired
       }
       try await ClientCertificateSession.shared.performHandshake(
-        serverURL: activeBackendServerUrl, credential: credential
+        serverURL: activeBackendServerUrl, credential: clientCredential
       )
       os_log("mTLS authentication succeeded.", log: self.log, type: .info)
     }
 
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
       let sessionConfig = URLSessionConfiguration.default
-      let session = URLSession(configuration: sessionConfig)
+      // Present the client certificate on the reachability probe itself. With per-request mTLS
+      // (no session cookie) every connection must carry the certificate, so a plain session is
+      // rejected with 403 before login can proceed.
+      let sessionDelegate = clientCredential.map { ClientCertificateURLSessionDelegate(credential: $0) }
+      let session = URLSession(
+        configuration: sessionConfig,
+        delegate: sessionDelegate,
+        delegateQueue: nil
+      )
       var request = URLRequest(url: activeBackendServerUrl)
       for (field, value) in credentials.httpHeaders {
         request.setValue(value, forHTTPHeaderField: field)

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -72,6 +72,8 @@ public enum AuthenticationError: LocalizedError {
   case invalidUrl
   case requestStatusError(message: String)
   case downloadError(message: String)
+  case clientCertificateRequired
+  case certificateExpired
 
   public var errorDescription: String? {
     var ret = ""
@@ -84,6 +86,12 @@ public enum AuthenticationError: LocalizedError {
       ret = "Requesting server URL finished with status response error code '\(message)'!"
     case let .downloadError(message: message):
       ret = message
+    case .clientCertificateRequired:
+      ret =
+        "This server requires a client certificate (mTLS). Import one using the Certificate option."
+    case .certificateExpired:
+      ret =
+        "The client certificate has expired. Please import a new certificate."
     }
     return ret
   }
@@ -317,6 +325,20 @@ public final class BackendProxy: Sendable {
       throw AuthenticationError.invalidUrl
     }
 
+    if let credential = ClientCertificateManager.shared.getCredential(
+      tag: ClientCertificateManager.loginTag
+    ) {
+      if let certInfo = ClientCertificateManager.shared.getCertificateInfo(
+        tag: ClientCertificateManager.loginTag
+      ), certInfo.isExpired {
+        throw AuthenticationError.certificateExpired
+      }
+      try await ClientCertificateSession.shared.performHandshake(
+        serverURL: activeBackendServerUrl, credential: credential
+      )
+      os_log("mTLS authentication succeeded.", log: self.log, type: .info)
+    }
+
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
       let sessionConfig = URLSessionConfiguration.default
       let session = URLSession(configuration: sessionConfig)
@@ -326,11 +348,17 @@ public final class BackendProxy: Sendable {
       }
       let task = session.downloadTask(with: request) { tempLocalUrl, response, error in
         if let error = error {
-          continuation
-            .resume(
-              throwing: AuthenticationError
-                .downloadError(message: error.localizedDescription)
-            )
+          let nsError = error as NSError
+          if nsError.domain == NSURLErrorDomain,
+             nsError.code == NSURLErrorClientCertificateRequired {
+            continuation.resume(throwing: AuthenticationError.clientCertificateRequired)
+          } else {
+            continuation
+              .resume(
+                throwing: AuthenticationError
+                  .downloadError(message: error.localizedDescription)
+              )
+          }
         } else {
           if let statusCode = (response as? HTTPURLResponse)?.statusCode {
             if statusCode >= 400,

--- a/AmperfyKit/Api/ClientCertificateSession.swift
+++ b/AmperfyKit/Api/ClientCertificateSession.swift
@@ -1,0 +1,134 @@
+//
+//  ClientCertificateSession.swift
+//  AmperfyKit
+//
+//  Created by Jerzy Królak on 08.05.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import os.log
+
+// MARK: - ClientCertificateSession
+
+public final class ClientCertificateSession: NSObject, URLSessionDelegate, @unchecked Sendable {
+  public static let shared = ClientCertificateSession()
+
+  private let lock = NSLock()
+  private var activeAuthTask: Task<(), Error>?
+
+  private override init() {
+    super.init()
+  }
+
+  public func reauthenticateIfNeeded(accountTag: String, serverURL: URL) async throws {
+    let existingTask: Task<(), Error>? = lock.withLock { activeAuthTask }
+    if let existingTask {
+      try await existingTask.value
+      return
+    }
+
+    guard let credential = ClientCertificateManager.shared.getCredential(tag: accountTag) else {
+      return
+    }
+
+    let task = Task {
+      try await self.performHandshake(serverURL: serverURL, credential: credential)
+    }
+    lock.withLock { activeAuthTask = task }
+
+    do {
+      try await task.value
+      lock.withLock { activeAuthTask = nil }
+    } catch {
+      lock.withLock { activeAuthTask = nil }
+      throw error
+    }
+  }
+
+  public func performHandshake(serverURL: URL, credential: URLCredential) async throws {
+    let handler = ClientCertificateURLSessionDelegate(credential: credential)
+    let config = URLSessionConfiguration.default
+    let session = URLSession(configuration: config, delegate: handler, delegateQueue: nil)
+    defer { session.finishTasksAndInvalidate() }
+
+    var request = URLRequest(url: serverURL)
+    request.httpMethod = "GET"
+
+    let (_, response) = try await session.data(for: request)
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw ClientCertificateSessionError.invalidResponse
+    }
+
+    let statusCode = httpResponse.statusCode
+    guard (200 ... 499).contains(statusCode) else {
+      throw ClientCertificateSessionError.serverError(statusCode: statusCode)
+    }
+
+    os_log(
+      .default,
+      "mTLS handshake completed (status %d), cookies stored",
+      statusCode
+    )
+  }
+}
+
+// MARK: - ClientCertificateURLSessionDelegate
+
+final class ClientCertificateURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+  private let credential: URLCredential
+
+  init(credential: URLCredential) {
+    self.credential = credential
+    super.init()
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> ()
+  ) {
+    switch challenge.protectionSpace.authenticationMethod {
+    case NSURLAuthenticationMethodClientCertificate:
+      completionHandler(.useCredential, credential)
+    case NSURLAuthenticationMethodServerTrust:
+      if let trust = challenge.protectionSpace.serverTrust {
+        completionHandler(.useCredential, URLCredential(trust: trust))
+      } else {
+        completionHandler(.performDefaultHandling, nil)
+      }
+    default:
+      completionHandler(.performDefaultHandling, nil)
+    }
+  }
+}
+
+// MARK: - ClientCertificateSessionError
+
+public enum ClientCertificateSessionError: LocalizedError {
+  case invalidResponse
+  case serverError(statusCode: Int)
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidResponse:
+      return "Invalid response from server during certificate authentication."
+    case let .serverError(statusCode):
+      return "Server returned error \(statusCode) during certificate authentication."
+    }
+  }
+}

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -956,7 +956,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     return try await request(url: url)
   }
 
-  private func request(url: URL) async throws -> APIDataResponse {
+  private func performAFRequest(url: URL) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
       let afRequest = AF.request(url, method: .get)
       afRequest.validate().responseData { response in
@@ -983,6 +983,26 @@ final class SubsonicServerApi: URLCleanser, Sendable {
         }
         fatalError("should not get here")
       }
+    }
+  }
+
+  private func request(url: URL) async throws -> APIDataResponse {
+    do {
+      return try await performAFRequest(url: url)
+    } catch {
+      if let account,
+         let serverURLString = credentials.wrappedValue?.activeBackendServerUrl,
+         let serverURL = URL(string: serverURLString),
+         ClientCertificateManager.shared.hasIdentity(
+           tag: ClientCertificateManager.accountTag(for: account.ident)
+         ) {
+        try await ClientCertificateSession.shared.reauthenticateIfNeeded(
+          accountTag: ClientCertificateManager.accountTag(for: account.ident),
+          serverURL: serverURL
+        )
+        return try await performAFRequest(url: url)
+      }
+      throw error
     }
   }
 }

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -971,7 +971,11 @@ final class SubsonicServerApi: URLCleanser, Sendable {
 
   private func performAFRequest(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
-      let afRequest = AF.request(url, method: .get, headers: headers)
+      var afRequest = AF.request(url, method: .get, headers: headers)
+      if let credential = ClientCertificateManager.shared
+        .credentialForAccountOrLogin(accountIdent: account?.ident) {
+        afRequest = afRequest.authenticate(with: credential)
+      }
       afRequest.validate().responseData { response in
         if response.response?.statusCode == 404 {
           let cleanedURL = self.cleanse(url: response.request?.url)

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -969,7 +969,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     return try await request(url: url, headers: buildHTTPHeaders())
   }
 
-  private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
+  private func performAFRequest(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
       let afRequest = AF.request(url, method: .get, headers: headers)
       afRequest.validate().responseData { response in
@@ -996,6 +996,26 @@ final class SubsonicServerApi: URLCleanser, Sendable {
         }
         fatalError("should not get here")
       }
+    }
+  }
+
+  private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
+    do {
+      return try await performAFRequest(url: url, headers: headers)
+    } catch {
+      if let account,
+         let serverURLString = credentials.wrappedValue?.activeBackendServerUrl,
+         let serverURL = URL(string: serverURLString),
+         ClientCertificateManager.shared.hasIdentity(
+           tag: ClientCertificateManager.accountTag(for: account.ident)
+         ) {
+        try await ClientCertificateSession.shared.reauthenticateIfNeeded(
+          accountTag: ClientCertificateManager.accountTag(for: account.ident),
+          serverURL: serverURL
+        )
+        return try await performAFRequest(url: url, headers: headers)
+      }
+      throw error
     }
   }
 }

--- a/AmperfyKit/Common/ClientCertificateManager.swift
+++ b/AmperfyKit/Common/ClientCertificateManager.swift
@@ -1,0 +1,294 @@
+//
+//  ClientCertificateManager.swift
+//  AmperfyKit
+//
+//  Created by Jerzy Królak on 08.05.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Security
+
+// MARK: - ClientCertificateError
+
+public enum ClientCertificateError: LocalizedError, Equatable {
+  case invalidPKCS12Data
+  case incorrectPassword
+  case keychainError(status: OSStatus)
+  case noIdentityFound
+  case certificateExpired
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidPKCS12Data:
+      return "The certificate file is invalid or corrupted."
+    case .incorrectPassword:
+      return "Incorrect certificate password."
+    case let .keychainError(status):
+      return "Keychain error: \(status)"
+    case .noIdentityFound:
+      return "No identity found in the certificate file."
+    case .certificateExpired:
+      return "The certificate has expired."
+    }
+  }
+}
+
+// MARK: - ClientCertificateInfo
+
+public struct ClientCertificateInfo: Sendable {
+  public let subjectName: String
+  public let issuerName: String
+  public let expirationDate: Date?
+
+  public var isExpired: Bool {
+    guard let expirationDate else { return false }
+    return expirationDate < Date()
+  }
+
+  public var isExpiringSoon: Bool {
+    guard let expirationDate else { return false }
+    let thirtyDays = TimeInterval(30 * 24 * 60 * 60)
+    return !isExpired && expirationDate.timeIntervalSinceNow < thirtyDays
+  }
+
+  public var daysUntilExpiry: Int? {
+    guard let expirationDate else { return nil }
+    return Calendar.current.dateComponents([.day], from: Date(), to: expirationDate).day
+  }
+}
+
+// MARK: - ClientCertificateManager
+
+public final class ClientCertificateManager: Sendable {
+  public static let shared = ClientCertificateManager()
+  public static let loginTag = "amperfy.mtls.login"
+
+  public static func accountTag(for accountIdent: String) -> String {
+    "amperfy.mtls.\(accountIdent)"
+  }
+
+  private init() {}
+
+  public func importPKCS12(data: Data, password: String) throws -> (
+    identity: SecIdentity, info: ClientCertificateInfo
+  ) {
+    let options: [String: Any] = [kSecImportExportPassphrase as String: password]
+    var rawItems: CFArray?
+    let status = SecPKCS12Import(data as CFData, options as CFDictionary, &rawItems)
+
+    guard status == errSecSuccess else {
+      if status == errSecAuthFailed || status == errSecDecode {
+        throw ClientCertificateError.incorrectPassword
+      }
+      throw ClientCertificateError.invalidPKCS12Data
+    }
+
+    guard let items = rawItems as? [[String: Any]],
+          let firstItem = items.first,
+          let identityRef = firstItem[kSecImportItemIdentity as String]
+    else {
+      throw ClientCertificateError.noIdentityFound
+    }
+    // swiftlint:disable:next force_cast
+    let identity = identityRef as! SecIdentity
+
+    let info = try extractCertificateInfo(from: identity)
+    return (identity, info)
+  }
+
+  public func storeIdentity(_ identity: SecIdentity, tag: String) throws {
+    try removeIdentityIfExists(tag: tag)
+
+    let addQuery: [String: Any] = [
+      kSecClass as String: kSecClassIdentity,
+      kSecValueRef as String: identity,
+      kSecAttrLabel as String: tag,
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+    ]
+
+    let status = SecItemAdd(addQuery as CFDictionary, nil)
+    guard status == errSecSuccess else {
+      throw ClientCertificateError.keychainError(status: status)
+    }
+  }
+
+  public func getIdentity(tag: String) -> SecIdentity? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassIdentity,
+      kSecAttrLabel as String: tag,
+      kSecReturnRef as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    guard status == errSecSuccess else { return nil }
+    return (result as! SecIdentity)
+  }
+
+  public func getCredential(tag: String) -> URLCredential? {
+    guard let identity = getIdentity(tag: tag) else { return nil }
+    return URLCredential(
+      identity: identity,
+      certificates: nil,
+      persistence: .forSession
+    )
+  }
+
+  public func removeIdentity(tag: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassIdentity,
+      kSecAttrLabel as String: tag,
+    ]
+
+    let status = SecItemDelete(query as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else {
+      throw ClientCertificateError.keychainError(status: status)
+    }
+  }
+
+  public func hasIdentity(tag: String) -> Bool {
+    getIdentity(tag: tag) != nil
+  }
+
+  public func getCertificateInfo(tag: String) -> ClientCertificateInfo? {
+    guard let identity = getIdentity(tag: tag) else { return nil }
+    return try? extractCertificateInfo(from: identity)
+  }
+
+  public func migrateIdentity(from sourceTag: String, to destinationTag: String) throws {
+    guard let identity = getIdentity(tag: sourceTag) else { return }
+    try storeIdentity(identity, tag: destinationTag)
+    try removeIdentity(tag: sourceTag)
+  }
+
+  // MARK: - Private
+
+  private func removeIdentityIfExists(tag: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassIdentity,
+      kSecAttrLabel as String: tag,
+    ]
+    let status = SecItemDelete(query as CFDictionary)
+    if status != errSecSuccess, status != errSecItemNotFound {
+      throw ClientCertificateError.keychainError(status: status)
+    }
+  }
+
+  private func extractCertificateInfo(from identity: SecIdentity) throws -> ClientCertificateInfo {
+    var certificate: SecCertificate?
+    let status = SecIdentityCopyCertificate(identity, &certificate)
+    guard status == errSecSuccess, let cert = certificate else {
+      throw ClientCertificateError.noIdentityFound
+    }
+
+    let subjectName = SecCertificateCopySubjectSummary(cert) as String? ?? "Unknown"
+    let derData = SecCertificateCopyData(cert) as Data
+    let expirationDate = Self.parseExpirationDate(from: derData)
+
+    return ClientCertificateInfo(
+      subjectName: subjectName,
+      issuerName: "Unknown",
+      expirationDate: expirationDate
+    )
+  }
+
+  /// Parses the notAfter date from DER-encoded X.509 certificate data.
+  /// X.509 structure: SEQUENCE { tbsCertificate SEQUENCE { version, serial, sigAlgo, issuer, validity SEQUENCE { notBefore, notAfter }, ... } }
+  private static func parseExpirationDate(from derData: Data) -> Date? {
+    var offset = 0
+    let bytes = [UInt8](derData)
+
+    func readTag() -> UInt8? {
+      guard offset < bytes.count else { return nil }
+      let tag = bytes[offset]
+      offset += 1
+      return tag
+    }
+
+    func readLength() -> Int? {
+      guard offset < bytes.count else { return nil }
+      let first = bytes[offset]
+      offset += 1
+      if first < 0x80 {
+        return Int(first)
+      }
+      let numBytes = Int(first & 0x7F)
+      guard offset + numBytes <= bytes.count else { return nil }
+      var length = 0
+      for _ in 0 ..< numBytes {
+        length = (length << 8) | Int(bytes[offset])
+        offset += 1
+      }
+      return length
+    }
+
+    func skipElement() -> Bool {
+      guard readTag() != nil, let len = readLength() else { return false }
+      offset += len
+      return offset <= bytes.count
+    }
+
+    func enterSequence() -> Bool {
+      guard let tag = readTag(), (tag & 0x30) == 0x30 else { return false }
+      return readLength() != nil
+    }
+
+    func parseTime() -> Date? {
+      guard let tag = readTag(), let len = readLength() else { return nil }
+      guard offset + len <= bytes.count else { return nil }
+      let timeBytes = Array(bytes[offset ..< (offset + len)])
+      offset += len
+      guard let timeString = String(bytes: timeBytes, encoding: .ascii) else { return nil }
+
+      let formatter = DateFormatter()
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = TimeZone(identifier: "UTC")
+
+      if tag == 0x17 { // UTCTime
+        formatter.dateFormat = "yyMMddHHmmss'Z'"
+      } else if tag == 0x18 { // GeneralizedTime
+        formatter.dateFormat = "yyyyMMddHHmmss'Z'"
+      } else {
+        return nil
+      }
+      return formatter.date(from: timeString)
+    }
+
+    // Certificate SEQUENCE
+    guard enterSequence() else { return nil }
+    // tbsCertificate SEQUENCE
+    guard enterSequence() else { return nil }
+
+    // version [0] EXPLICIT (optional)
+    if offset < bytes.count, bytes[offset] == 0xA0 {
+      guard skipElement() else { return nil }
+    }
+    // serialNumber
+    guard skipElement() else { return nil }
+    // signature algorithm
+    guard skipElement() else { return nil }
+    // issuer
+    guard skipElement() else { return nil }
+    // validity SEQUENCE
+    guard enterSequence() else { return nil }
+    // notBefore
+    _ = parseTime()
+    // notAfter
+    return parseTime()
+  }
+}

--- a/AmperfyKit/Common/ClientCertificateManager.swift
+++ b/AmperfyKit/Common/ClientCertificateManager.swift
@@ -73,7 +73,7 @@ public struct ClientCertificateInfo: Sendable {
 
 // MARK: - ClientCertificateManager
 
-public final class ClientCertificateManager: Sendable {
+public final class ClientCertificateManager: @unchecked Sendable {
   public static let shared = ClientCertificateManager()
   public static let loginTag = "amperfy.mtls.login"
 
@@ -82,6 +82,33 @@ public final class ClientCertificateManager: Sendable {
   }
 
   private init() {}
+
+  /// Account ident of the currently streaming account, if any.
+  /// Set on the main actor before playback starts and read from the streaming library's
+  /// background URLSession delegate queue, so access is lock-protected.
+  private let activeStreamingTagLock = NSLock()
+  private var _activeStreamingCertificateAccountIdent: String?
+
+  public var activeStreamingCertificateAccountIdent: String? {
+    get {
+      activeStreamingTagLock.lock()
+      defer { activeStreamingTagLock.unlock() }
+      return _activeStreamingCertificateAccountIdent
+    }
+    set {
+      activeStreamingTagLock.lock()
+      defer { activeStreamingTagLock.unlock() }
+      _activeStreamingCertificateAccountIdent = newValue
+    }
+  }
+
+  /// The `URLCredential` to present for the currently streaming account, or `nil` if no account is
+  /// set (e.g. radio). Uses the same accountTag→loginTag fallback as the API and download paths,
+  /// so it works even when the identity is still under the login tag. Safe to call from any thread.
+  public func activeStreamingCredential() -> URLCredential? {
+    guard let ident = activeStreamingCertificateAccountIdent else { return nil }
+    return credentialForAccountOrLogin(accountIdent: ident)
+  }
 
   public func importPKCS12(data: Data, password: String) throws -> (
     identity: SecIdentity, info: ClientCertificateInfo
@@ -147,6 +174,17 @@ public final class ClientCertificateManager: Sendable {
       certificates: nil,
       persistence: .forSession
     )
+  }
+
+  /// Resolves the client-certificate credential to present for the given account, falling back to the
+  /// login-time certificate (used before the identity is migrated from the login tag to the account tag).
+  /// Shared by every per-request mTLS path: API requests, downloads, and the login reachability probe.
+  public func credentialForAccountOrLogin(accountIdent: String?) -> URLCredential? {
+    if let accountIdent,
+       let credential = getCredential(tag: Self.accountTag(for: accountIdent)) {
+      return credential
+    }
+    return getCredential(tag: Self.loginTag)
   }
 
   public func removeIdentity(tag: String) throws {

--- a/AmperfyKit/Download/DownloadManager.swift
+++ b/AmperfyKit/Download/DownloadManager.swift
@@ -92,6 +92,9 @@ actor DownloadManager: NSObject, DownloadManageable {
   private let eventLogger: EventLogger
   private let settings: AmperfySettings
   private let urlCleanser: URLCleanser
+  // Account ident used to resolve the client certificate to present on mTLS challenges.
+  // Immutable and Sendable, so it is safe to read from the nonisolated URLSession delegate.
+  internal let clientCertificateAccountIdent: String?
 
   private var isRunning = false
   private var taskOperations = [DownloadRequest: DownloadOperation]()
@@ -115,7 +118,8 @@ actor DownloadManager: NSObject, DownloadManageable {
     notificationHandler: EventNotificationHandler,
     urlCleanser: URLCleanser,
     limitCacheSize: Bool,
-    isFailWithPopupError: Bool
+    isFailWithPopupError: Bool,
+    clientCertificateAccountIdent: String? = nil
   ) {
     self.name = name
     self.log = OSLog(subsystem: "Amperfy", category: name)
@@ -129,6 +133,7 @@ actor DownloadManager: NSObject, DownloadManageable {
     self.urlCleanser = urlCleanser
     self.isCacheSizeLimited = limitCacheSize
     self.isFailWithPopupError = isFailWithPopupError
+    self.clientCertificateAccountIdent = clientCertificateAccountIdent
     self.taskQueue = OperationQueue()
 
     super.init()

--- a/AmperfyKit/Download/DownloadManagerSessionExtension.swift
+++ b/AmperfyKit/Download/DownloadManagerSessionExtension.swift
@@ -112,6 +112,21 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
 //    // ignore progress: don't save progress in CoreData -> huge CPU load
 //  }
 
+  nonisolated func urlSession(
+    _ session: URLSession,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate,
+          let credential = ClientCertificateManager.shared
+          .credentialForAccountOrLogin(accountIdent: clientCertificateAccountIdent)
+    else {
+      completionHandler(.performDefaultHandling, nil)
+      return
+    }
+    completionHandler(.useCredential, credential)
+  }
+
   nonisolated func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
     os_log("URLSession urlSessionDidFinishEvents", log: self.log, type: .info)
     Task { @MainActor in

--- a/AmperfyKit/MetaManager.swift
+++ b/AmperfyKit/MetaManager.swift
@@ -146,7 +146,8 @@ public class MetaManager {
       notificationHandler: notificationHandler,
       urlCleanser: backendApi,
       limitCacheSize: true,
-      isFailWithPopupError: true
+      isFailWithPopupError: true,
+      clientCertificateAccountIdent: account.ident
     )
 
     let configuration = URLSessionConfiguration
@@ -192,7 +193,8 @@ public class MetaManager {
       notificationHandler: notificationHandler,
       urlCleanser: backendApi,
       limitCacheSize: false,
-      isFailWithPopupError: false
+      isFailWithPopupError: false,
+      clientCertificateAccountIdent: account.ident
     )
 
     let validationCB: PreDownloadIsValidCB =

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -639,14 +639,31 @@ class BackendAudioPlayer: NSObject {
       return
     }
 
+    let headers = Self.cookieHeaders(for: asset.url)
+
     switch queueType {
     case .play:
       currentPreparedUrl = asset.url.absoluteString
-      player?.play(url: asset.url)
+      if headers.isEmpty {
+        player?.play(url: asset.url)
+      } else {
+        player?.play(url: asset.url, headers: headers)
+      }
     case .queue:
       nextPreloadedUrl = asset.url.absoluteString
-      player?.queue(url: asset.url)
+      if headers.isEmpty {
+        player?.queue(url: asset.url)
+      } else {
+        player?.queue(url: asset.url, headers: headers)
+      }
     }
+  }
+
+  private static func cookieHeaders(for url: URL) -> [String: String] {
+    guard let cookies = HTTPCookieStorage.shared.cookies(for: url), !cookies.isEmpty else {
+      return [:]
+    }
+    return HTTPCookie.requestHeaderFields(with: cookies)
   }
 
   // MARK: - EQ Implementation

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -560,6 +560,7 @@ class BackendAudioPlayer: NSObject {
           throw BackendError.invalidUrl
         }
         playType = .stream
+        ClientCertificateManager.shared.activeStreamingCertificateAccountIdent = nil
         return streamUrl
       } else {
         if queueType == .play {
@@ -579,6 +580,14 @@ class BackendAudioPlayer: NSObject {
         }
         let backendApi = getBackendApiCB(accountInfo)
         httpHeaders = backendApi.httpHeaders
+        ClientCertificateManager.shared.activeStreamingCertificateAccountIdent = accountInfo.ident
+        os_log(
+          .default,
+          "Streaming mTLS certificate for account %{public}@: %{public}@",
+          accountInfo.ident,
+          ClientCertificateManager.shared
+            .credentialForAccountOrLogin(accountIdent: accountInfo.ident) != nil ? "found" : "MISSING"
+        )
         return try await backendApi.generateUrl(
           forStreamingPlayable: playable.info,
           maxBitrate: streamingMaxBitrate,

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -645,22 +645,32 @@ class BackendAudioPlayer: NSObject {
       return
     }
 
+    var headers = Self.cookieHeaders(for: asset.url)
+    headers.merge(httpHeaders) { _, new in new }
+
     switch queueType {
     case .play:
       currentPreparedUrl = asset.url.absoluteString
-      if httpHeaders.isEmpty {
+      if headers.isEmpty {
         player?.play(url: asset.url)
       } else {
-        player?.play(url: asset.url, headers: httpHeaders)
+        player?.play(url: asset.url, headers: headers)
       }
     case .queue:
       nextPreloadedUrl = asset.url.absoluteString
-      if httpHeaders.isEmpty {
+      if headers.isEmpty {
         player?.queue(url: asset.url)
       } else {
-        player?.queue(url: asset.url, headers: httpHeaders)
+        player?.queue(url: asset.url, headers: headers)
       }
     }
+  }
+
+  private static func cookieHeaders(for url: URL) -> [String: String] {
+    guard let cookies = HTTPCookieStorage.shared.cookies(for: url), !cookies.isEmpty else {
+      return [:]
+    }
+    return HTTPCookie.requestHeaderFields(with: cookies)
   }
 
   // MARK: - EQ Implementation


### PR DESCRIPTION
Enable .p12/.pfx certificate import for mutual TLS authentication with reverse proxies like Cloudflare Access. Uses certificate only for initial handshake to obtain session cookie, then relies on cookie for all subsequent requests including streaming.