### PR TITLE
Performance: fix multi-second freeze when opening large library lists

### DIFF
--- a/Amperfy/Screens/ViewController/AlbumsCollectionVC.swift
+++ b/Amperfy/Screens/ViewController/AlbumsCollectionVC.swift
@@ -170,6 +170,11 @@ class AlbumsCollectionVC: SingleSnapshotFetchedResultsCollectionViewController<A
   fileprivate var common: AlbumsCommonVCInteractions
 
   private var previousSize: CGSize = .zero
+  private var cachedItemSize: CGSize?
+
+  func invalidateItemSizeCache() {
+    cachedItemSize = nil
+  }
 
   public var displayFilter: DisplayCategoryFilter {
     set { common.displayFilter = newValue }
@@ -281,6 +286,7 @@ class AlbumsCollectionVC: SingleSnapshotFetchedResultsCollectionViewController<A
 
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
+    invalidateItemSizeCache()
     extendSafeAreaToAccountForMiniPlayer()
     common.updateRightBarButtonItems()
     common.updateFromRemote()
@@ -346,8 +352,15 @@ class AlbumsCollectionVC: SingleSnapshotFetchedResultsCollectionViewController<A
     let currentSize = view.bounds.size
     if currentSize != previousSize {
       previousSize = currentSize
+      cachedItemSize = nil
       collectionView.collectionViewLayout.invalidateLayout()
     }
+  }
+
+  override func viewSafeAreaInsetsDidChange() {
+    super.viewSafeAreaInsetsDidChange()
+    cachedItemSize = nil
+    collectionView.collectionViewLayout.invalidateLayout()
   }
 }
 
@@ -363,22 +376,28 @@ extension AlbumsCollectionVC: UICollectionViewDelegateFlowLayout {
     sizeForItemAt indexPath: IndexPath
   )
     -> CGSize {
+    if let cachedItemSize {
+      return cachedItemSize
+    }
     let inset = self.collectionView(
       collectionView,
       layout: collectionViewLayout,
       insetForSectionAt: indexPath.section
     )
 
+    let gridSize = appDelegate.storage.settings.user.albumsGridSizeSetting
     let marginsAndInsets = inset.left + inset.right + collectionView.safeAreaInsets
       .left + collectionView.safeAreaInsets.right + Self
       .minimumInteritemSpacing *
-      CGFloat(appDelegate.storage.settings.user.albumsGridSizeSetting - 1)
+      CGFloat(gridSize - 1)
     let itemWidth =
       (
         (collectionView.bounds.size.width - marginsAndInsets) /
-          CGFloat(appDelegate.storage.settings.user.albumsGridSizeSetting)
+          CGFloat(gridSize)
       ).rounded(.down)
-    return CGSize(width: itemWidth, height: itemWidth + 45)
+    let itemSize = CGSize(width: itemWidth, height: itemWidth + 45)
+    cachedItemSize = itemSize
+    return itemSize
   }
 
   func collectionView(

--- a/Amperfy/Screens/ViewController/AlbumsCommonVCInteractions.swift
+++ b/Amperfy/Screens/ViewController/AlbumsCommonVCInteractions.swift
@@ -391,6 +391,7 @@ class AlbumsCommonVCInteractions {
       if newIntValue != self.appDelegate.storage.settings.user.albumsGridSizeSetting {
         self.appDelegate.storage.settings.user.albumsGridSizeSetting = newIntValue
         if let collectionVC = rootVC as? AlbumsCollectionVC {
+          collectionVC.invalidateItemSizeCache()
           collectionVC.collectionView.reloadData()
         }
       }

--- a/AmperfyKit/Storage/ResultController/BasicFetchedResultsController.swift
+++ b/AmperfyKit/Storage/ResultController/BasicFetchedResultsController.swift
@@ -465,6 +465,9 @@ public class CachedFetchedResultsController<ResultType>: BasicFetchedResultsCont
   where ResultType: NSFetchRequestResult {
   let account: Account
   var keepAllResultsUpdated = true
+  private var didFetchAll = false
+  private var didFetchSearch = false
+  private var lastSearchPredicateFormat: String?
   private let allFetchResulsController: CustomSectionIndexFetchedResultsController<ResultType>
   private let searchFetchResulsController: CustomSectionIndexFetchedResultsController<ResultType>
   private var sectionIndexType: SectionIndexType
@@ -522,6 +525,14 @@ public class CachedFetchedResultsController<ResultType>: BasicFetchedResultsCont
 
   override public func search(predicate: NSPredicate?) {
     isSearchActive = true
+    let predicateFormat = predicate?.predicateFormat
+    if didFetchSearch,
+       lastSearchPredicateFormat == predicateFormat,
+       searchFetchResulsController.fetchedObjects != nil {
+      return
+    }
+    didFetchSearch = true
+    lastSearchPredicateFormat = predicateFormat
     searchFetchResulsController.fetchRequest.predicate = predicate
     searchFetchResulsController.fetch()
   }
@@ -531,7 +542,17 @@ public class CachedFetchedResultsController<ResultType>: BasicFetchedResultsCont
   }
 
   override public func fetch() {
+    let wasSearchActive = isSearchActive
     isSearchActive = false
+    didFetchSearch = false
+    lastSearchPredicateFormat = nil
+    if !wasSearchActive,
+       didFetchAll,
+       keepAllResultsUpdated,
+       allFetchResulsController.fetchedObjects != nil {
+      return
+    }
+    didFetchAll = true
     allFetchResulsController.fetch()
   }
 
@@ -541,6 +562,8 @@ public class CachedFetchedResultsController<ResultType>: BasicFetchedResultsCont
 
   override public func clearResults() {
     isSearchActive = true
+    didFetchSearch = false
+    lastSearchPredicateFormat = nil
     searchFetchResulsController.clearResults()
   }
 
@@ -559,6 +582,8 @@ public class CachedFetchedResultsController<ResultType>: BasicFetchedResultsCont
 
   public func hideResults() {
     isSearchActive = true
+    didFetchSearch = false
+    lastSearchPredicateFormat = nil
     searchFetchResulsController.fetchRequest.predicate = NSPredicate(format: "id == nil")
     searchFetchResulsController.fetch()
   }


### PR DESCRIPTION
With a large library, opening the Songs/Artists/Albums lists froze the UI for
several seconds. Two independent root causes, one commit each:

1. CachedFetchedResultsController re-ran performFetch on every appearance,
   rebuilding the section cache and materializing the whole result set on the
   main thread. Now skipped when results are already loaded and kept live by the
   delegate (returning from search still refreshes).

2. The Albums grid recomputed the cell size per item, and that read decodes the
   user settings JSON from UserDefaults on every access (~47k decodes for ~24k
   albums). The size is constant per layout pass, so it is cached now.

Measured on a ~58k-song / ~24k-album library:
- Albums grid entry: ~5s freeze -> 0,5s
- Artists entry: redundant re-fetch eliminated
- Albums: redundant ~3s re-fetch eliminated

Songs entry (~0.8s; loads 57k IDs because keepAllResultsUpdated is false) is a
separate concern, left for a follow-up.

Independent of #731 (debounce): different methods, no logic overlap, the branches
merge cleanly.

Verified: AmperfyKitTests pass, SwiftFormat clean, no project.pbxproj changes.