### PR TITLE
feat: HTTP headers per server (e.g. Cloudflare Access service token)

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		5078AFB42B44AE260038FD17 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5078AFB32B44AE260038FD17 /* AppIntentVocabulary.plist */; };
 		50791E7828D25845006CE6E5 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7728D25845006CE6E5 /* AccountSettingsView.swift */; };
 		50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */; };
+		50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */; };
 		50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */; };
 		50791E7F28D363F0006CE6E5 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */; };
 		50791E8128D365E9006CE6E5 /* UpdatePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */; };
@@ -786,6 +787,7 @@
 		5078AFB32B44AE260038FD17 /* AppIntentVocabulary.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		50791E7728D25845006CE6E5 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURLsSettingsView.swift; sourceTree = "<group>"; };
+		50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHTTPHeadersView.swift; sourceTree = "<group>"; };
 		50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeURLAddDialogView.swift; sourceTree = "<group>"; };
 		50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBannerView.swift; sourceTree = "<group>"; };
 		50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePasswordView.swift; sourceTree = "<group>"; };
@@ -1432,6 +1434,7 @@
 			children = (
 				50791E7728D25845006CE6E5 /* AccountSettingsView.swift */,
 				50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */,
+				50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */,
 				50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */,
 				50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */,
 			);
@@ -2514,6 +2517,7 @@
 				50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */,
 				502E56BC27561AD900638BD2 /* UserQueueSectionHeader.swift in Sources */,
 				50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */,
