### PR TITLE
fix: the current song play position and queue is preserved on app close

### DIFF
--- a/Amperfy/AppDelegate.swift
+++ b/Amperfy/AppDelegate.swift
@@ -397,6 +397,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     os_log("applicationDidEnterBackground", log: self.log, type: .info)
+    player.savePlayPosition()
+    storage.main.saveContext()
   }
 
   func applicationWillEnterForeground(_ application: UIApplication) {

--- a/Amperfy/SceneDelegate.swift
+++ b/Amperfy/SceneDelegate.swift
@@ -196,6 +196,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard appDelegate.isNormalInteraction else {
       return
     }
+    appDelegate.player.savePlayPosition()
+    appDelegate.storage.main.saveContext()
     appDelegate.scheduleAppRefresh()
   }
 

--- a/AmperfyKit/Player/AudioPlayer.swift
+++ b/AmperfyKit/Player/AudioPlayer.swift
@@ -273,14 +273,24 @@ public class AudioPlayer: NSObject, BackendAudioPlayerNotifiable {
   }
 
   private func seekToLastStoppedPlayTime() {
-    if let playable = currentlyPlaying,
-       playable.playProgress > 0,
-       playable
-       .isPodcastEpisode ||
-       (
-         (playable.isSong || backendAudioPlayer.isErrorOccurred) && settings.user
-           .isPlayerSongPlaybackResumeEnabled
-       ) {
+    guard let playable = currentlyPlaying, playable.playProgress > 0 else { return }
+
+    // Restore playback position after app termination for the song
+    // that was interrupted. This applies once regardless of the
+    // isPlayerSongPlaybackResumeEnabled setting.
+    let resumeSongIdKey = "resumePlaybackSongId"
+    if let resumeId = UserDefaults.standard.string(forKey: resumeSongIdKey),
+       playable.objectID.uriRepresentation().absoluteString == resumeId {
+      backendAudioPlayer.seek(toSecond: Double(playable.playProgress))
+      UserDefaults.standard.removeObject(forKey: resumeSongIdKey)
+      return
+    }
+
+    if playable.isPodcastEpisode ||
+      (
+        (playable.isSong || backendAudioPlayer.isErrorOccurred) && settings.user
+          .isPlayerSongPlaybackResumeEnabled
+      ) {
       backendAudioPlayer.seek(toSecond: Double(playable.playProgress))
     }
   }
@@ -302,6 +312,19 @@ public class AudioPlayer: NSObject, BackendAudioPlayerNotifiable {
   func didReadStreamMetadata(_ metadata: [String: String]) {
     guard let radio = currentlyPlaying?.asRadio else { return }
     updateRadioNowPlaying(from: metadata, radio: radio)
+  }
+
+  func savePlayPosition() {
+    guard let playable = currentlyPlaying, !playable.isRadio else { return }
+    let playDuration = backendAudioPlayer.duration
+    let playProgress = backendAudioPlayer.elapsedTime
+    guard playDuration != 0.0, playProgress != 0.0 else { return }
+    playable.playDuration = Int(playDuration)
+    playable.playProgress = Int(playProgress)
+    UserDefaults.standard.set(
+      playable.objectID.uriRepresentation().absoluteString,
+      forKey: "resumePlaybackSongId"
+    )
   }
 
   private func savePlayInformation(of playable: AbstractPlayable) {

--- a/AmperfyKit/Player/PlayerFacade.swift
+++ b/AmperfyKit/Player/PlayerFacade.swift
@@ -231,6 +231,7 @@ public protocol PlayerFacade {
   func updateEqualizerEnabled(isEnabled: Bool)
   func updateEqualizerSetting(eqSetting: EqualizerSetting)
   func updateReplayGainEnabled(isEnabled: Bool)
+  func savePlayPosition()
 }
 
 extension PlayerFacade {
@@ -672,5 +673,9 @@ class PlayerFacadeImpl: PlayerFacade {
 
   func addNotifier(notifier: MusicPlayable) {
     musicPlayer.addNotifier(notifier: notifier)
+  }
+
+  func savePlayPosition() {
+    musicPlayer.savePlayPosition()
   }
 }


### PR DESCRIPTION
Previously, the current queue and play position was discarded when the app closed. This PR addresses this and preserves the play position and current queue on app close so it can be applied when the app starts. This is a separate feature from the existing "Song Playback Resume" feature and will not affect/be affected by it. 