### PR TITLE
feat: adding the ability to start an instant mix at the end of the queue

### DIFF
--- a/Amperfy/Screens/ViewController/SettingsHostVC.swift
+++ b/Amperfy/Screens/ViewController/SettingsHostVC.swift
@@ -192,6 +192,11 @@ class SettingsHostVC: UIViewController {
       self.appDelegate.storage.settings.user.isPlayerSongPlaybackResumeEnabled = newValue
     }))
 
+    settings.isAutoMixAfterEnd = appDelegate.storage.settings.user.isAutoMixAfterEnd
+    changesAgent.append(settings.$isAutoMixAfterEnd.sink(receiveValue: { newValue in
+      self.appDelegate.storage.settings.user.isAutoMixAfterEnd = newValue
+    }))
+
     settings.swipeActionSettings = appDelegate.storage.settings.user.swipeActionSettings
 
     settings.isReplayGainEnabled = appDelegate.storage.settings.user.isReplayGainEnabled

--- a/Amperfy/SwiftUI/Settings/ObservableSettings.swift
+++ b/Amperfy/SwiftUI/Settings/ObservableSettings.swift
@@ -92,4 +92,7 @@ final class Settings: ObservableObject {
 
   @Published
   var isMiniPlayerAlwaysOnTop = false
+
+  @Published
+  var isAutoMixAfterEnd = false
 }

--- a/Amperfy/SwiftUI/Settings/Player/PlayerSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Player/PlayerSettingsView.swift
@@ -109,6 +109,16 @@ struct PlayerSettingsView: View {
           SettingsCheckBoxRow(title: "Manual Playback", isOn: $settings.isPlaybackStartOnlyOnPlay)
         }, footer: "Enable to start playback only when the Play button is pressed.")
 
+        SettingsSection(
+          content: {
+            SettingsCheckBoxRow(
+              title: "Instant Mix After End",
+              isOn: $settings.isAutoMixAfterEnd
+            )
+          },
+          footer: "When the queue ends, automatically continue playback using Instant Mix to find similar songs."
+        )
+
         // Streaming Format Settings
         SettingsSection(
           content: {

--- a/AmperfyKit/AmperfyKit.swift
+++ b/AmperfyKit/AmperfyKit.swift
@@ -157,6 +157,13 @@ public class AmperKit {
     playerAudioSessionHandler!.eventLogger = eventLogger
     playerAudioSessionHandler!.configureObserverForAudioSessionInterruption()
     backendAudioPlayer.triggerReinsertPlayableCB = curPlayer.play
+    curPlayer.autoInstantMixCB = { [weak self] song in
+      guard let self, let accountInfo = song.account?.info else { return [] }
+      return try await self.getMeta(accountInfo).librarySyncer.requestSimilarSongs(
+        song: song,
+        count: 99
+      )
+    }
     backendAudioPlayer.updateEqualizerEnabled(isEnabled: storage.settings.user.isEqualizerEnabled)
     backendAudioPlayer
       .updateEqualizerSetting(eqSetting: storage.settings.user.activeEqualizerSetting)

--- a/AmperfyKit/Player/AudioPlayer.swift
+++ b/AmperfyKit/Player/AudioPlayer.swift
@@ -54,6 +54,7 @@ public class AudioPlayer: NSObject, BackendAudioPlayerNotifiable {
   }
 
   var isShouldPauseAfterFinishedPlaying = false
+  var autoInstantMixCB: ((Song) async throws -> [Song])?
 
   private var playerStatus: PlayerStatusPersistent
   private var queueHandler: PlayQueueHandler
@@ -209,6 +210,21 @@ public class AudioPlayer: NSObject, BackendAudioPlayerNotifiable {
   func playNext() {
     if let nextPlayerIndex = nextPlayerIndex {
       play(playerIndex: nextPlayerIndex)
+    } else if settings.user.isAutoMixAfterEnd,
+              let song = currentlyPlaying?.asSong,
+              let cb = autoInstantMixCB,
+              !backendAudioPlayer.isOfflineMode {
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        do {
+          let similarSongs = try await cb(song)
+          guard !similarSongs.isEmpty else { self.stop(); return }
+          self.queueHandler.appendContextQueue(playables: similarSongs)
+          self.play(playerIndex: PlayerIndex(queueType: .next, index: 0))
+        } catch {
+          self.stop()
+        }
+      }
     } else {
       stop()
     }

--- a/AmperfyKit/Storage/Settings.swift
+++ b/AmperfyKit/Storage/Settings.swift
@@ -171,6 +171,12 @@ public struct UserSettings: Sendable, Codable {
     set { _isPlayerSongPlaybackResumeEnabled = newValue }
   }
 
+  private var _isAutoMixAfterEnd: Bool = false
+  public var isAutoMixAfterEnd: Bool {
+    get { _isAutoMixAfterEnd }
+    set { _isAutoMixAfterEnd = newValue }
+  }
+
   private var _isHapticsEnabled: Bool = true
   public var isHapticsEnabled: Bool {
     get { _isHapticsEnabled }


### PR DESCRIPTION
Adds a setting to the player preferences that runs instant mix on the last played song when the queue ends