### PR TITLE
feat(auth): add Cloudflare Access service-token authentication

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -205,7 +205,6 @@
 		50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */; };
 		50BE5D542850F4E700156FC6 /* SubsonicVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */; };
 		50BE5D552850F4E700156FC6 /* UtilitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5090963726496A9500DD9826 /* UtilitiesTest.swift */; };
-		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
 		50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */; };
 		50BE5D572850F4F600156FC6 /* album_missing_artistId.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50ED2B9227BB932700331BF7 /* album_missing_artistId.xml */; };
 		50BE5D582850F4F600156FC6 /* artist_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AB92C526661F5800DCE45C /* artist_example_1.xml */; };
@@ -530,10 +529,14 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
-		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		84625E0C03B157E25B3263F9 /* CloudflareAccessTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF41DAA880C7CA5841A0F24D /* CloudflareAccessTest.swift */; };
+		99F511255FC6DA0801C84285 /* CloudflareAccessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0FE05DE4A986308757879F /* CloudflareAccessSettingsView.swift */; };
+		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
+		D6E1087E09291130C536EA72 /* CloudflareAccessCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711A55AA94CD590AAC390806 /* CloudflareAccessCredentialStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -840,7 +843,6 @@
 		509001C027182A1300A8056D /* CatalogParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserTest.swift; sourceTree = "<group>"; };
 		509001C227182A4700A8056D /* CatalogParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserDelegate.swift; sourceTree = "<group>"; };
 		5090963726496A9500DD9826 /* UtilitiesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTest.swift; sourceTree = "<group>"; };
-		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
 		509357512E3BF47800CD4075 /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
 		509362EC28E041FF005C2AAC /* Amperfy v28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v28.xcdatamodel"; sourceTree = "<group>"; };
 		50947E0227DA011F00C368D7 /* ScrobbleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleEntry.swift; sourceTree = "<group>"; };
@@ -1148,12 +1150,16 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
-		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		711A55AA94CD590AAC390806 /* CloudflareAccessCredentialStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudflareAccessCredentialStore.swift; sourceTree = "<group>"; };
+		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
+		BC0FE05DE4A986308757879F /* CloudflareAccessSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudflareAccessSettingsView.swift; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
+		FF41DAA880C7CA5841A0F24D /* CloudflareAccessTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CloudflareAccessTest.swift; path = ../Api/CloudflareAccessTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1332,6 +1338,7 @@
 				505CA1F42B848B8300AA81CD /* QuickActionsHandler.swift */,
 				5021B1272BC723F400893C33 /* FuzzySearcher.swift */,
 				09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */,
+				711A55AA94CD590AAC390806 /* CloudflareAccessCredentialStore.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1434,6 +1441,7 @@
 				50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */,
 				50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */,
 				50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */,
+				BC0FE05DE4A986308757879F /* CloudflareAccessSettingsView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -2142,6 +2150,7 @@
 				50DB11A8266536190033BFFA /* Subsonic */,
 				50DB1180266501EC0033BFFA /* Ampache */,
 				50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */,
+				FF41DAA880C7CA5841A0F24D /* CloudflareAccessTest.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -2631,6 +2640,7 @@
 				50AB3B3C2F01D5AC00556CE4 /* OpenAppWithConfigurationIntent.swift in Sources */,
 				50C171482D10644600C0C53A /* PlaylistAddAlbumDetailVC.swift in Sources */,
 				50DE29EB2B8FCEB700ABA78E /* LibraryNavigatorConfigurator.swift in Sources */,
+				99F511255FC6DA0801C84285 /* CloudflareAccessSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2831,6 +2841,7 @@
 				50C9D6A4284FAA77007F18D0 /* MappingModelV10toV11.xcmappingmodel in Sources */,
 				50C9D697284FAA6C007F18D0 /* PlaylistMO+CoreDataProperties.swift in Sources */,
 				50C9D6D9284FAB88007F18D0 /* EmbeddedArtworkExtractor.swift in Sources */,
+				D6E1087E09291130C536EA72 /* CloudflareAccessCredentialStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2896,6 +2907,7 @@
 				50BE5D8A2850F50F00156FC6 /* ErrorParserTest.swift in Sources */,
 				50BE5D942850F51E00156FC6 /* UnitTestHelper.swift in Sources */,
 				50AE79B82C1F68090085CBB3 /* SsLyricsBySongId2ParserTest.swift in Sources */,