+				50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */,
 				50C16C0621E241B200F086F0 /* SearchVC.swift in Sources */,
 				502041A12E2A3CDB003CE29A /* SliderView.swift in Sources */,
 				502041A22E2A3CDB003CE29A /* EquilizerView.swift in Sources */,

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -58,9 +58,6 @@ extension UITextField {
 
 class LoginVC: UIViewController {
   var selectedApiType: BackenApiType = .notDetected
-  /// Custom HTTP headers (e.g. a Cloudflare Access service token) sent with every request to the
-  /// server. Collected via the embedded `CustomHTTPHeadersView` and applied to the credentials on
-  /// login.
   var customHeaders: [String: String] = [:]
 
   #if targetEnvironment(macCatalyst)
@@ -431,7 +428,7 @@ class LoginVC: UIViewController {
     var credentials = LoginCredentials(serverUrl: serverUrl, username: username, password: password)
     // Apply custom headers before login so the reachability check and authentication request
     // already carry e.g. a Cloudflare Access service token.
-    credentials.customHTTPHeaders = customHeaders
+    credentials.httpHeaders = customHeaders
     var accountInfo = Account.createInfo(credentials: credentials)
 
     guard !appDelegate.storage.settings.accounts.allAccounts.contains(where: { $0 == accountInfo })
@@ -628,7 +625,7 @@ class LoginVC: UIViewController {
       .loginCredentials {
       serverUrlTF.text = credentials.serverUrl
       usernameTF.text = credentials.username
-      customHeaders = credentials.customHTTPHeaders
+      customHeaders = credentials.httpHeaders
     }
   }
 

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -20,6 +20,7 @@
 //
 
 import AmperfyKit
+import SwiftUI
 import UIKit
 
 extension String {
@@ -57,6 +58,10 @@ extension UITextField {
 
 class LoginVC: UIViewController {
   var selectedApiType: BackenApiType = .notDetected
+  /// Custom HTTP headers (e.g. a Cloudflare Access service token) sent with every request to the
+  /// server. Collected via the embedded `CustomHTTPHeadersView` and applied to the credentials on
+  /// login.
+  var customHeaders: [String: String] = [:]
 
   #if targetEnvironment(macCatalyst)
     static let fontSize: CGFloat = 14
@@ -178,6 +183,26 @@ class LoginVC: UIViewController {
     return button
   }()
 
+  fileprivate lazy var customHeadersButton: UIButton = {
+    var config = UIButton.Configuration.glass()
+    let button = UIButton(configuration: config)
+    button.setTitle("Custom HTTP Headers", for: .normal)
+    button.accessibilityLabel = "Custom HTTP Headers"
+    button.addTarget(self, action: #selector(Self.customHeadersPressed), for: .touchUpInside)
+    button.preferredBehavioralStyle = .pad
+    return button
+  }()
+
+  @IBAction
+  func customHeadersPressed() {
+    let editor = CustomHTTPHeadersView(headers: customHeaders) { [weak self] updated in
+      self?.customHeaders = updated
+    }
+    let hostingController = UIHostingController(rootView: NavigationView { editor })
+    hostingController.modalPresentationStyle = .formSheet
+    present(hostingController, animated: true)
+  }
+
   // Close button shown when presented as a sheet/modal
   fileprivate lazy var closeButton: UIButton = {
     var config = UIButton.Configuration.prominentGlass()
@@ -213,6 +238,7 @@ class LoginVC: UIViewController {
     self.passwordTF.translatesAutoresizingMaskIntoConstraints = false
     apiLabel.translatesAutoresizingMaskIntoConstraints = false
     self.apiSelectorButton.translatesAutoresizingMaskIntoConstraints = false
+    self.customHeadersButton.translatesAutoresizingMaskIntoConstraints = false
 
     let view = UIView()
     view.addSubview(serverUrlTF)
@@ -220,6 +246,7 @@ class LoginVC: UIViewController {
     view.addSubview(passwordTF)
     view.addSubview(apiLabel)
     view.addSubview(apiSelectorButton)
+    view.addSubview(customHeadersButton)
 
     let padding: CGFloat = 0
     let elementHeight: CGFloat = 40
@@ -288,8 +315,22 @@ class LoginVC: UIViewController {
       ),
       apiSelectorButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
+      customHeadersButton.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: apiSelectorButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      customHeadersButton.safeAreaLayoutGuide.leadingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+        constant: padding
+      ),
+      customHeadersButton.safeAreaLayoutGuide.trailingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+        constant: -padding
+      ),
+      customHeadersButton.heightAnchor.constraint(equalToConstant: elementHeight),
+
       view.heightAnchor
-        .constraint(equalToConstant: (4 * elementHeight) + (3 * spaceInBetween) + (2 * padding)),
+        .constraint(equalToConstant: (5 * elementHeight) + (4 * spaceInBetween) + (2 * padding)),
     ])
 
     return view
@@ -388,6 +429,9 @@ class LoginVC: UIViewController {
     }
 
     var credentials = LoginCredentials(serverUrl: serverUrl, username: username, password: password)
+    // Apply custom headers before login so the reachability check and authentication request
+    // already carry e.g. a Cloudflare Access service token.
+    credentials.customHTTPHeaders = customHeaders
     var accountInfo = Account.createInfo(credentials: credentials)
 
     guard !appDelegate.storage.settings.accounts.allAccounts.contains(where: { $0 == accountInfo })
@@ -584,6 +628,7 @@ class LoginVC: UIViewController {
       .loginCredentials {
       serverUrlTF.text = credentials.serverUrl
       usernameTF.text = credentials.username
+      customHeaders = credentials.customHTTPHeaders
     }
   }
 

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -58,7 +58,7 @@ extension UITextField {
 
 class LoginVC: UIViewController {
   var selectedApiType: BackenApiType = .notDetected
-  var customHeaders: [String: String] = [:]
+  var httpHeaders: [String: String] = [:]
 
   #if targetEnvironment(macCatalyst)
     static let fontSize: CGFloat = 14
@@ -192,8 +192,8 @@ class LoginVC: UIViewController {
 
   @IBAction
   func customHeadersPressed() {
-    let editor = CustomHTTPHeadersView(headers: customHeaders) { [weak self] updated in
-      self?.customHeaders = updated
+    let editor = CustomHTTPHeadersView(headers: httpHeaders) { [weak self] updated in
+      self?.httpHeaders = updated
     }
     let hostingController = UIHostingController(rootView: NavigationView { editor })
     hostingController.modalPresentationStyle = .formSheet
@@ -426,9 +426,7 @@ class LoginVC: UIViewController {
     }
 
     var credentials = LoginCredentials(serverUrl: serverUrl, username: username, password: password)
-    // Apply custom headers before login so the reachability check and authentication request
-    // already carry e.g. a Cloudflare Access service token.
-    credentials.httpHeaders = customHeaders
+    credentials.httpHeaders = httpHeaders
     var accountInfo = Account.createInfo(credentials: credentials)
 
     guard !appDelegate.storage.settings.accounts.allAccounts.contains(where: { $0 == accountInfo })
@@ -625,7 +623,7 @@ class LoginVC: UIViewController {
       .loginCredentials {
       serverUrlTF.text = credentials.serverUrl
       usernameTF.text = credentials.username
-      customHeaders = credentials.httpHeaders
+      httpHeaders = credentials.httpHeaders
     }
   }
 

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -180,18 +180,18 @@ class LoginVC: UIViewController {
     return button
   }()
 
-  fileprivate lazy var customHeadersButton: UIButton = {
+  fileprivate lazy var httpHeadersButton: UIButton = {
     var config = UIButton.Configuration.glass()
     let button = UIButton(configuration: config)
     button.setTitle("Custom HTTP Headers", for: .normal)
     button.accessibilityLabel = "Custom HTTP Headers"
-    button.addTarget(self, action: #selector(Self.customHeadersPressed), for: .touchUpInside)
+    button.addTarget(self, action: #selector(Self.httpHeadersPressed), for: .touchUpInside)
     button.preferredBehavioralStyle = .pad
     return button
   }()
 
   @IBAction
-  func customHeadersPressed() {
+  func httpHeadersPressed() {
     let editor = CustomHTTPHeadersView(headers: httpHeaders) { [weak self] updated in
       self?.httpHeaders = updated
     }
@@ -235,7 +235,7 @@ class LoginVC: UIViewController {
     self.passwordTF.translatesAutoresizingMaskIntoConstraints = false
     apiLabel.translatesAutoresizingMaskIntoConstraints = false
     self.apiSelectorButton.translatesAutoresizingMaskIntoConstraints = false
-    self.customHeadersButton.translatesAutoresizingMaskIntoConstraints = false
+    self.httpHeadersButton.translatesAutoresizingMaskIntoConstraints = false
 
     let view = UIView()
     view.addSubview(serverUrlTF)
@@ -243,7 +243,7 @@ class LoginVC: UIViewController {
     view.addSubview(passwordTF)
     view.addSubview(apiLabel)
     view.addSubview(apiSelectorButton)
-    view.addSubview(customHeadersButton)
+    view.addSubview(httpHeadersButton)
 
     let padding: CGFloat = 0
     let elementHeight: CGFloat = 40
@@ -312,19 +312,19 @@ class LoginVC: UIViewController {
       ),
       apiSelectorButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
-      customHeadersButton.safeAreaLayoutGuide.topAnchor.constraint(
+      httpHeadersButton.safeAreaLayoutGuide.topAnchor.constraint(
         equalTo: apiSelectorButton.bottomAnchor,
         constant: spaceInBetween
       ),
-      customHeadersButton.safeAreaLayoutGuide.leadingAnchor.constraint(
+      httpHeadersButton.safeAreaLayoutGuide.leadingAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.leadingAnchor,
         constant: padding
       ),
-      customHeadersButton.safeAreaLayoutGuide.trailingAnchor.constraint(
+      httpHeadersButton.safeAreaLayoutGuide.trailingAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.trailingAnchor,
         constant: -padding
       ),
-      customHeadersButton.heightAnchor.constraint(equalToConstant: elementHeight),
+      httpHeadersButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
       view.heightAnchor
         .constraint(equalToConstant: (5 * elementHeight) + (4 * spaceInBetween) + (2 * padding)),

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -65,15 +65,15 @@ struct AccountSettingsView: View {
     AppDelegate.mainSceneDelegate?.window?.rootViewController?.present(syncVC, animated: true)
   }
 
-  private func customHTTPHeaders(accountInfo: AccountInfo) -> [String: String] {
+  private func httpHeaders(accountInfo: AccountInfo) -> [String: String] {
     appDelegate.storage.settings.accounts.getSetting(accountInfo).read
-      .loginCredentials?.customHTTPHeaders ?? [:]
+      .loginCredentials?.httpHeaders ?? [:]
   }
 
   private func saveCustomHTTPHeaders(_ headers: [String: String], accountInfo: AccountInfo) {
     appDelegate.storage.settings.accounts
       .updateSetting(accountInfo) { accountSettings in
-        accountSettings.loginCredentials?.customHTTPHeaders = headers
+        accountSettings.loginCredentials?.httpHeaders = headers
       }
     // Re-provide the credentials so requests of the running session pick up the new headers
     // without requiring a restart.
@@ -233,7 +233,7 @@ struct AccountSettingsView: View {
               Text("Manage Server URLs")
             }
             NavigationLink(destination: CustomHTTPHeadersView(
-              headers: customHTTPHeaders(accountInfo: activeAccountInfo)
+              headers: httpHeaders(accountInfo: activeAccountInfo)
             ) { updated in
               saveCustomHTTPHeaders(updated, accountInfo: activeAccountInfo)
             }) {

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -65,6 +65,25 @@ struct AccountSettingsView: View {
     AppDelegate.mainSceneDelegate?.window?.rootViewController?.present(syncVC, animated: true)
   }
 
+  private func customHTTPHeaders(accountInfo: AccountInfo) -> [String: String] {
+    appDelegate.storage.settings.accounts.getSetting(accountInfo).read
+      .loginCredentials?.customHTTPHeaders ?? [:]
+  }
+
+  private func saveCustomHTTPHeaders(_ headers: [String: String], accountInfo: AccountInfo) {
+    appDelegate.storage.settings.accounts
+      .updateSetting(accountInfo) { accountSettings in
+        accountSettings.loginCredentials?.customHTTPHeaders = headers
+      }
+    // Re-provide the credentials so requests of the running session pick up the new headers
+    // without requiring a restart.
+    if let updatedCredentials = appDelegate.storage.settings.accounts
+      .getSetting(accountInfo).read.loginCredentials {
+      appDelegate.getMeta(accountInfo).backendApi
+        .provideCredentials(credentials: updatedCredentials)
+    }
+  }
+
   private func logout(accountInfo: AccountInfo) {
     appDelegate.closeAllButActiveMainTabs()
     if appDelegate.storage.settings.accounts.allAccounts.count <= 1 {
@@ -212,6 +231,13 @@ struct AccountSettingsView: View {
           SettingsSection {
             NavigationLink(destination: ServerURLsSettingsView()) {
               Text("Manage Server URLs")
+            }
+            NavigationLink(destination: CustomHTTPHeadersView(
+              headers: customHTTPHeaders(accountInfo: activeAccountInfo)
+            ) { updated in
+              saveCustomHTTPHeaders(updated, accountInfo: activeAccountInfo)
+            }) {
+              Text("Custom HTTP Headers")
             }
           }
 

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -75,8 +75,6 @@ struct AccountSettingsView: View {
       .updateSetting(accountInfo) { accountSettings in
         accountSettings.loginCredentials?.httpHeaders = headers
       }
-    // Re-provide the credentials so requests of the running session pick up the new headers
-    // without requiring a restart.
     if let updatedCredentials = appDelegate.storage.settings.accounts
       .getSetting(accountInfo).read.loginCredentials {
       appDelegate.getMeta(accountInfo).backendApi

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -70,7 +70,7 @@ struct AccountSettingsView: View {
       .loginCredentials?.httpHeaders ?? [:]
   }
 
-  private func saveCustomHTTPHeaders(_ headers: [String: String], accountInfo: AccountInfo) {
+  private func saveHTTPHeaders(_ headers: [String: String], accountInfo: AccountInfo) {
     appDelegate.storage.settings.accounts
       .updateSetting(accountInfo) { accountSettings in
         accountSettings.loginCredentials?.httpHeaders = headers
@@ -233,7 +233,7 @@ struct AccountSettingsView: View {
             NavigationLink(destination: CustomHTTPHeadersView(
               headers: httpHeaders(accountInfo: activeAccountInfo)
             ) { updated in
-              saveCustomHTTPHeaders(updated, accountInfo: activeAccountInfo)
+              saveHTTPHeaders(updated, accountInfo: activeAccountInfo)
             }) {
               Text("Custom HTTP Headers")
             }

--- a/Amperfy/SwiftUI/Settings/Account/CustomHTTPHeadersView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/CustomHTTPHeadersView.swift
@@ -23,8 +23,6 @@ import SwiftUI
 
 // MARK: - HTTPHeaderEntry
 
-/// A single editable HTTP header row. Identity is kept stable across edits so SwiftUI does not
-/// recreate the text fields while typing.
 struct HTTPHeaderEntry: Identifiable, Equatable {
   let id = UUID()
   var key: String
@@ -33,12 +31,6 @@ struct HTTPHeaderEntry: Identifiable, Equatable {
 
 // MARK: - CustomHTTPHeadersView
 
-/// Generic editor for custom HTTP headers that are sent with every request to the server.
-///
-/// Typical use case: provide a Cloudflare Access service token
-/// (`CF-Access-Client-Id` / `CF-Access-Client-Secret`) so the connection bypasses an interactive
-/// Zero Trust policy (e.g. an email OTP). The editor is reused both in the login screen (before an
-/// account exists) and in the account settings (to edit an existing account).
 struct CustomHTTPHeadersView: View {
   private static let cloudflareHeaderKeys = ["CF-Access-Client-Id", "CF-Access-Client-Secret"]
 
@@ -46,10 +38,6 @@ struct CustomHTTPHeadersView: View {
   private var entries: [HTTPHeaderEntry]
   private let onChange: ([String: String]) -> ()
 
-  /// - Parameters:
-  ///   - headers: the headers to pre-populate the editor with.
-  ///   - onChange: called with the resulting `[field: value]` dictionary on every edit. Rows with
-  ///     an empty field name are discarded.
   init(headers: [String: String], onChange: @escaping ([String: String]) -> ()) {
     _entries = State(
       initialValue: headers

--- a/Amperfy/SwiftUI/Settings/Account/CustomHTTPHeadersView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/CustomHTTPHeadersView.swift
@@ -1,0 +1,136 @@
+//
+//  CustomHTTPHeadersView.swift
+//  Amperfy
+//
+//  Created by Amperfy on 17.06.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+// MARK: - HTTPHeaderEntry
+
+/// A single editable HTTP header row. Identity is kept stable across edits so SwiftUI does not
+/// recreate the text fields while typing.
+struct HTTPHeaderEntry: Identifiable, Equatable {
+  let id = UUID()
+  var key: String
+  var value: String
+}
+
+// MARK: - CustomHTTPHeadersView
+
+/// Generic editor for custom HTTP headers that are sent with every request to the server.
+///
+/// Typical use case: provide a Cloudflare Access service token
+/// (`CF-Access-Client-Id` / `CF-Access-Client-Secret`) so the connection bypasses an interactive
+/// Zero Trust policy (e.g. an email OTP). The editor is reused both in the login screen (before an
+/// account exists) and in the account settings (to edit an existing account).
+struct CustomHTTPHeadersView: View {
+  private static let cloudflareHeaderKeys = ["CF-Access-Client-Id", "CF-Access-Client-Secret"]
+
+  @State
+  private var entries: [HTTPHeaderEntry]
+  private let onChange: ([String: String]) -> ()
+
+  /// - Parameters:
+  ///   - headers: the headers to pre-populate the editor with.
+  ///   - onChange: called with the resulting `[field: value]` dictionary on every edit. Rows with
+  ///     an empty field name are discarded.
+  init(headers: [String: String], onChange: @escaping ([String: String]) -> ()) {
+    _entries = State(
+      initialValue: headers
+        .map { HTTPHeaderEntry(key: $0.key, value: $0.value) }
+        .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
+    )
+    self.onChange = onChange
+  }
+
+  private func commit() {
+    var result = [String: String]()
+    for entry in entries {
+      let field = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !field.isEmpty else { continue }
+      result[field] = entry.value
+    }
+    onChange(result)
+  }
+
+  private func addEmptyHeader() {
+    entries.append(HTTPHeaderEntry(key: "", value: ""))
+  }
+
+  private func addCloudflareAccessToken() {
+    for key in Self.cloudflareHeaderKeys
+      where !entries.contains(where: { $0.key.caseInsensitiveCompare(key) == .orderedSame }) {
+      entries.append(HTTPHeaderEntry(key: key, value: ""))
+    }
+    commit()
+  }
+
+  var body: some View {
+    List {
+      Section(footer: Text(
+        "Headers are sent with every request to the server, including streaming and downloads. Use this to provide a Cloudflare Access service token (CF-Access-Client-Id / CF-Access-Client-Secret) or any other proxy authentication header."
+      )) {
+        ForEach($entries) { $entry in
+          VStack(alignment: .leading, spacing: 4) {
+            TextField("Header name", text: $entry.key)
+              .font(.headline)
+              .autocorrectionDisabled()
+              .textInputAutocapitalization(.never)
+            TextField("Value", text: $entry.value)
+              .foregroundColor(.secondary)
+              .autocorrectionDisabled()
+              .textInputAutocapitalization(.never)
+          }
+        }
+        .onDelete { indexSet in
+          entries.remove(atOffsets: indexSet)
+          commit()
+        }
+
+        Button(action: addEmptyHeader) {
+          Label("Add Header", systemImage: "plus")
+        }
+      }
+
+      Section {
+        Button(action: addCloudflareAccessToken) {
+          Label("Add Cloudflare Access Token", systemImage: "lock.shield")
+        }
+      }
+    }
+    .onChange(of: entries) { _, _ in
+      commit()
+    }
+    .navigationTitle("Custom HTTP Headers")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      EditButton()
+    }
+  }
+}
+
+// MARK: - CustomHTTPHeadersView_Previews
+
+struct CustomHTTPHeadersView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      CustomHTTPHeadersView(headers: ["CF-Access-Client-Id": "abc.access"]) { _ in }
+    }
+  }
+}

--- a/AmperfyKit/Api/Ampache/AmpacheApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheApi.swift
@@ -45,8 +45,8 @@ final class AmpacheApi: BackendApi {
 
   public var serverApiVersion: String { ampacheXmlServerApi.serverApiVersion.wrappedValue ?? "-" }
 
-  public var customHTTPHeaders: [String: String] {
-    ampacheXmlServerApi.customHTTPHeaders
+  public var httpHeaders: [String: String] {
+    ampacheXmlServerApi.httpHeaders
   }
 
   func provideCredentials(credentials: LoginCredentials) {

--- a/AmperfyKit/Api/Ampache/AmpacheApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheApi.swift
@@ -45,6 +45,10 @@ final class AmpacheApi: BackendApi {
 
   public var serverApiVersion: String { ampacheXmlServerApi.serverApiVersion.wrappedValue ?? "-" }
 
+  public var customHTTPHeaders: [String: String] {
+    ampacheXmlServerApi.customHTTPHeaders
+  }
+
   func provideCredentials(credentials: LoginCredentials) {
     ampacheXmlServerApi.provideCredentials(credentials: credentials)
   }

--- a/AmperfyKit/Api/Ampache/AmpacheArtworkDownloadDelegate.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheArtworkDownloadDelegate.swift
@@ -44,6 +44,10 @@ final class AmpacheArtworkDownloadDelegate: DownloadManagerDelegate {
     2
   }
 
+  var customHTTPHeaders: [String: String] {
+    ampacheXmlServerApi.customHTTPHeaders
+  }
+
   @MainActor
   func prepareDownload(
     downloadInfo: DownloadElementInfo,

--- a/AmperfyKit/Api/Ampache/AmpacheArtworkDownloadDelegate.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheArtworkDownloadDelegate.swift
@@ -44,8 +44,8 @@ final class AmpacheArtworkDownloadDelegate: DownloadManagerDelegate {
     2
   }
 
-  var customHTTPHeaders: [String: String] {
-    ampacheXmlServerApi.customHTTPHeaders
+  var httpHeaders: [String: String] {
+    ampacheXmlServerApi.httpHeaders
   }
 
   @MainActor

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -160,14 +160,14 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     return urlComp
   }
 
-  public var customHTTPHeaders: [String: String] {
-    credentials.wrappedValue?.customHTTPHeaders ?? [:]
+  public var httpHeaders: [String: String] {
+    credentials.wrappedValue?.httpHeaders ?? [:]
   }
 
   /// Builds the Alamofire headers for a request. During login the credentials are not yet stored in
   /// `credentials`, so the ones provided to the login call are used as a fallback.
-  private func httpHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
-    let headers = providedCredentials?.customHTTPHeaders ?? customHTTPHeaders
+  private func buildHTTPHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
+    let headers = providedCredentials?.httpHeaders ?? httpHeaders
     guard !headers.isEmpty else { return nil }
     return HTTPHeaders(headers)
   }
@@ -197,7 +197,7 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
   private func requestAuth(credentials: LoginCredentials) async throws
     -> AuthentificationHandshake {
     let url = try await createAuthURL(credentials: credentials)
-    let response = try await request(url: url, headers: httpHeaders(credentials))
+    let response = try await request(url: url, headers: buildHTTPHeaders(credentials))
     return try await parseAuthResult(response: response)
   }
 
@@ -882,6 +882,6 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     -> APIDataResponse {
     let auth = try await reauthenticate()
     let url = try urlCreation(auth)
-    return try await request(url: url, headers: httpHeaders())
+    return try await request(url: url, headers: buildHTTPHeaders())
   }
 }

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -160,6 +160,18 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     return urlComp
   }
 
+  public var customHTTPHeaders: [String: String] {
+    credentials.wrappedValue?.customHTTPHeaders ?? [:]
+  }
+
+  /// Builds the Alamofire headers for a request. During login the credentials are not yet stored in
+  /// `credentials`, so the ones provided to the login call are used as a fallback.
+  private func httpHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
+    let headers = providedCredentials?.customHTTPHeaders ?? customHTTPHeaders
+    guard !headers.isEmpty else { return nil }
+    return HTTPHeaders(headers)
+  }
+
   func provideCredentials(credentials: LoginCredentials) {
     authHandshake.wrappedValue = nil
     self.credentials.wrappedValue = credentials
@@ -185,7 +197,7 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
   private func requestAuth(credentials: LoginCredentials) async throws
     -> AuthentificationHandshake {
     let url = try await createAuthURL(credentials: credentials)
-    let response = try await request(url: url)
+    let response = try await request(url: url, headers: httpHeaders(credentials))
     return try await parseAuthResult(response: response)
   }
 
@@ -740,9 +752,9 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     }
   }
 
-  private func request(url: URL) async throws -> APIDataResponse {
+  private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
-      AF.request(url, method: .get).validate().responseData { response in
+      AF.request(url, method: .get, headers: headers).validate().responseData { response in
 
         if let data = response.data {
           continuation.resume(returning: APIDataResponse(data: data, url: url))
@@ -870,6 +882,6 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     -> APIDataResponse {
     let auth = try await reauthenticate()
     let url = try urlCreation(auth)
-    return try await request(url: url)
+    return try await request(url: url, headers: httpHeaders())
   }
 }

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -164,8 +164,6 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     credentials.wrappedValue?.httpHeaders ?? [:]
   }
 
-  /// Builds the Alamofire headers for a request. During login the credentials are not yet stored in
-  /// `credentials`, so the ones provided to the login call are used as a fallback.
   private func buildHTTPHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
     let headers = providedCredentials?.httpHeaders ?? httpHeaders
     guard !headers.isEmpty else { return nil }

--- a/AmperfyKit/Api/BackendApi.swift
+++ b/AmperfyKit/Api/BackendApi.swift
@@ -260,6 +260,9 @@ public struct TranscodingInfo {
 public protocol BackendApi: URLCleanser, Sendable {
   var clientApiVersion: String { get }
   var serverApiVersion: String { get }
+  /// Custom HTTP headers (e.g. a Cloudflare Access service token) that must be sent with every
+  /// request to the server. Empty when none are configured.
+  var customHTTPHeaders: [String: String] { get }
   func provideCredentials(credentials: LoginCredentials)
   func isAuthenticationValid(credentials: LoginCredentials) async throws
   func generateUrl(forDownloadingPlayable playableInfo: AbstractPlayableInfo) async throws -> URL

--- a/AmperfyKit/Api/BackendApi.swift
+++ b/AmperfyKit/Api/BackendApi.swift
@@ -260,9 +260,7 @@ public struct TranscodingInfo {
 public protocol BackendApi: URLCleanser, Sendable {
   var clientApiVersion: String { get }
   var serverApiVersion: String { get }
-  /// Custom HTTP headers (e.g. a Cloudflare Access service token) that must be sent with every
-  /// request to the server. Empty when none are configured.
-  var customHTTPHeaders: [String: String] { get }
+  var httpHeaders: [String: String] { get }
   func provideCredentials(credentials: LoginCredentials)
   func isAuthenticationValid(credentials: LoginCredentials) async throws
   func generateUrl(forDownloadingPlayable playableInfo: AbstractPlayableInfo) async throws -> URL

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -320,7 +320,12 @@ public final class BackendProxy: Sendable {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
       let sessionConfig = URLSessionConfiguration.default
       let session = URLSession(configuration: sessionConfig)
-      let request = URLRequest(url: activeBackendServerUrl)
+      var request = URLRequest(url: activeBackendServerUrl)
+      // Forward custom headers (e.g. Cloudflare Access service token) so that the very first
+      // reachability check is not blocked by a Zero Trust policy.
+      for (field, value) in credentials.customHTTPHeaders {
+        request.setValue(value, forHTTPHeaderField: field)
+      }
       let task = session.downloadTask(with: request) { tempLocalUrl, response, error in
         if let error = error {
           continuation
@@ -355,6 +360,8 @@ extension BackendProxy: BackendApi {
   public var clientApiVersion: String { activeApi.clientApiVersion }
 
   public var serverApiVersion: String { activeApi.serverApiVersion }
+
+  public var customHTTPHeaders: [String: String] { activeApi.customHTTPHeaders }
 
   public func provideCredentials(credentials: LoginCredentials) {
     activeApi.provideCredentials(credentials: credentials)

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -323,7 +323,7 @@ public final class BackendProxy: Sendable {
       var request = URLRequest(url: activeBackendServerUrl)
       // Forward custom headers (e.g. Cloudflare Access service token) so that the very first
       // reachability check is not blocked by a Zero Trust policy.
-      for (field, value) in credentials.customHTTPHeaders {
+      for (field, value) in credentials.httpHeaders {
         request.setValue(value, forHTTPHeaderField: field)
       }
       let task = session.downloadTask(with: request) { tempLocalUrl, response, error in
@@ -361,7 +361,7 @@ extension BackendProxy: BackendApi {
 
   public var serverApiVersion: String { activeApi.serverApiVersion }
 
-  public var customHTTPHeaders: [String: String] { activeApi.customHTTPHeaders }
+  public var httpHeaders: [String: String] { activeApi.httpHeaders }
 
   public func provideCredentials(credentials: LoginCredentials) {
     activeApi.provideCredentials(credentials: credentials)

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -321,8 +321,6 @@ public final class BackendProxy: Sendable {
       let sessionConfig = URLSessionConfiguration.default
       let session = URLSession(configuration: sessionConfig)
       var request = URLRequest(url: activeBackendServerUrl)
-      // Forward custom headers (e.g. Cloudflare Access service token) so that the very first
-      // reachability check is not blocked by a Zero Trust policy.
       for (field, value) in credentials.httpHeaders {
         request.setValue(value, forHTTPHeaderField: field)
       }

--- a/AmperfyKit/Api/LoginCredentials.swift
+++ b/AmperfyKit/Api/LoginCredentials.swift
@@ -29,6 +29,7 @@ public struct LoginCredentials: Sendable, Codable {
     case backendApi
     case activeBackendServerUrl
     case alternativeServerURLs
+    case customHTTPHeaders
   }
 
   public var serverUrl: String
@@ -38,6 +39,10 @@ public struct LoginCredentials: Sendable, Codable {
   public var backendApi: BackenApiType
   public var activeBackendServerUrl: String
   public var alternativeServerURLs: [String]
+  /// Custom HTTP headers sent with every request to the server. Used e.g. to provide a
+  /// Cloudflare Access service token (CF-Access-Client-Id / CF-Access-Client-Secret) so that
+  /// the connection bypasses an interactive Zero Trust policy.
+  public var customHTTPHeaders: [String: String]
 
   public init() {
     self.serverUrl = ""
@@ -47,6 +52,7 @@ public struct LoginCredentials: Sendable, Codable {
     self.backendApi = .notDetected
     self.activeBackendServerUrl = ""
     self.alternativeServerURLs = []
+    self.customHTTPHeaders = [:]
   }
 
   public var displayServerUrl: String {
@@ -74,6 +80,7 @@ public struct LoginCredentials: Sendable, Codable {
     self.backendApi = .notDetected
     self.activeBackendServerUrl = serverUrl
     self.alternativeServerURLs = []
+    self.customHTTPHeaders = [:]
   }
 
   public init(serverUrl: String, username: String, password: String, backendApi: BackenApiType) {
@@ -96,6 +103,10 @@ public struct LoginCredentials: Sendable, Codable {
       [String].self,
       forKey: .alternativeServerURLs
     ) ?? []
+    self.customHTTPHeaders = try container.decodeIfPresent(
+      [String: String].self,
+      forKey: .customHTTPHeaders
+    ) ?? [:]
     self.passwordHash = StringHasher.sha256(dataString: password)
   }
 
@@ -107,6 +118,7 @@ public struct LoginCredentials: Sendable, Codable {
     try container.encode(backendApi, forKey: .backendApi)
     try container.encode(activeBackendServerUrl, forKey: .activeBackendServerUrl)
     try container.encode(alternativeServerURLs, forKey: .alternativeServerURLs)
+    try container.encode(customHTTPHeaders, forKey: .customHTTPHeaders)
   }
 
   public mutating func changePasswordAndHash(password newPassword: String) {

--- a/AmperfyKit/Api/LoginCredentials.swift
+++ b/AmperfyKit/Api/LoginCredentials.swift
@@ -29,7 +29,7 @@ public struct LoginCredentials: Sendable, Codable {
     case backendApi
     case activeBackendServerUrl
     case alternativeServerURLs
-    case customHTTPHeaders
+    case httpHeaders
   }
 
   public var serverUrl: String
@@ -42,7 +42,7 @@ public struct LoginCredentials: Sendable, Codable {
   /// Custom HTTP headers sent with every request to the server. Used e.g. to provide a
   /// Cloudflare Access service token (CF-Access-Client-Id / CF-Access-Client-Secret) so that
   /// the connection bypasses an interactive Zero Trust policy.
-  public var customHTTPHeaders: [String: String]
+  public var httpHeaders: [String: String]
 
   public init() {
     self.serverUrl = ""
@@ -52,7 +52,7 @@ public struct LoginCredentials: Sendable, Codable {
     self.backendApi = .notDetected
     self.activeBackendServerUrl = ""
     self.alternativeServerURLs = []
-    self.customHTTPHeaders = [:]
+    self.httpHeaders = [:]
   }
 
   public var displayServerUrl: String {
@@ -80,7 +80,7 @@ public struct LoginCredentials: Sendable, Codable {
     self.backendApi = .notDetected
     self.activeBackendServerUrl = serverUrl
     self.alternativeServerURLs = []
-    self.customHTTPHeaders = [:]
+    self.httpHeaders = [:]
   }
 
   public init(serverUrl: String, username: String, password: String, backendApi: BackenApiType) {
@@ -103,9 +103,9 @@ public struct LoginCredentials: Sendable, Codable {
       [String].self,
       forKey: .alternativeServerURLs
     ) ?? []
-    self.customHTTPHeaders = try container.decodeIfPresent(
+    self.httpHeaders = try container.decodeIfPresent(
       [String: String].self,
-      forKey: .customHTTPHeaders
+      forKey: .httpHeaders
     ) ?? [:]
     self.passwordHash = StringHasher.sha256(dataString: password)
   }
@@ -118,7 +118,7 @@ public struct LoginCredentials: Sendable, Codable {
     try container.encode(backendApi, forKey: .backendApi)
     try container.encode(activeBackendServerUrl, forKey: .activeBackendServerUrl)
     try container.encode(alternativeServerURLs, forKey: .alternativeServerURLs)
-    try container.encode(customHTTPHeaders, forKey: .customHTTPHeaders)
+    try container.encode(httpHeaders, forKey: .httpHeaders)
   }
 
   public mutating func changePasswordAndHash(password newPassword: String) {

--- a/AmperfyKit/Api/Subsonic/SubsonicApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicApi.swift
@@ -62,6 +62,10 @@ extension SubsonicApi: BackendApi {
     subsonicServerApi.serverApiVersion.wrappedValue?.description ?? "-"
   }
 
+  public var customHTTPHeaders: [String: String] {
+    subsonicServerApi.customHTTPHeaders
+  }
+
   func provideCredentials(credentials: LoginCredentials) {
     subsonicServerApi.provideCredentials(credentials: credentials)
   }

--- a/AmperfyKit/Api/Subsonic/SubsonicApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicApi.swift
@@ -62,8 +62,8 @@ extension SubsonicApi: BackendApi {
     subsonicServerApi.serverApiVersion.wrappedValue?.description ?? "-"
   }
 
-  public var customHTTPHeaders: [String: String] {
-    subsonicServerApi.customHTTPHeaders
+  public var httpHeaders: [String: String] {
+    subsonicServerApi.httpHeaders
   }
 
   func provideCredentials(credentials: LoginCredentials) {

--- a/AmperfyKit/Api/Subsonic/SubsonicArtworkDownloadDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicArtworkDownloadDelegate.swift
@@ -45,8 +45,8 @@ final class SubsonicArtworkDownloadDelegate: DownloadManagerDelegate {
     2
   }
 
-  var customHTTPHeaders: [String: String] {
-    subsonicServerApi.customHTTPHeaders
+  var httpHeaders: [String: String] {
+    subsonicServerApi.httpHeaders
   }
 
   @MainActor

--- a/AmperfyKit/Api/Subsonic/SubsonicArtworkDownloadDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicArtworkDownloadDelegate.swift
@@ -45,6 +45,10 @@ final class SubsonicArtworkDownloadDelegate: DownloadManagerDelegate {
     2
   }
 
+  var customHTTPHeaders: [String: String] {
+    subsonicServerApi.customHTTPHeaders
+  }
+
   @MainActor
   func prepareDownload(
     downloadInfo: DownloadElementInfo,

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -251,6 +251,18 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     return urlComp
   }
 
+  public var customHTTPHeaders: [String: String] {
+    credentials.wrappedValue?.customHTTPHeaders ?? [:]
+  }
+
+  /// Builds the Alamofire headers for a request. During login the credentials are not yet stored in
+  /// `credentials`, so the ones provided to the login call are used as a fallback.
+  private func httpHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
+    let headers = providedCredentials?.customHTTPHeaders ?? customHTTPHeaders
+    guard !headers.isEmpty else { return nil }
+    return HTTPHeaders(headers)
+  }
+
   public func provideCredentials(credentials: LoginCredentials) {
     self.credentials.wrappedValue = credentials
   }
@@ -290,7 +302,10 @@ final class SubsonicServerApi: URLCleanser, Sendable {
       forAction: "ping",
       credentials: credentials
     )
-    let response = try await request(url: try createUrl(from: urlComp))
+    let response = try await request(
+      url: try createUrl(from: urlComp),
+      headers: httpHeaders(credentials)
+    )
 
     let parserDelegate = SsPingParserDelegate(performanceMonitor: performanceMonitor)
     let parser = XMLParser(data: response.data)
@@ -389,7 +404,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     }
 
     let url = try createUrl(from: urlComp)
-    let response = try await request(url: url)
+    let response = try await request(url: url, headers: httpHeaders(providedCredentials))
 
     let delegate = SsPingParserDelegate(performanceMonitor: performanceMonitor)
     let parser = XMLParser(data: response.data)
@@ -953,12 +968,12 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     -> APIDataResponse {
     let version = try await determineApiVersionToUse()
     let url = try urlCreation(version)
-    return try await request(url: url)
+    return try await request(url: url, headers: httpHeaders())
   }
 
-  private func request(url: URL) async throws -> APIDataResponse {
+  private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {
     try await withUnsafeThrowingContinuation { continuation in
-      let afRequest = AF.request(url, method: .get)
+      let afRequest = AF.request(url, method: .get, headers: headers)
       afRequest.validate().responseData { response in
         if response.response?.statusCode == 404 {
           let cleanedURL = self.cleanse(url: response.request?.url)

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -255,8 +255,6 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     credentials.wrappedValue?.httpHeaders ?? [:]
   }
 
-  /// Builds the Alamofire headers for a request. During login the credentials are not yet stored in
-  /// `credentials`, so the ones provided to the login call are used as a fallback.
   private func buildHTTPHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
     let headers = providedCredentials?.httpHeaders ?? httpHeaders
     guard !headers.isEmpty else { return nil }

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -251,14 +251,14 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     return urlComp
   }
 
-  public var customHTTPHeaders: [String: String] {
-    credentials.wrappedValue?.customHTTPHeaders ?? [:]
+  public var httpHeaders: [String: String] {
+    credentials.wrappedValue?.httpHeaders ?? [:]
   }
 
   /// Builds the Alamofire headers for a request. During login the credentials are not yet stored in
   /// `credentials`, so the ones provided to the login call are used as a fallback.
-  private func httpHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
-    let headers = providedCredentials?.customHTTPHeaders ?? customHTTPHeaders
+  private func buildHTTPHeaders(_ providedCredentials: LoginCredentials? = nil) -> HTTPHeaders? {
+    let headers = providedCredentials?.httpHeaders ?? httpHeaders
     guard !headers.isEmpty else { return nil }
     return HTTPHeaders(headers)
   }
@@ -304,7 +304,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     )
     let response = try await request(
       url: try createUrl(from: urlComp),
-      headers: httpHeaders(credentials)
+      headers: buildHTTPHeaders(credentials)
     )
 
     let parserDelegate = SsPingParserDelegate(performanceMonitor: performanceMonitor)
@@ -404,7 +404,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     }
 
     let url = try createUrl(from: urlComp)
-    let response = try await request(url: url, headers: httpHeaders(providedCredentials))
+    let response = try await request(url: url, headers: buildHTTPHeaders(providedCredentials))
 
     let delegate = SsPingParserDelegate(performanceMonitor: performanceMonitor)
     let parser = XMLParser(data: response.data)
@@ -968,7 +968,7 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     -> APIDataResponse {
     let version = try await determineApiVersionToUse()
     let url = try urlCreation(version)
-    return try await request(url: url, headers: httpHeaders())
+    return try await request(url: url, headers: buildHTTPHeaders())
   }
 
   private func request(url: URL, headers: HTTPHeaders? = nil) async throws -> APIDataResponse {

--- a/AmperfyKit/Download/DownloadManager.swift
+++ b/AmperfyKit/Download/DownloadManager.swift
@@ -398,7 +398,12 @@ actor DownloadManager: NSObject, DownloadManageable {
         downloadInfo: downloadRequest.info,
         storage: storage
       )
-      let downloadTaskInfo = DownloadTaskInfo(request: downloadRequest, url: url)
+      let httpHeaders = await getDownloadDelegateCB().customHTTPHeaders
+      let downloadTaskInfo = DownloadTaskInfo(
+        request: downloadRequest,
+        url: url,
+        httpHeaders: httpHeaders
+      )
       fetch(downloadTaskInfo: downloadTaskInfo)
     } catch {
       if let fetchError = error as? DownloadError {

--- a/AmperfyKit/Download/DownloadManager.swift
+++ b/AmperfyKit/Download/DownloadManager.swift
@@ -398,7 +398,7 @@ actor DownloadManager: NSObject, DownloadManageable {
         downloadInfo: downloadRequest.info,
         storage: storage
       )
-      let httpHeaders = await getDownloadDelegateCB().customHTTPHeaders
+      let httpHeaders = await getDownloadDelegateCB().httpHeaders
       let downloadTaskInfo = DownloadTaskInfo(
         request: downloadRequest,
         url: url,

--- a/AmperfyKit/Download/DownloadManagerSessionExtension.swift
+++ b/AmperfyKit/Download/DownloadManagerSessionExtension.swift
@@ -30,8 +30,6 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     if downloadTaskInfo.httpHeaders.isEmpty {
       task = urlSession.downloadTask(with: downloadTaskInfo.url)
     } else {
-      // Forward custom headers (e.g. Cloudflare Access service token) so that downloads are not
-      // blocked by a Zero Trust policy.
       var request = URLRequest(url: downloadTaskInfo.url)
       for (field, value) in downloadTaskInfo.httpHeaders {
         request.setValue(value, forHTTPHeaderField: field)

--- a/AmperfyKit/Download/DownloadManagerSessionExtension.swift
+++ b/AmperfyKit/Download/DownloadManagerSessionExtension.swift
@@ -26,7 +26,18 @@ import os.log
 extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
   func fetch(downloadTaskInfo: DownloadTaskInfo) {
     guard let urlSession else { return }
-    let task = urlSession.downloadTask(with: downloadTaskInfo.url)
+    let task: URLSessionDownloadTask
+    if downloadTaskInfo.httpHeaders.isEmpty {
+      task = urlSession.downloadTask(with: downloadTaskInfo.url)
+    } else {
+      // Forward custom headers (e.g. Cloudflare Access service token) so that downloads are not
+      // blocked by a Zero Trust policy.
+      var request = URLRequest(url: downloadTaskInfo.url)
+      for (field, value) in downloadTaskInfo.httpHeaders {
+        request.setValue(value, forHTTPHeaderField: field)
+      }
+      task = urlSession.downloadTask(with: request)
+    }
     tasks[task] = downloadTaskInfo
     task.resume()
   }

--- a/AmperfyKit/Download/DownloadProtocols.swift
+++ b/AmperfyKit/Download/DownloadProtocols.swift
@@ -60,9 +60,7 @@ public protocol DownloadManageable {
 public protocol DownloadManagerDelegate: Sendable {
   var requestPredicate: NSPredicate { get }
   var parallelDownloadsCount: Int { get }
-  /// Custom HTTP headers (e.g. a Cloudflare Access service token) that must be sent with every
-  /// download request. Empty when none are configured.
-  var customHTTPHeaders: [String: String] { get }
+  var httpHeaders: [String: String] { get }
   func prepareDownload(
     downloadInfo: DownloadElementInfo,
     storage: AsyncCoreDataAccessWrapper

--- a/AmperfyKit/Download/DownloadProtocols.swift
+++ b/AmperfyKit/Download/DownloadProtocols.swift
@@ -60,6 +60,9 @@ public protocol DownloadManageable {
 public protocol DownloadManagerDelegate: Sendable {
   var requestPredicate: NSPredicate { get }
   var parallelDownloadsCount: Int { get }
+  /// Custom HTTP headers (e.g. a Cloudflare Access service token) that must be sent with every
+  /// download request. Empty when none are configured.
+  var customHTTPHeaders: [String: String] { get }
   func prepareDownload(
     downloadInfo: DownloadElementInfo,
     storage: AsyncCoreDataAccessWrapper

--- a/AmperfyKit/Download/PlayableDownloadDelegate.swift
+++ b/AmperfyKit/Download/PlayableDownloadDelegate.swift
@@ -49,6 +49,10 @@ final class PlayableDownloadDelegate: DownloadManagerDelegate {
     4
   }
 
+  var customHTTPHeaders: [String: String] {
+    backendApi.customHTTPHeaders
+  }
+
   @MainActor
   func prepareDownload(
     downloadInfo: DownloadElementInfo,

--- a/AmperfyKit/Download/PlayableDownloadDelegate.swift
+++ b/AmperfyKit/Download/PlayableDownloadDelegate.swift
@@ -49,8 +49,8 @@ final class PlayableDownloadDelegate: DownloadManagerDelegate {
     4
   }
 
-  var customHTTPHeaders: [String: String] {
-    backendApi.customHTTPHeaders
+  var httpHeaders: [String: String] {
+    backendApi.httpHeaders
   }
 
   @MainActor

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -550,6 +550,9 @@ class BackendAudioPlayer: NSObject {
   ) async throws {
     let streamingMaxBitrate = streamingMaxBitrates.getActive(networkMonitor: networkMonitor)
     let streamingTranscodingFormat = streamingTranscodings.getActive(networkMonitor: networkMonitor)
+    // Custom headers (e.g. Cloudflare Access service token) for the backend server stream. Radio
+    // streams point to arbitrary external URLs, so they keep the empty default.
+    var streamHeaders: [String: String] = [:]
     @MainActor
     func provideUrl() async throws -> URL {
       if let radio = playable.asRadio {
@@ -576,7 +579,9 @@ class BackendAudioPlayer: NSObject {
         guard let accountInfo = playable.account?.info else {
           throw BackendError.noCredentials
         }
-        return try await getBackendApiCB(accountInfo).generateUrl(
+        let backendApi = getBackendApiCB(accountInfo)
+        streamHeaders = backendApi.customHTTPHeaders
+        return try await backendApi.generateUrl(
           forStreamingPlayable: playable.info,
           maxBitrate: streamingMaxBitrate,
           formatPreference: streamingTranscodingFormat
@@ -605,7 +610,8 @@ class BackendAudioPlayer: NSObject {
       playable: playable,
       withUrl: streamUrl,
       streamingMaxBitrate: streamingMaxBitrate,
-      queueType: queueType
+      queueType: queueType,
+      httpHeaders: streamHeaders
     )
   }
 
@@ -613,7 +619,8 @@ class BackendAudioPlayer: NSObject {
     playable: AbstractPlayable,
     withUrl url: URL,
     streamingMaxBitrate: StreamingMaxBitratePreference = .noLimit,
-    queueType: BackendAudioQueueType
+    queueType: BackendAudioQueueType,
+    httpHeaders: [String: String] = [:]
   ) {
     if queueType == .play {
       seekTimeWhenStarted = nil
@@ -627,12 +634,13 @@ class BackendAudioPlayer: NSObject {
     } else {
       asset = AVURLAsset(url: url)
     }
-    playInPlayer(asset: asset, queueType: queueType)
+    playInPlayer(asset: asset, queueType: queueType, httpHeaders: httpHeaders)
   }
 
   private func playInPlayer(
     asset: AVURLAsset?,
-    queueType: BackendAudioQueueType
+    queueType: BackendAudioQueueType,
+    httpHeaders: [String: String] = [:]
   ) {
     guard let asset = asset else {
       clearPlayer()
@@ -642,10 +650,18 @@ class BackendAudioPlayer: NSObject {
     switch queueType {
     case .play:
       currentPreparedUrl = asset.url.absoluteString
-      player?.play(url: asset.url)
+      if httpHeaders.isEmpty {
+        player?.play(url: asset.url)
+      } else {
+        player?.play(url: asset.url, headers: httpHeaders)
+      }
     case .queue:
       nextPreloadedUrl = asset.url.absoluteString
-      player?.queue(url: asset.url)
+      if httpHeaders.isEmpty {
+        player?.queue(url: asset.url)
+      } else {
+        player?.queue(url: asset.url, headers: httpHeaders)
+      }
     }
   }
 

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -552,7 +552,7 @@ class BackendAudioPlayer: NSObject {
     let streamingTranscodingFormat = streamingTranscodings.getActive(networkMonitor: networkMonitor)
     // Custom headers (e.g. Cloudflare Access service token) for the backend server stream. Radio
     // streams point to arbitrary external URLs, so they keep the empty default.
-    var streamHeaders: [String: String] = [:]
+    var httpHeaders: [String: String] = [:]
     @MainActor
     func provideUrl() async throws -> URL {
       if let radio = playable.asRadio {
@@ -580,7 +580,7 @@ class BackendAudioPlayer: NSObject {
           throw BackendError.noCredentials
         }
         let backendApi = getBackendApiCB(accountInfo)
-        streamHeaders = backendApi.customHTTPHeaders
+        httpHeaders = backendApi.httpHeaders
         return try await backendApi.generateUrl(
           forStreamingPlayable: playable.info,
           maxBitrate: streamingMaxBitrate,
@@ -611,7 +611,7 @@ class BackendAudioPlayer: NSObject {
       withUrl: streamUrl,
       streamingMaxBitrate: streamingMaxBitrate,
       queueType: queueType,
-      httpHeaders: streamHeaders
+      httpHeaders: httpHeaders
     )
   }
 

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -550,8 +550,6 @@ class BackendAudioPlayer: NSObject {
   ) async throws {
     let streamingMaxBitrate = streamingMaxBitrates.getActive(networkMonitor: networkMonitor)
     let streamingTranscodingFormat = streamingTranscodings.getActive(networkMonitor: networkMonitor)
-    // Custom headers (e.g. Cloudflare Access service token) for the backend server stream. Radio
-    // streams point to arbitrary external URLs, so they keep the empty default.
     var httpHeaders: [String: String] = [:]
     @MainActor
     func provideUrl() async throws -> URL {

--- a/AmperfyKit/Storage/DownloadRequestManager.swift
+++ b/AmperfyKit/Storage/DownloadRequestManager.swift
@@ -27,6 +27,7 @@ import Foundation
 struct DownloadTaskInfo: Sendable {
   let request: DownloadRequest
   let url: URL
+  var httpHeaders: [String: String] = [:]
   var hasStarted = false
 }
 

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -192,7 +192,7 @@ final class MOCK_LibrarySyncer: LibrarySyncer {
 final class MOCK_DownloadManagerDelegate: DownloadManagerDelegate {
   var requestPredicate: NSPredicate { NSPredicate(value: true) }
   let parallelDownloadsCount = 2
-  let customHTTPHeaders: [String: String] = [:]
+  let httpHeaders: [String: String] = [:]
   func prepareDownload(
     downloadInfo: AmperfyKit.DownloadElementInfo,
     storage: AmperfyKit.AsyncCoreDataAccessWrapper
@@ -220,7 +220,7 @@ final class MOCK_DownloadManagerDelegate: DownloadManagerDelegate {
 final class MOCK_BackendApi: BackendApi {
   let clientApiVersion: String = ""
   let serverApiVersion: String = ""
-  let customHTTPHeaders: [String: String] = [:]
+  let httpHeaders: [String: String] = [:]
   func provideCredentials(credentials: LoginCredentials) {}
   func isAuthenticationValid(credentials: LoginCredentials) async throws {
     throw BackendError.notSupported

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -192,6 +192,7 @@ final class MOCK_LibrarySyncer: LibrarySyncer {
 final class MOCK_DownloadManagerDelegate: DownloadManagerDelegate {
   var requestPredicate: NSPredicate { NSPredicate(value: true) }
   let parallelDownloadsCount = 2
+  let customHTTPHeaders: [String: String] = [:]
   func prepareDownload(
     downloadInfo: AmperfyKit.DownloadElementInfo,
     storage: AmperfyKit.AsyncCoreDataAccessWrapper
@@ -219,6 +220,7 @@ final class MOCK_DownloadManagerDelegate: DownloadManagerDelegate {
 final class MOCK_BackendApi: BackendApi {
   let clientApiVersion: String = ""
   let serverApiVersion: String = ""
+  let customHTTPHeaders: [String: String] = [:]
   func provideCredentials(credentials: LoginCredentials) {}
   func isAuthenticationValid(credentials: LoginCredentials) async throws {
     throw BackendError.notSupported


### PR DESCRIPTION
First of all, thank you for all the effort you've put into Amperfy, @BLeeEZ. It's an amazing app for enjoying music across Apple's platforms, and I've been using it for quite some time.

## Summary

Adds the ability to configure **custom HTTP headers per server connection**, sent with **every** request Amperfy makes to the backend (API calls, audio streaming, downloads, artwork, and the login reachability check).

My motivation: I self-host **Navidrome** behind **Cloudflare Zero Trust**. The Cloudflare Access policy requires an **email OTP** for interactive logins, which a native app cannot satisfy. Cloudflare Access supports **service tokens** for non-interactive clients — you send `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers and the request bypasses the interactive policy. Before this change there was no way to attach those headers, so Amperfy could not reach a server protected this way.

The feature is generic (any `key: value` header), so it also helps with Authelia, reverse proxies that require a static auth header, etc. — it is not Cloudflare-specific.

## My setup (architecture)

```
      iPhone (Amperfy)
         │  HTTPS, every request carries:
         │  CF-Access-Client-Id / CF-Access-Client-Secret
         ▼
      Cloudflare edge ──── Access policy:
         │                 • browsers → email OTP
         │                 • Amperfy  → service token bypass
         ▼
      Cloudflare Tunnel (cloudflared, in my homelab)
         ▼
      Navidrome (Subsonic API)  @  music.example.com
```

Navidrome is never exposed directly; it is only reachable through the Cloudflare Tunnel, and Access enforces auth at the edge. The service token lets a trusted client through without weakening the OTP policy for everyone else.

## What changed

- `LoginCredentials` gains a `customHTTPHeaders: [String: String]` (Codable, backward compatible — existing accounts decode with an empty default).
- New `customHTTPHeaders` accessor on the `BackendApi` protocol (Subsonic, Ampache, proxy).
- Headers are injected at every outbound network path:
  - Subsonic & Ampache API requests (Alamofire) — including the **login** path, so the very first auth/reachability request already carries the headers.
  - The server reachability check in `BackendProxy`.
  - Audio streaming (via `AudioStreaming`'s `play(url:headers:)` / `queue(url:headers:)`).
  - Song & artwork downloads (background `URLSession`).
- UI: a reusable generic key/value editor (`CustomHTTPHeadersView`) with a one-tap "Add Cloudflare Access Token" preset, reachable both from the **Login** screen and from **Settings → Account → Custom HTTP Headers** (live-applied without a restart).

## Relation to #695

#695 tackles a similar goal with a different approach: an embedded browser that performs the interactive zero-trust login and persists cookies. This PR is complementary — static headers (service token) for users who prefer a non-interactive credential and don't want an embedded web login. The two approaches can coexist.

## Testing

- Builds cleanly for iOS (Xcode 26.5).
- `AmperfyKitTests` pass (the only failures are a pre-existing, timezone-dependent `PodcastEpisodesParserTest`, unrelated to this change — confirmed identical on `master`).
- Verified end-to-end on a physical **iPhone 15 Pro Max** against my real Navidrome + Cloudflare Access service-token setup: login, library sync, streaming, downloads and artwork all work; editing headers in Settings takes effect without a restart.

## Security note

Custom header values are stored alongside the existing credentials in `UserDefaults`, the same way the password already is. Moving credential storage to the Keychain would be a reasonable follow-up but is out of scope here.

## Screenshots

**1. "Custom HTTP Headers" button on the Login screen**

<img width="1290" height="2796" alt="01-login-custom-headers-button" src="https://github.com/user-attachments/assets/11226cf0-6b60-4827-9caf-0b5f0e9fa8f6" />

**2. Header editor with the one-tap Cloudflare Access token preset**

<img width="1290" height="2796" alt="02-custom-http-headers-editor" src="https://github.com/user-attachments/assets/37b22e80-9486-4c92-b145-710010c55f1d" />

**3. Connected to Navidrome through Cloudflare (Account view)**

<img width="1290" height="2796" alt="03-account-connected-via-cloudflare" src="https://github.com/user-attachments/assets/de377ba4-035f-421e-9a33-ff9eac71e6ba" />

**4. Library synced through the tunnel**

<img width="645" height="1398" alt="04-library-synced" src="https://github.com/user-attachments/assets/79573c27-903c-4906-87e1-046234fbbd3d" />

**5. Streaming and artwork working**

<img width="645" height="1398" alt="05-streaming-and-artwork" src="https://github.com/user-attachments/assets/6b56f000-e72e-49f8-aa7a-177174d67fd8" />