### PR TITLE
Hide shuffle controls when disabled

### DIFF
--- a/Amperfy/Screens/Player/PlayerUIHandler.swift
+++ b/Amperfy/Screens/Player/PlayerUIHandler.swift
@@ -212,7 +212,10 @@ class PlayerUIHandler: NSObject {
       config.image = .shuffle
       shuffleButton.configuration = config
     }
-    shuffleButton.isEnabled = appDelegate.storage.settings.user.isPlayerShuffleButtonEnabled
+    let isShuffleButtonVisible = player.playerMode == .music &&
+      appDelegate.storage.settings.user.isPlayerShuffleButtonEnabled
+    shuffleButton.isHidden = !isShuffleButtonVisible
+    shuffleButton.isEnabled = isShuffleButtonVisible
     shuffleButton.isSelected = player.isShuffle
   }
 

--- a/Amperfy/Screens/Player/SectionHeader/ContextQueueNextSectionHeader.swift
+++ b/Amperfy/Screens/Player/SectionHeader/ContextQueueNextSectionHeader.swift
@@ -73,7 +73,7 @@ class ContextQueueNextSectionHeader: UIView {
     switch player.playerMode {
     case .music:
       repeatButton.isHidden = false
-      shuffleButton.isHidden = false
+      shuffleButton.isHidden = !appDelegate.storage.settings.user.isPlayerShuffleButtonEnabled
     case .podcast:
       repeatButton.isHidden = true
       shuffleButton.isHidden = true

--- a/Amperfy/Screens/View/LibraryElementDetailTableHeaderView.swift
+++ b/Amperfy/Screens/View/LibraryElementDetailTableHeaderView.swift
@@ -55,6 +55,13 @@ class LibraryElementDetailTableHeaderView: UIView {
 
   private var config: PlayShuffleInfoConfiguration?
 
+  private var isPlayShuffledButtonHidden: Bool {
+    guard let config else { return true }
+    let isHiddenBySetting = config.isShuffleOnContextNeccessary &&
+      !appDelegate.storage.settings.user.isPlayerShuffleButtonEnabled
+    return config.isShuffleHidden || isHiddenBySetting
+  }
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     self.layoutMargins = UIEdgeInsets(
@@ -97,6 +104,7 @@ class LibraryElementDetailTableHeaderView: UIView {
 
   func refresh() {
     guard let config = config else { return }
+    refreshPlayShuffledButtonAvailability()
     if config.isEmbeddedInOtherView {
       layoutMargins = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
     } else {
@@ -161,7 +169,7 @@ class LibraryElementDetailTableHeaderView: UIView {
       for: .normal
     )
     playShuffledButton.layer.cornerRadius = 10.0
-    playShuffledButton.isHidden = configuration.isShuffleHidden
+    refreshPlayShuffledButtonAvailability()
     activate()
     registerForTraitChanges(
       [UITraitUserInterfaceStyle.self, UITraitHorizontalSizeClass.self],
@@ -173,12 +181,17 @@ class LibraryElementDetailTableHeaderView: UIView {
 
   func activate() {
     playAllButton.isEnabled = true
-    playShuffledButton.isEnabled = !(config?.isShuffleOnContextNeccessary ?? true) || appDelegate
-      .storage.settings.user.isPlayerShuffleButtonEnabled
+    refreshPlayShuffledButtonAvailability()
   }
 
   func deactivate() {
     playAllButton.isEnabled = false
     playShuffledButton.isEnabled = false
+  }
+
+  private func refreshPlayShuffledButtonAvailability() {
+    let isHidden = isPlayShuffledButtonHidden
+    playShuffledButton.isHidden = isHidden
+    playShuffledButton.isEnabled = !isHidden
   }
 }

--- a/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/DisplaySettingsView.swift
@@ -151,7 +151,7 @@ struct DisplaySettingsView: View {
         SettingsSection(
           content: {
             SettingsCheckBoxRow(
-              title: "Disable Player Shuffle Button",
+              title: "Hide Player Shuffle Button",
               isOn: Binding<Bool>(
                 get: { !settings.isPlayerShuffleButtonEnabled },
                 set: {
@@ -162,7 +162,7 @@ struct DisplaySettingsView: View {
             )
           },
           footer:
-          "The player shuffle button is displayed but non-interactive."
+          "Hide player shuffle controls throughout the app."
         )
       }
     }


### PR DESCRIPTION
## Summary
- hide playlist/detail-header shuffle controls when the player shuffle button setting is disabled
- hide shared player shuffle buttons instead of leaving them visible but inactive
- keep non-shuffle Random controls available and update the display setting copy to match the hide behavior

Refs #312 item 1.

## Validation
- `git diff --check`

Not run: Swift/Xcode tests, because this Windows environment does not have `swift` or Xcode tooling installed.