+				84625E0C03B157E25B3263F9 /* CloudflareAccessTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -166,6 +166,72 @@ class LoginVC: UIViewController {
     return button
   }()
 
+  // Cloudflare Access service-token values entered via the Advanced Login Settings popup.
+  // The presence of both a client id and secret enables the feature for the new account.
+  private var cloudflareClientId: String = ""
+  private var cloudflareClientSecret: String = ""
+
+  fileprivate lazy var advancedSettingsButton: UIButton = {
+    var config = UIButton.Configuration.glass()
+    let button = UIButton(configuration: config)
+    button.setTitle("Advanced Login Settings", for: .normal)
+    button.addTarget(
+      self,
+      action: #selector(Self.advancedSettingsPressed),
+      for: .touchUpInside
+    )
+    button.preferredBehavioralStyle = .pad
+    return button
+  }()
+
+  @IBAction
+  func advancedSettingsPressed() {
+    serverUrlTF.resignFirstResponder()
+    usernameTF.resignFirstResponder()
+    passwordTF.resignFirstResponder()
+    presentCloudflareAccessDialog()
+  }
+
+  private func presentCloudflareAccessDialog() {
+    let alert = UIAlertController(
+      title: "Cloudflare Access Service Token",
+      message: "Optional. Provide a Client ID and Client Secret to authenticate through Cloudflare Access. Leave both empty to disable.",
+      preferredStyle: .alert
+    )
+    alert.addTextField { tf in
+      tf.placeholder = "Client ID"
+      tf.autocorrectionType = .no
+      tf.autocapitalizationType = .none
+      tf.text = self.cloudflareClientId
+    }
+    alert.addTextField { tf in
+      tf.placeholder = "Client Secret"
+      tf.isSecureTextEntry = true
+      tf.autocorrectionType = .no
+      tf.autocapitalizationType = .none
+      tf.text = self.cloudflareClientSecret
+    }
+    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Save", style: .default) { _ in
+      self.cloudflareClientId = alert.textFields?.first?.text?
+        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      self.cloudflareClientSecret = alert.textFields?.last?.text ?? ""
+      self.updateAdvancedSettingsButtonTitle()
+    })
+    present(alert, animated: true)
+  }
+
+  private var isCloudflareAccessConfigured: Bool {
+    !cloudflareClientId.isEmpty && !cloudflareClientSecret.isEmpty
+  }
+
+  private func updateAdvancedSettingsButtonTitle() {
+    let title = isCloudflareAccessConfigured
+      ? "Advanced Login Settings (CF Access set)"
+      : "Advanced Login Settings"
+    advancedSettingsButton.setTitle(title, for: .normal)
+  }
+
   fileprivate lazy var loginButton: UIButton = {
     var config = UIButton.Configuration.prominentGlass()
     config.image = .login
@@ -201,10 +267,45 @@ class LoginVC: UIViewController {
 
   @IBAction
   func loginPressed() {
-    serverUrlTF.resignFirstResponder()
-    usernameTF.resignFirstResponder()
-    passwordTF.resignFirstResponder()
+    dismissKeyboard()
     login()
+  }
+
+  @objc
+  func dismissKeyboard() {
+    view.endEditing(true)
+  }
+
+  @objc
+  private func keyboardWillChangeFrame(_ notification: Notification) {
+    guard let userInfo = notification.userInfo,
+          let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?
+          .cgRectValue,
+          let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+    else { return }
+
+    // Force layout so the form frame is up to date, then measure how far the form's bottom
+    // (including the login button below it) extends past the top of the keyboard.
+    view.layoutIfNeeded()
+    let keyboardTopInViewY = view.bounds.height - keyboardFrame.height
+    let formBottomInViewY = loginGlassContainer.frame.maxY
+    let overlap = formBottomInViewY - keyboardTopInViewY
+
+    let shift = overlap > 0 ? -(overlap + 16) : 0
+    formCenterYConstraint?.constant = shift
+    UIView.animate(withDuration: duration) {
+      self.view.layoutIfNeeded()
+    }
+  }
+
+  @objc
+  private func keyboardWillHide(_ notification: Notification) {
+    let duration = (notification
+      .userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
+    formCenterYConstraint?.constant = 0
+    UIView.animate(withDuration: duration) {
+      self.view.layoutIfNeeded()
+    }
   }
 
   public lazy var formView: UIView = {
@@ -213,6 +314,7 @@ class LoginVC: UIViewController {
     self.passwordTF.translatesAutoresizingMaskIntoConstraints = false
     apiLabel.translatesAutoresizingMaskIntoConstraints = false
     self.apiSelectorButton.translatesAutoresizingMaskIntoConstraints = false
+    self.advancedSettingsButton.translatesAutoresizingMaskIntoConstraints = false
 
     let view = UIView()
     view.addSubview(serverUrlTF)
@@ -220,6 +322,7 @@ class LoginVC: UIViewController {
     view.addSubview(passwordTF)
     view.addSubview(apiLabel)
     view.addSubview(apiSelectorButton)
+    view.addSubview(advancedSettingsButton)
 
     let padding: CGFloat = 0
     let elementHeight: CGFloat = 40
@@ -288,8 +391,22 @@ class LoginVC: UIViewController {
       ),
       apiSelectorButton.heightAnchor.constraint(equalToConstant: elementHeight),
 
+      advancedSettingsButton.safeAreaLayoutGuide.topAnchor.constraint(
+        equalTo: apiSelectorButton.bottomAnchor,
+        constant: spaceInBetween
+      ),
+      advancedSettingsButton.safeAreaLayoutGuide.leadingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+        constant: padding
+      ),
+      advancedSettingsButton.safeAreaLayoutGuide.trailingAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+        constant: -padding
+      ),
+      advancedSettingsButton.heightAnchor.constraint(equalToConstant: elementHeight),
+
       view.heightAnchor
-        .constraint(equalToConstant: (4 * elementHeight) + (3 * spaceInBetween) + (2 * padding)),
+        .constraint(equalToConstant: (5 * elementHeight) + (4 * spaceInBetween) + (2 * padding)),
     ])
 
     return view
@@ -302,6 +419,7 @@ class LoginVC: UIViewController {
   var formLeadingConstraing: NSLayoutConstraint?
   var formTrailingConstraing: NSLayoutConstraint?
   var formWitdhConstraing: NSLayoutConstraint?
+  var formCenterYConstraint: NSLayoutConstraint?
 
   public lazy var mainContainerView: UIView = {
     self.formView.translatesAutoresizingMaskIntoConstraints = false
@@ -388,12 +506,28 @@ class LoginVC: UIViewController {
     }
 
     var credentials = LoginCredentials(serverUrl: serverUrl, username: username, password: password)
+
+    if isCloudflareAccessConfigured {
+      credentials.isCloudflareAccessEnabled = true
+      credentials.cloudflareAccessClientId = cloudflareClientId
+    }
+
     var accountInfo = Account.createInfo(credentials: credentials)
 
     guard !appDelegate.storage.settings.accounts.allAccounts.contains(where: { $0 == accountInfo })
     else {
       showErrorMsg(message: "Account already added!")
       return
+    }
+
+    // Persist the secret to the Keychain before authentication so the login probe can use it.
+    // The account ident is based on the server URL + username, so it is stable across API
+    // auto-detection (only `backendApi` changes, which is not part of the ident hash).
+    if credentials.isCloudflareAccessEnabled {
+      CloudflareAccessCredentialStore.shared.setSecret(
+        cloudflareClientSecret,
+        forAccountIdent: accountInfo.ident
+      )
     }
 
     Task { @MainActor in
@@ -450,6 +584,25 @@ class LoginVC: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     updateApiSelectorText()
+    updateAdvancedSettingsButtonTitle()
+
+    // Tap anywhere outside the text fields to dismiss the keyboard.
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(Self.dismissKeyboard))
+    tapGesture.cancelsTouchesInView = false
+    view.addGestureRecognizer(tapGesture)
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(Self.keyboardWillChangeFrame(_:)),
+      name: UIResponder.keyboardWillChangeFrameNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(Self.keyboardWillHide(_:)),
+      name: UIResponder.keyboardWillHideNotification,
+      object: nil
+    )
 
     apiSelectorButton.showsMenuAsPrimaryAction = true
     apiSelectorButton.menu = UIMenu(title: "Select API", children: [
@@ -506,13 +659,18 @@ class LoginVC: UIViewController {
       multiplier: 1.0,
       constant: 0
     ))
+    formCenterYConstraint = formGlassContainer.centerYAnchor.constraint(
+      equalTo: view.centerYAnchor,
+      constant: 0
+    )
+
     NSLayoutConstraint.activate([
       amperfyLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0),
       amperfyLabel.bottomAnchor.constraint(equalTo: formGlassContainer.topAnchor, constant: -30),
       amperfyLabel.heightAnchor.constraint(equalToConstant: 60),
 
       formGlassContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0),
-      formGlassContainer.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 0),
+      formCenterYConstraint!,
       formWitdhConstraing!,
       formLeadingConstraing!,
       formTrailingConstraing!,
@@ -584,6 +742,12 @@ class LoginVC: UIViewController {
       .loginCredentials {
       serverUrlTF.text = credentials.serverUrl
       usernameTF.text = credentials.username
+      if credentials.isCloudflareAccessEnabled {
+        cloudflareClientId = credentials.cloudflareAccessClientId
+        cloudflareClientSecret = CloudflareAccessCredentialStore.shared
+          .getSecret(forAccountIdent: Account.createInfo(credentials: credentials).ident) ?? ""
+      }
+      updateAdvancedSettingsButtonTitle()
     }
   }
 

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -30,6 +30,8 @@ struct AccountSettingsView: View {
   @State
   var isPwUpdateDialogVisible = false
   @State
+  var isCloudflareAccessDialogVisible = false
+  @State
   var isShowLogoutAlert = false
   @State
   var isShowResyncLibraryAlert = false
@@ -77,6 +79,8 @@ struct AccountSettingsView: View {
 
     // delete cached files
     CacheFileManager.shared.deleteAccountCache(accountInfo: accountInfo)
+    // remove the Cloudflare Access secret from the Keychain
+    CloudflareAccessCredentialStore.shared.removeSecret(forAccountIdent: accountInfo.ident)
     // reset login credentials -> at new start the login view is presented to auth and resync library
     appDelegate.storage.settings.accounts.logout(accountInfo)
     appDelegate.notificationHandler.post(name: .accountDeleted, object: nil, userInfo: nil)
@@ -216,6 +220,18 @@ struct AccountSettingsView: View {
           }
 
           SettingsSection {
+            SettingsRow(title: "Cloudflare Access", splitPercentage: splitPercentage) {
+              SecondaryText(
+                appDelegate.storage.settings.accounts.getSetting(settings.activeAccountInfo).read
+                  .loginCredentials?.isCloudflareAccessEnabled == true ? "Enabled" : "Disabled"
+              )
+            }
+            SettingsButtonRow(title: "Configure Service Token") {
+              withPopupAnimation { isCloudflareAccessDialogVisible = true }
+            }
+          }
+
+          SettingsSection {
             SettingsButtonRow(title: "Update Password") {
               withPopupAnimation { isPwUpdateDialogVisible = true }
             }
@@ -264,6 +280,9 @@ struct AccountSettingsView: View {
     .navigationBarTitleDisplayMode(.inline)
     .sheet(isPresented: $isPwUpdateDialogVisible) {
       UpdatePasswordView(isVisible: $isPwUpdateDialogVisible)
+    }
+    .sheet(isPresented: $isCloudflareAccessDialogVisible) {
+      CloudflareAccessSettingsView(isVisible: $isCloudflareAccessDialogVisible)
     }
   }
 }

--- a/Amperfy/SwiftUI/Settings/Account/CloudflareAccessSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/CloudflareAccessSettingsView.swift
@@ -1,0 +1,180 @@
+//
+//  CloudflareAccessSettingsView.swift
+//  Amperfy
+//
+//  Created by Jerzy Królak on 17.06.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+
+// MARK: - CloudflareAccessSettingsView
+
+struct CloudflareAccessSettingsView: View {
+  @Binding
+  var isVisible: Bool
+
+  @State
+  var isEnabled = false
+  @State
+  var clientIdInput = ""
+  // The stored secret is never read back into the UI. An empty field means "keep existing".
+  @State
+  var clientSecretInput = ""
+  @State
+  var hasStoredSecret = false
+  @State
+  var errorMsg = ""
+  @State
+  var successMsg = ""
+
+  @EnvironmentObject
+  var settings: Settings
+
+  private func loadCurrentValues() {
+    errorMsg = ""
+    successMsg = ""
+    guard let activeAccountInfo = settings.activeAccountInfo,
+          let credentials = appDelegate.storage.settings.accounts.getSetting(activeAccountInfo)
+          .read.loginCredentials
+    else { return }
+    isEnabled = credentials.isCloudflareAccessEnabled
+    clientIdInput = credentials.cloudflareAccessClientId
+    hasStoredSecret = CloudflareAccessCredentialStore.shared
+      .hasSecret(forAccountIdent: activeAccountInfo.ident)
+    clientSecretInput = ""
+  }
+
+  private func save() {
+    errorMsg = ""
+    successMsg = ""
+    guard let activeAccountInfo = settings.activeAccountInfo else {
+      errorMsg = "No active account."
+      return
+    }
+
+    if isEnabled {
+      let clientId = clientIdInput.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !clientId.isEmpty else {
+        errorMsg = "Please provide a Client ID."
+        return
+      }
+      let willHaveSecret = !clientSecretInput.isEmpty || hasStoredSecret
+      guard willHaveSecret else {
+        errorMsg = "Please provide a Client Secret."
+        return
+      }
+      if !clientSecretInput.isEmpty {
+        CloudflareAccessCredentialStore.shared.setSecret(
+          clientSecretInput,
+          forAccountIdent: activeAccountInfo.ident
+        )
+      }
+      applyCredentialsUpdate(
+        activeAccountInfo: activeAccountInfo,
+        enabled: true,
+        clientId: clientId
+      )
+    } else {
+      // Disabling: remove the stored secret and clear the configuration.
+      CloudflareAccessCredentialStore.shared.removeSecret(forAccountIdent: activeAccountInfo.ident)
+      applyCredentialsUpdate(activeAccountInfo: activeAccountInfo, enabled: false, clientId: "")
+    }
+
+    successMsg = "Cloudflare Access settings saved."
+    clientSecretInput = ""
+    hasStoredSecret = CloudflareAccessCredentialStore.shared
+      .hasSecret(forAccountIdent: activeAccountInfo.ident)
+  }
+
+  private func applyCredentialsUpdate(
+    activeAccountInfo: AccountInfo,
+    enabled: Bool,
+    clientId: String
+  ) {
+    appDelegate.storage.settings.accounts.updateSetting(activeAccountInfo) { accountSettings in
+      accountSettings.loginCredentials?.isCloudflareAccessEnabled = enabled
+      accountSettings.loginCredentials?.cloudflareAccessClientId = clientId
+    }
+    if let updated = appDelegate.storage.settings.accounts.getSetting(activeAccountInfo).read
+      .loginCredentials {
+      appDelegate.getMeta(activeAccountInfo).backendApi.provideCredentials(credentials: updated)
+    }
+  }
+
+  var body: some View {
+    ZStack {
+      List {
+        Section {
+          VStack(spacing: 20) {
+            Text("Cloudflare Access Service Token")
+              .font(.title2).fontWeight(.bold).padding(.all, 10)
+
+            if !successMsg.isEmpty {
+              InfoBannerView(message: successMsg, color: .success)
+            }
+            if !errorMsg.isEmpty {
+              InfoBannerView(message: errorMsg, color: .error)
+            }
+
+            Toggle("Enable Service Token", isOn: $isEnabled)
+
+            if isEnabled {
+              VStack(spacing: 5) {
+                TextField("Client ID", text: $clientIdInput)
+                  .textFieldStyle(.roundedBorder)
+                  .autocorrectionDisabled(true)
+                  .textInputAutocapitalization(.never)
+                SecureField(
+                  hasStoredSecret ? "Client Secret (leave blank to keep)" : "Client Secret",
+                  text: $clientSecretInput
+                )
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
+              }
+            }
+          }
+
+          HStack {
+            Button(action: { isVisible = false }) {
+              HStack { Spacer(); Text("Cancel").fontWeight(.semibold); Spacer() }
+            }
+            .buttonStyle(DefaultButtonStyle())
+            Spacer()
+            Button(action: { save() }) {
+              HStack { Spacer(); Text("Save"); Spacer() }
+            }
+            .buttonStyle(DefaultButtonStyle())
+          }
+          .padding([.top], 8)
+        }
+        #if targetEnvironment(macCatalyst) /// ok
+        .listRowBackground(Color.clear)
+        #else
+        .padding()
+        #endif
+      }
+      #if targetEnvironment(macCatalyst) // ok
+      .listStyle(.plain)
+      #endif
+    }
+    .onAppear {
+      loadCurrentValues()
+    }
+  }
+}

--- a/AmperfyKit/Api/Ampache/AmpacheApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheApi.swift
@@ -45,6 +45,10 @@ final class AmpacheApi: BackendApi {
 
   public var serverApiVersion: String { ampacheXmlServerApi.serverApiVersion.wrappedValue ?? "-" }
 
+  public var cloudflareAccessHeaders: [String: String] {
+    ampacheXmlServerApi.cloudflareAccessHeaders
+  }
+
   func provideCredentials(credentials: LoginCredentials) {
     ampacheXmlServerApi.provideCredentials(credentials: credentials)
   }

--- a/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheXmlServerApi.swift
@@ -165,6 +165,10 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
     self.credentials.wrappedValue = credentials
   }
 
+  var cloudflareAccessHeaders: [String: String] {
+    credentials.wrappedValue?.cloudflareAccessHeaders ?? [:]
+  }
+
   private func authenticate(credentials: LoginCredentials) async throws
     -> AuthentificationHandshake {
     do {
@@ -178,6 +182,9 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
   }
 
   func isAuthenticationValid(credentials: LoginCredentials) async throws {
+    // Store credentials up front so Cloudflare Access headers are attached to the
+    // handshake request, not just to requests made after login succeeds.
+    provideCredentials(credentials: credentials)
     try await requestAuth(credentials: credentials)
   }
 
@@ -741,8 +748,9 @@ final class AmpacheXmlServerApi: URLCleanser, Sendable {
   }
 
   private func request(url: URL) async throws -> APIDataResponse {
-    try await withUnsafeThrowingContinuation { continuation in
-      AF.request(url, method: .get).validate().responseData { response in
+    let headers = HTTPHeaders(credentials.wrappedValue?.cloudflareAccessHeaders ?? [:])
+    return try await withUnsafeThrowingContinuation { continuation in
+      AF.request(url, method: .get, headers: headers).validate().responseData { response in
 
         if let data = response.data {
           continuation.resume(returning: APIDataResponse(data: data, url: url))

--- a/AmperfyKit/Api/BackendApi.swift
+++ b/AmperfyKit/Api/BackendApi.swift
@@ -260,6 +260,9 @@ public struct TranscodingInfo {
 public protocol BackendApi: URLCleanser, Sendable {
   var clientApiVersion: String { get }
   var serverApiVersion: String { get }
+  /// Cloudflare Access service-token headers for the active credentials, or empty when disabled.
+  /// Used to authorise streaming requests, which bypass the Alamofire/URLSession request paths.
+  var cloudflareAccessHeaders: [String: String] { get }
   func provideCredentials(credentials: LoginCredentials)
   func isAuthenticationValid(credentials: LoginCredentials) async throws
   func generateUrl(forDownloadingPlayable playableInfo: AbstractPlayableInfo) async throws -> URL

--- a/AmperfyKit/Api/BackendProxy.swift
+++ b/AmperfyKit/Api/BackendProxy.swift
@@ -320,7 +320,10 @@ public final class BackendProxy: Sendable {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
       let sessionConfig = URLSessionConfiguration.default
       let session = URLSession(configuration: sessionConfig)
-      let request = URLRequest(url: activeBackendServerUrl)
+      var request = URLRequest(url: activeBackendServerUrl)
+      for (field, value) in credentials.cloudflareAccessHeaders {
+        request.setValue(value, forHTTPHeaderField: field)
+      }
       let task = session.downloadTask(with: request) { tempLocalUrl, response, error in
         if let error = error {
           continuation
@@ -355,6 +358,8 @@ extension BackendProxy: BackendApi {
   public var clientApiVersion: String { activeApi.clientApiVersion }
 
   public var serverApiVersion: String { activeApi.serverApiVersion }
+
+  public var cloudflareAccessHeaders: [String: String] { activeApi.cloudflareAccessHeaders }
 
   public func provideCredentials(credentials: LoginCredentials) {
     activeApi.provideCredentials(credentials: credentials)

--- a/AmperfyKit/Api/LoginCredentials.swift
+++ b/AmperfyKit/Api/LoginCredentials.swift
@@ -22,6 +22,9 @@
 import Foundation
 
 public struct LoginCredentials: Sendable, Codable {
+  public static let cloudflareAccessClientIdHeader = "CF-Access-Client-Id"
+  public static let cloudflareAccessClientSecretHeader = "CF-Access-Client-Secret"
+
   private enum CodingKeys: String, CodingKey {
     case serverUrl
     case username
@@ -29,6 +32,8 @@ public struct LoginCredentials: Sendable, Codable {
     case backendApi
     case activeBackendServerUrl
     case alternativeServerURLs
+    case isCloudflareAccessEnabled
+    case cloudflareAccessClientId
   }
 
   public var serverUrl: String
@@ -39,6 +44,11 @@ public struct LoginCredentials: Sendable, Codable {
   public var activeBackendServerUrl: String
   public var alternativeServerURLs: [String]
 
+  /// Whether Cloudflare Access service-token authentication is enabled for this server.
+  /// The client secret itself is stored in the Keychain, never here.
+  public var isCloudflareAccessEnabled: Bool
+  public var cloudflareAccessClientId: String
+
   public init() {
     self.serverUrl = ""
     self.username = ""
@@ -47,6 +57,8 @@ public struct LoginCredentials: Sendable, Codable {
     self.backendApi = .notDetected
     self.activeBackendServerUrl = ""
     self.alternativeServerURLs = []
+    self.isCloudflareAccessEnabled = false
+    self.cloudflareAccessClientId = ""
   }
 
   public var displayServerUrl: String {
@@ -74,6 +86,8 @@ public struct LoginCredentials: Sendable, Codable {
     self.backendApi = .notDetected
     self.activeBackendServerUrl = serverUrl
     self.alternativeServerURLs = []
+    self.isCloudflareAccessEnabled = false
+    self.cloudflareAccessClientId = ""
   }
 
   public init(serverUrl: String, username: String, password: String, backendApi: BackenApiType) {
@@ -96,6 +110,14 @@ public struct LoginCredentials: Sendable, Codable {
       [String].self,
       forKey: .alternativeServerURLs
     ) ?? []
+    self.isCloudflareAccessEnabled = try container.decodeIfPresent(
+      Bool.self,
+      forKey: .isCloudflareAccessEnabled
+    ) ?? false
+    self.cloudflareAccessClientId = try container.decodeIfPresent(
+      String.self,
+      forKey: .cloudflareAccessClientId
+    ) ?? ""
     self.passwordHash = StringHasher.sha256(dataString: password)
   }
 
@@ -107,10 +129,27 @@ public struct LoginCredentials: Sendable, Codable {
     try container.encode(backendApi, forKey: .backendApi)
     try container.encode(activeBackendServerUrl, forKey: .activeBackendServerUrl)
     try container.encode(alternativeServerURLs, forKey: .alternativeServerURLs)
+    try container.encode(isCloudflareAccessEnabled, forKey: .isCloudflareAccessEnabled)
+    try container.encode(cloudflareAccessClientId, forKey: .cloudflareAccessClientId)
   }
 
   public mutating func changePasswordAndHash(password newPassword: String) {
     password = newPassword
     passwordHash = StringHasher.sha256(dataString: newPassword)
+  }
+
+  /// The Cloudflare Access service-token headers to attach to every server-bound request,
+  /// or an empty dictionary when the feature is disabled or the secret is missing.
+  /// The secret is fetched from the Keychain on demand and never held in plaintext storage.
+  public var cloudflareAccessHeaders: [String: String] {
+    guard isCloudflareAccessEnabled, !cloudflareAccessClientId.isEmpty else { return [:] }
+    let ident = Account.createInfo(credentials: self).ident
+    guard let secret = CloudflareAccessCredentialStore.shared.getSecret(forAccountIdent: ident),
+          !secret.isEmpty
+    else { return [:] }
+    return [
+      Self.cloudflareAccessClientIdHeader: cloudflareAccessClientId,
+      Self.cloudflareAccessClientSecretHeader: secret,
+    ]
   }
 }

--- a/AmperfyKit/Api/Subsonic/SubsonicApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicApi.swift
@@ -62,6 +62,10 @@ extension SubsonicApi: BackendApi {
     subsonicServerApi.serverApiVersion.wrappedValue?.description ?? "-"
   }
 
+  public var cloudflareAccessHeaders: [String: String] {
+    subsonicServerApi.cloudflareAccessHeaders
+  }
+
   func provideCredentials(credentials: LoginCredentials) {
     subsonicServerApi.provideCredentials(credentials: credentials)
   }

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -255,6 +255,10 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     self.credentials.wrappedValue = credentials
   }
 
+  var cloudflareAccessHeaders: [String: String] {
+    credentials.wrappedValue?.cloudflareAccessHeaders ?? [:]
+  }
+
   public func cleanse(url: URL?) -> CleansedURL {
     guard let url = url,
           var urlComp = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -284,6 +288,9 @@ final class SubsonicServerApi: URLCleanser, Sendable {
   }
 
   public func isAuthenticationValid(credentials: LoginCredentials) async throws {
+    // Store credentials up front so Cloudflare Access headers are attached to the
+    // pre-login ping/version requests, not just to requests made after login succeeds.
+    provideCredentials(credentials: credentials)
     let version = try await determineApiVersionToUse(providedCredentials: credentials)
     let urlComp = try createAuthApiUrlComponent(
       version: version,
@@ -957,8 +964,9 @@ final class SubsonicServerApi: URLCleanser, Sendable {
   }
 
   private func request(url: URL) async throws -> APIDataResponse {
-    try await withUnsafeThrowingContinuation { continuation in
-      let afRequest = AF.request(url, method: .get)
+    let headers = HTTPHeaders(credentials.wrappedValue?.cloudflareAccessHeaders ?? [:])
+    return try await withUnsafeThrowingContinuation { continuation in
+      let afRequest = AF.request(url, method: .get, headers: headers)
       afRequest.validate().responseData { response in
         if response.response?.statusCode == 404 {
           let cleanedURL = self.cleanse(url: response.request?.url)

--- a/AmperfyKit/Common/CloudflareAccessCredentialStore.swift
+++ b/AmperfyKit/Common/CloudflareAccessCredentialStore.swift
@@ -1,0 +1,107 @@
+//
+//  CloudflareAccessCredentialStore.swift
+//  AmperfyKit
+//
+//  Created by Jerzy Królak on 17.06.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Security
+
+/// Securely stores Cloudflare Access service-token client secrets in the iOS Keychain.
+///
+/// Only the secret is kept here. The client id and the enabled flag live in
+/// `LoginCredentials` (UserDefaults), since they are not sensitive. The secret is
+/// keyed by account ident so each server has its own entry.
+public final class CloudflareAccessCredentialStore: Sendable {
+  public static let shared = CloudflareAccessCredentialStore()
+
+  private static let service = "amperfy.cloudflareAccess.clientSecret"
+
+  private init() {}
+
+  /// Stores (or replaces) the client secret for the given account ident.
+  /// Passing an empty string removes the entry.
+  @discardableResult
+  public func setSecret(_ secret: String, forAccountIdent ident: String) -> Bool {
+    guard !secret.isEmpty else {
+      return removeSecret(forAccountIdent: ident)
+    }
+    guard let data = secret.data(using: .utf8) else { return false }
+
+    var query = baseQuery(forAccountIdent: ident)
+    let attributes: [String: Any] = [
+      kSecValueData as String: data,
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+    ]
+
+    let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    if updateStatus == errSecSuccess {
+      return true
+    }
+    if updateStatus == errSecItemNotFound {
+      query[kSecValueData as String] = data
+      query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+      return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+    }
+    return false
+  }
+
+  /// Returns the stored client secret for the given account ident, if present.
+  public func getSecret(forAccountIdent ident: String) -> String? {
+    var query = baseQuery(forAccountIdent: ident)
+    query[kSecReturnData as String] = true
+    query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    guard status == errSecSuccess,
+          let data = result as? Data,
+          let secret = String(data: data, encoding: .utf8)
+    else { return nil }
+    return secret
+  }
+
+  public func hasSecret(forAccountIdent ident: String) -> Bool {
+    var query = baseQuery(forAccountIdent: ident)
+    query[kSecMatchLimit as String] = kSecMatchLimitOne
+    return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+  }
+
+  @discardableResult
+  public func removeSecret(forAccountIdent ident: String) -> Bool {
+    let query = baseQuery(forAccountIdent: ident)
+    let status = SecItemDelete(query as CFDictionary)
+    return status == errSecSuccess || status == errSecItemNotFound
+  }
+
+  /// Moves a secret stored under one ident to another. Used during login, when the
+  /// account ident is finalised only after the backend API type is detected.
+  public func migrateSecret(fromAccountIdent source: String, toAccountIdent destination: String) {
+    guard source != destination, let secret = getSecret(forAccountIdent: source) else { return }
+    setSecret(secret, forAccountIdent: destination)
+    removeSecret(forAccountIdent: source)
+  }
+
+  private func baseQuery(forAccountIdent ident: String) -> [String: Any] {
+    [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: Self.service,
+      kSecAttrAccount as String: ident,
+    ]
+  }
+}

--- a/AmperfyKit/MetaManager.swift
+++ b/AmperfyKit/MetaManager.swift
@@ -153,6 +153,7 @@ public class MetaManager {
       .background(
         withIdentifier: "\(Bundle.main.bundleIdentifier!).\(account.ident).PlayableDownloader.background"
       )
+    applyCloudflareAccessHeaders(to: configuration)
     let urlSession = URLSession(
       configuration: configuration,
       delegate: dlManager,
@@ -233,6 +234,7 @@ public class MetaManager {
       }
 
     let configuration = URLSessionConfiguration.default
+    applyCloudflareAccessHeaders(to: configuration)
     let urlSession = URLSession(
       configuration: configuration,
       delegate: dlManager,
@@ -245,6 +247,19 @@ public class MetaManager {
     )
 
     return dlManager
+  }
+
+  /// Attaches Cloudflare Access service-token headers to a download session configuration
+  /// when the active account has the feature enabled. No-op otherwise.
+  private func applyCloudflareAccessHeaders(to configuration: URLSessionConfiguration) {
+    let headers = settings.accounts.getSetting(account.info).read.loginCredentials?
+      .cloudflareAccessHeaders ?? [:]
+    guard !headers.isEmpty else { return }
+    var additionalHeaders = configuration.httpAdditionalHeaders ?? [:]
+    for (field, value) in headers {
+      additionalHeaders[field] = value
+    }
+    configuration.httpAdditionalHeaders = additionalHeaders
   }
 
   @MainActor

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -550,6 +550,8 @@ class BackendAudioPlayer: NSObject {
   ) async throws {
     let streamingMaxBitrate = streamingMaxBitrates.getActive(networkMonitor: networkMonitor)
     let streamingTranscodingFormat = streamingTranscodings.getActive(networkMonitor: networkMonitor)
+    // Cloudflare Access headers apply only to the user's own server (not to external radio hosts).
+    var streamHeaders: [String: String] = [:]
     @MainActor
     func provideUrl() async throws -> URL {
       if let radio = playable.asRadio {
@@ -576,7 +578,9 @@ class BackendAudioPlayer: NSObject {
         guard let accountInfo = playable.account?.info else {
           throw BackendError.noCredentials
         }
-        return try await getBackendApiCB(accountInfo).generateUrl(
+        let backendApi = getBackendApiCB(accountInfo)
+        streamHeaders = backendApi.cloudflareAccessHeaders
+        return try await backendApi.generateUrl(
           forStreamingPlayable: playable.info,
           maxBitrate: streamingMaxBitrate,
           formatPreference: streamingTranscodingFormat
@@ -605,6 +609,7 @@ class BackendAudioPlayer: NSObject {
       playable: playable,
       withUrl: streamUrl,
       streamingMaxBitrate: streamingMaxBitrate,
+      streamHeaders: streamHeaders,
       queueType: queueType
     )
   }
@@ -613,6 +618,7 @@ class BackendAudioPlayer: NSObject {
     playable: AbstractPlayable,
     withUrl url: URL,
     streamingMaxBitrate: StreamingMaxBitratePreference = .noLimit,
+    streamHeaders: [String: String] = [:],
     queueType: BackendAudioQueueType
   ) {
     if queueType == .play {
@@ -627,11 +633,12 @@ class BackendAudioPlayer: NSObject {
     } else {
       asset = AVURLAsset(url: url)
     }
-    playInPlayer(asset: asset, queueType: queueType)
+    playInPlayer(asset: asset, streamHeaders: streamHeaders, queueType: queueType)
   }
 
   private func playInPlayer(
     asset: AVURLAsset?,
+    streamHeaders: [String: String] = [:],
     queueType: BackendAudioQueueType
   ) {
     guard let asset = asset else {
@@ -642,10 +649,10 @@ class BackendAudioPlayer: NSObject {
     switch queueType {
     case .play:
       currentPreparedUrl = asset.url.absoluteString
-      player?.play(url: asset.url)
+      player?.play(url: asset.url, headers: streamHeaders)
     case .queue:
       nextPreloadedUrl = asset.url.absoluteString
-      player?.queue(url: asset.url)
+      player?.queue(url: asset.url, headers: streamHeaders)
     }
   }
 

--- a/AmperfyKitTests/Cases/API/CloudflareAccessTest.swift
+++ b/AmperfyKitTests/Cases/API/CloudflareAccessTest.swift
@@ -1,0 +1,141 @@
+//
+//  CloudflareAccessTest.swift
+//  AmperfyKitTests
+//
+//  Created by Jerzy Królak on 17.06.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import AmperfyKit
+import XCTest
+
+class CloudflareAccessTest: XCTestCase {
+  /// Old persisted credentials (before the feature existed) must decode with the
+  /// feature disabled, so existing users are unaffected.
+  func testDecodingLegacyCredentialsDefaultsToDisabled() throws {
+    let legacyJson = """
+    {
+      "serverUrl": "https://music.example.com",
+      "username": "alice",
+      "password": "secret",
+      "backendApi": 2,
+      "activeBackendServerUrl": "https://music.example.com",
+      "alternativeServerURLs": []
+    }
+    """
+    let data = Data(legacyJson.utf8)
+    let credentials = try JSONDecoder().decode(LoginCredentials.self, from: data)
+    XCTAssertFalse(credentials.isCloudflareAccessEnabled)
+    XCTAssertEqual(credentials.cloudflareAccessClientId, "")
+    XCTAssertTrue(credentials.cloudflareAccessHeaders.isEmpty)
+  }
+
+  func testEncodeDecodeRoundTripPreservesCloudflareConfig() throws {
+    var credentials = LoginCredentials(
+      serverUrl: "https://music.example.com",
+      username: "bob",
+      password: "pw"
+    )
+    credentials.isCloudflareAccessEnabled = true
+    credentials.cloudflareAccessClientId = "client-id-123"
+
+    let encoded = try JSONEncoder().encode(credentials)
+    let decoded = try JSONDecoder().decode(LoginCredentials.self, from: encoded)
+    XCTAssertTrue(decoded.isCloudflareAccessEnabled)
+    XCTAssertEqual(decoded.cloudflareAccessClientId, "client-id-123")
+  }
+
+  /// Headers must be empty when disabled, even if a secret is present in the Keychain.
+  func testHeadersEmptyWhenDisabled() {
+    var credentials = LoginCredentials(
+      serverUrl: "https://disabled.example.com",
+      username: "carol",
+      password: "pw"
+    )
+    let ident = Account.createInfo(credentials: credentials).ident
+    CloudflareAccessCredentialStore.shared.setSecret("the-secret", forAccountIdent: ident)
+    defer { CloudflareAccessCredentialStore.shared.removeSecret(forAccountIdent: ident) }
+
+    credentials.isCloudflareAccessEnabled = false
+    XCTAssertTrue(credentials.cloudflareAccessHeaders.isEmpty)
+  }
+
+  func testHeadersPopulatedWhenEnabledWithSecret() {
+    var credentials = LoginCredentials(
+      serverUrl: "https://enabled.example.com",
+      username: "dave",
+      password: "pw"
+    )
+    credentials.isCloudflareAccessEnabled = true
+    credentials.cloudflareAccessClientId = "my-client-id"
+    let ident = Account.createInfo(credentials: credentials).ident
+    CloudflareAccessCredentialStore.shared.setSecret("my-secret", forAccountIdent: ident)
+    defer { CloudflareAccessCredentialStore.shared.removeSecret(forAccountIdent: ident) }
+
+    let headers = credentials.cloudflareAccessHeaders
+    XCTAssertEqual(headers[LoginCredentials.cloudflareAccessClientIdHeader], "my-client-id")
+    XCTAssertEqual(headers[LoginCredentials.cloudflareAccessClientSecretHeader], "my-secret")
+  }
+
+  /// When enabled but the secret is missing from the Keychain, no partial headers are sent.
+  func testHeadersEmptyWhenSecretMissing() {
+    var credentials = LoginCredentials(
+      serverUrl: "https://nosecret.example.com",
+      username: "erin",
+      password: "pw"
+    )
+    credentials.isCloudflareAccessEnabled = true
+    credentials.cloudflareAccessClientId = "client-id"
+    let ident = Account.createInfo(credentials: credentials).ident
+    CloudflareAccessCredentialStore.shared.removeSecret(forAccountIdent: ident)
+
+    XCTAssertTrue(credentials.cloudflareAccessHeaders.isEmpty)
+  }
+
+  func testKeychainStoreRoundTripAndRemoval() {
+    let ident = "test-account-\(UUID().uuidString)"
+    let store = CloudflareAccessCredentialStore.shared
+    defer { store.removeSecret(forAccountIdent: ident) }
+
+    XCTAssertFalse(store.hasSecret(forAccountIdent: ident))
+    XCTAssertTrue(store.setSecret("round-trip", forAccountIdent: ident))
+    XCTAssertTrue(store.hasSecret(forAccountIdent: ident))
+    XCTAssertEqual(store.getSecret(forAccountIdent: ident), "round-trip")
+
+    // Overwrite
+    XCTAssertTrue(store.setSecret("updated", forAccountIdent: ident))
+    XCTAssertEqual(store.getSecret(forAccountIdent: ident), "updated")
+
+    // Empty secret removes the entry
+    XCTAssertTrue(store.setSecret("", forAccountIdent: ident))
+    XCTAssertFalse(store.hasSecret(forAccountIdent: ident))
+  }
+
+  func testKeychainMigration() {
+    let source = "source-\(UUID().uuidString)"
+    let dest = "dest-\(UUID().uuidString)"
+    let store = CloudflareAccessCredentialStore.shared
+    defer {
+      store.removeSecret(forAccountIdent: source)
+      store.removeSecret(forAccountIdent: dest)
+    }
+
+    store.setSecret("to-migrate", forAccountIdent: source)
+    store.migrateSecret(fromAccountIdent: source, toAccountIdent: dest)
+    XCTAssertFalse(store.hasSecret(forAccountIdent: source))
+    XCTAssertEqual(store.getSecret(forAccountIdent: dest), "to-migrate")
+  }
+}

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -219,6 +219,7 @@ final class MOCK_DownloadManagerDelegate: DownloadManagerDelegate {
 final class MOCK_BackendApi: BackendApi {
   let clientApiVersion: String = ""
   let serverApiVersion: String = ""
+  let cloudflareAccessHeaders: [String: String] = [:]
   func provideCredentials(credentials: LoginCredentials) {}
   func isAuthenticationValid(credentials: LoginCredentials) async throws {
     throw BackendError.notSupported


### PR DESCRIPTION
Enable connecting to servers behind Cloudflare Access by attaching service-token headers to all server-bound requests. The client secret is stored in the Keychain, and existing accounts are unaffected.

Includes login-screen UI for entering the token and a keyboard-handling fix so the fields stay reachable.