### PR TITLE
fix: showing song list instead of auto-playing in carplay

### DIFF
--- a/Amperfy/CarPlay/CarPlayCommonListExtension.swift
+++ b/Amperfy/CarPlay/CarPlayCommonListExtension.swift
@@ -275,28 +275,32 @@ extension CarPlaySceneDelegate {
     ]
     section.handler = { [weak self] item, completion in
       guard let self = self else { completion(); return }
-      var songItems = [CPListItem]()
-      songItems.append(createPlayShuffledListItem(playContext: PlayContext(
-        containable: album,
-        playables: album.playables.filterCached(dependigOn: onlyCached || isOfflineMode)
-      )))
-      let albumSongs = album.playables.filterCached(dependigOn: onlyCached || isOfflineMode)
-        .prefix(LibraryStorage.carPlayMaxElements)
-      for (index, song) in albumSongs.enumerated() {
-        let listItem = createDetailTemplate(
-          for: song,
-          playContext: PlayContext(containable: album, index: index, playables: Array(albumSongs)),
-          isTrackDisplayed: true
-        )
-        songItems.append(listItem)
-      }
-      let albumTemplate = CPListTemplate(title: album.name, sections: [
-        CPListSection(items: songItems),
-      ])
+      let albumTemplate = createAlbumSongListTemplate(for: album, onlyCached: onlyCached)
       interfaceController?.pushTemplate(albumTemplate, animated: true, completion: nil)
       completion()
     }
     return section
+  }
+
+  func createAlbumSongListTemplate(for album: Album, onlyCached: Bool) -> CPListTemplate {
+    var songItems = [CPListItem]()
+    songItems.append(createPlayShuffledListItem(playContext: PlayContext(
+      containable: album,
+      playables: album.playables.filterCached(dependigOn: onlyCached || isOfflineMode)
+    )))
+    let albumSongs = album.playables.filterCached(dependigOn: onlyCached || isOfflineMode)
+      .prefix(LibraryStorage.carPlayMaxElements)
+    for (index, song) in albumSongs.enumerated() {
+      let listItem = createDetailTemplate(
+        for: song,
+        playContext: PlayContext(containable: album, index: index, playables: Array(albumSongs)),
+        isTrackDisplayed: true
+      )
+      songItems.append(listItem)
+    }
+    return CPListTemplate(title: album.name, sections: [
+      CPListSection(items: songItems),
+    ])
   }
 
   func createPlaylistsSections() -> [CPListSection] {

--- a/Amperfy/CarPlay/CarPlayHomeTabExtension.swift
+++ b/Amperfy/CarPlay/CarPlayHomeTabExtension.swift
@@ -140,9 +140,15 @@ extension CarPlaySceneDelegate {
             // ignore online fetch in CarPlay
           }
         }
-        self.appDelegate.player.play(context: PlayContext(containable: selectedPlayable))
-        displayNowPlaying {
+        if let album = selectedPlayable as? Album {
+          let albumTemplate = createAlbumSongListTemplate(for: album, onlyCached: isOfflineMode)
+          let _ = try? await interfaceController?.pushTemplate(albumTemplate, animated: true)
           completion()
+        } else {
+          self.appDelegate.player.play(context: PlayContext(containable: selectedPlayable))
+          displayNowPlaying {
+            completion()
+          }
         }
       }
     }

--- a/Amperfy/CarPlay/CarPlayHomeTabExtension.swift
+++ b/Amperfy/CarPlay/CarPlayHomeTabExtension.swift
@@ -144,6 +144,14 @@ extension CarPlaySceneDelegate {
           let albumTemplate = createAlbumSongListTemplate(for: album, onlyCached: isOfflineMode)
           let _ = try? await interfaceController?.pushTemplate(albumTemplate, animated: true)
           completion()
+        } else if let playlist = selectedPlayable as? Playlist {
+          let playlistDetailTemplate = CPListTemplate(title: playlist.name, sections: [
+            CPListSection(items: [CPListTemplateItem]()),
+          ])
+          playlistDetailSection = playlistDetailTemplate
+          createPlaylistDetailFetchController(playlist: playlist)
+          interfaceController?.pushTemplate(playlistDetailTemplate, animated: true, completion: nil)
+          completion()
         } else {
           self.appDelegate.player.play(context: PlayContext(containable: selectedPlayable))
           displayNowPlaying {

--- a/Amperfy/CarPlay/CarPlayNowPlayingExtension.swift
+++ b/Amperfy/CarPlay/CarPlayNowPlayingExtension.swift
@@ -98,6 +98,8 @@ extension CarPlaySceneDelegate {
     )
     CPNowPlayingTemplate.shared.updateNowPlayingButtons(buttons)
     CPNowPlayingTemplate.shared.isUpNextButtonEnabled = true
+    let currentlyPlayingAlbum = (appDelegate.player.currentlyPlaying as? Song)?.album
+    CPNowPlayingTemplate.shared.isAlbumArtistButtonEnabled = currentlyPlayingAlbum != nil
   }
 
   func displayNowPlaying(immediately: Bool = false, completion: @escaping (() -> ())) {
@@ -123,6 +125,16 @@ extension CarPlaySceneDelegate: CPNowPlayingTemplateObserver {
   nonisolated func nowPlayingTemplateUpNextButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {
     MainActor.assumeIsolated {
       self.interfaceController?.pushTemplate(playerQueueSection, animated: true, completion: nil)
+    }
+  }
+
+  nonisolated func nowPlayingTemplateAlbumArtistButtonTapped(
+    _ nowPlayingTemplate: CPNowPlayingTemplate
+  ) {
+    MainActor.assumeIsolated {
+      guard let album = (appDelegate.player.currentlyPlaying as? Song)?.album else { return }
+      let albumTemplate = createAlbumSongListTemplate(for: album, onlyCached: isOfflineMode)
+      interfaceController?.pushTemplate(albumTemplate, animated: true, completion: nil)
     }
   }
 


### PR DESCRIPTION
When tapping an album or playlist from the home screen in carplay, the album/playlist would start playing instead of showing the song list. This PR fixes that, and also as a bonus allows the user to tap the album name in the now playing screen to show the song list. 