### PR TITLE
Sync: speed up the full library sync and make it resumable

### DIFF
--- a/Amperfy/AppDelegate.swift
+++ b/Amperfy/AppDelegate.swift
@@ -281,9 +281,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         .asColor
     )
 
-    let accountSetting = storage.settings.accounts.getSetting(activeAccountInfo).read
-    let isInitialSyncResumable = accountSetting.initialSyncCompletionStatus == .aborted
-      && accountSetting.initialSyncCompletedAlbumBatches != nil
+    let isInitialSyncResumable = storage.settings.accounts.getSetting(activeAccountInfo).read
+      .isInitialSyncResumable
     guard AmperKit.shared.storage.settings.app.isLibrarySynced, !isInitialSyncResumable else {
       return true
     }

--- a/Amperfy/AppDelegate.swift
+++ b/Amperfy/AppDelegate.swift
@@ -281,7 +281,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         .asColor
     )
 
-    guard AmperKit.shared.storage.settings.app.isLibrarySynced else {
+    let accountSetting = storage.settings.accounts.getSetting(activeAccountInfo).read
+    let isInitialSyncResumable = accountSetting.initialSyncCompletionStatus == .aborted
+      && accountSetting.initialSyncCompletedAlbumBatches != nil
+    guard AmperKit.shared.storage.settings.app.isLibrarySynced, !isInitialSyncResumable else {
       return true
     }
 

--- a/Amperfy/SceneDelegate.swift
+++ b/Amperfy/SceneDelegate.swift
@@ -109,10 +109,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     #endif
     if let activeAccountInfo = AmperKit.shared.storage.settings.accounts.active {
       let account = appDelegate.storage.main.library.getAccount(info: activeAccountInfo)
-      let accountSetting = AmperKit.shared.storage.settings.accounts.getSetting(activeAccountInfo)
-        .read
-      let isInitialSyncResumable = accountSetting.initialSyncCompletionStatus == .aborted
-        && accountSetting.initialSyncCompletedAlbumBatches != nil
+      let isInitialSyncResumable = AmperKit.shared.storage.settings.accounts
+        .getSetting(activeAccountInfo).read.isInitialSyncResumable
       if !AmperKit.shared.storage.settings.app.isLibrarySynced || isInitialSyncResumable {
         initialViewController = AppStoryboard.Main.segueToSync(account: account)
       } else if AmperKit.shared.libraryUpdater.isVisualUpadateNeeded {

--- a/Amperfy/SceneDelegate.swift
+++ b/Amperfy/SceneDelegate.swift
@@ -109,7 +109,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     #endif
     if let activeAccountInfo = AmperKit.shared.storage.settings.accounts.active {
       let account = appDelegate.storage.main.library.getAccount(info: activeAccountInfo)
-      if !AmperKit.shared.storage.settings.app.isLibrarySynced {
+      let accountSetting = AmperKit.shared.storage.settings.accounts.getSetting(activeAccountInfo)
+        .read
+      let isInitialSyncResumable = accountSetting.initialSyncCompletionStatus == .aborted
+        && accountSetting.initialSyncCompletedAlbumBatches != nil
+      if !AmperKit.shared.storage.settings.app.isLibrarySynced || isInitialSyncResumable {
         initialViewController = AppStoryboard.Main.segueToSync(account: account)
       } else if AmperKit.shared.libraryUpdater.isVisualUpadateNeeded {
         initialViewController = AppStoryboard.Main.segueToUpdate()

--- a/Amperfy/Screens/ViewController/SyncVC.swift
+++ b/Amperfy/Screens/ViewController/SyncVC.swift
@@ -32,6 +32,7 @@ class SyncVC: UIViewController {
   var libObjectsToParseCount: Int = 1
   var syncFinished = false
   var account: Account!
+  private var syncTask: Task<(), Never>?
 
   @IBOutlet
   weak var progressBar: UIProgressView!
@@ -53,19 +54,17 @@ class SyncVC: UIViewController {
   }
 
   override func viewDidAppear(_ animated: Bool) {
-    Task { @MainActor in
+    syncTask = Task { @MainActor in
       self.appDelegate.eventLogger.supressAlerts = true
       if self.appDelegate.storage.settings.accounts.allAccounts.count <= 1 {
         self.appDelegate.storage.settings.app.isLibrarySynced = false
       }
-      let accountSettings = self.appDelegate.storage.settings.accounts.getSetting(account.info)
-        .read
-      let isResumingSync = accountSettings.initialSyncCompletionStatus == .aborted
-        && accountSettings.initialSyncCompletedAlbumBatches != nil
+      let isResumingSync = self.appDelegate.storage.settings.accounts.getSetting(account.info)
+        .read.isInitialSyncResumable
       if !isResumingSync {
         self.appDelegate.storage.settings.accounts.updateSetting(account.info) { accountSettings in
           accountSettings.initialSyncCompletedAlbumBatches = nil
-          accountSettings.initialSyncAlbumPollCount = nil
+          accountSettings.initialSyncAlbumCount = nil
         }
         self.appDelegate.storage.main.library
           .cleanStorageOfObsoleteAccountEntries(account: account)
@@ -139,11 +138,12 @@ class SyncVC: UIViewController {
       preferredStyle: .alert
     )
     let skip = UIAlertAction(title: "Skip", style: .destructive, handler: { action in
+      self.syncTask?.cancel()
       self.appDelegate.storage.settings.accounts
         .updateSetting(self.account.info) { accountSettings in
           accountSettings.initialSyncCompletionStatus = .skipped
           accountSettings.initialSyncCompletedAlbumBatches = nil
-          accountSettings.initialSyncAlbumPollCount = nil
+          accountSettings.initialSyncAlbumCount = nil
         }
       self.finishSync()
     })

--- a/Amperfy/Screens/ViewController/SyncVC.swift
+++ b/Amperfy/Screens/ViewController/SyncVC.swift
@@ -58,7 +58,21 @@ class SyncVC: UIViewController {
       if self.appDelegate.storage.settings.accounts.allAccounts.count <= 1 {
         self.appDelegate.storage.settings.app.isLibrarySynced = false
       }
-      self.appDelegate.storage.main.library.cleanStorageOfObsoleteAccountEntries(account: account)
+      let accountSettings = self.appDelegate.storage.settings.accounts.getSetting(account.info)
+        .read
+      let isResumingSync = accountSettings.initialSyncCompletionStatus == .aborted
+        && accountSettings.initialSyncCompletedAlbumBatches != nil
+      if !isResumingSync {
+        self.appDelegate.storage.settings.accounts.updateSetting(account.info) { accountSettings in
+          accountSettings.initialSyncCompletedAlbumBatches = nil
+          accountSettings.initialSyncAlbumPollCount = nil
+        }
+        self.appDelegate.storage.main.library
+          .cleanStorageOfObsoleteAccountEntries(account: account)
+      }
+      self.appDelegate.storage.settings.accounts.updateSetting(account.info) { accountSettings in
+        accountSettings.initialSyncCompletionStatus = .aborted
+      }
 
       do {
         try await self.appDelegate.getMeta(account.info).librarySyncer
@@ -66,6 +80,7 @@ class SyncVC: UIViewController {
         self.appDelegate.storage.settings.accounts.updateSetting(account.info) { accountSettings in
           accountSettings.initialSyncCompletionStatus = .completed
         }
+        self.finishSync()
       } catch {
         guard !self.syncFinished else { return }
         self.appDelegate.eventLogger.report(
@@ -76,8 +91,8 @@ class SyncVC: UIViewController {
         self.appDelegate.storage.settings.accounts.updateSetting(account.info) { accountSettings in
           accountSettings.initialSyncCompletionStatus = .aborted
         }
+        self.finishSync()
       }
-      self.finishSync()
     }
   }
 
@@ -127,6 +142,8 @@ class SyncVC: UIViewController {
       self.appDelegate.storage.settings.accounts
         .updateSetting(self.account.info) { accountSettings in
           accountSettings.initialSyncCompletionStatus = .skipped
+          accountSettings.initialSyncCompletedAlbumBatches = nil
+          accountSettings.initialSyncAlbumPollCount = nil
         }
       self.finishSync()
     })

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -57,6 +57,10 @@ struct AccountSettingsView: View {
     appDelegate.configureMainMenu()
 
     appDelegate.storage.settings.user.isOfflineMode = false
+    appDelegate.storage.settings.accounts.updateSetting(accountInfo) { accountSettings in
+      accountSettings.initialSyncCompletedAlbumBatches = nil
+      accountSettings.initialSyncAlbumPollCount = nil
+    }
     let account = appDelegate.storage.main.library.getAccount(info: accountInfo)
     appDelegate.player.logout(account: account)
     let syncVC = AppStoryboard.Main.segueToSync(account: account)

--- a/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Account/AccountSettingsView.swift
@@ -59,7 +59,7 @@ struct AccountSettingsView: View {
     appDelegate.storage.settings.user.isOfflineMode = false
     appDelegate.storage.settings.accounts.updateSetting(accountInfo) { accountSettings in
       accountSettings.initialSyncCompletedAlbumBatches = nil
-      accountSettings.initialSyncAlbumPollCount = nil
+      accountSettings.initialSyncAlbumCount = nil
     }
     let account = appDelegate.storage.main.library.getAccount(info: accountInfo)
     appDelegate.player.logout(account: account)

--- a/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
@@ -27,6 +27,14 @@ import UIKit
 class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   private let ampacheXmlServerApi: AmpacheXmlServerApi
 
+  private static let maxParallelSyncRequests: Int = 4
+  private static let songSyncBatchSize: Int = 16
+
+  private struct AlbumSyncPayload: Sendable {
+    let albumInfo: APIDataResponse
+    let albumSongs: APIDataResponse
+  }
+
   init(
     ampacheXmlServerApi: AmpacheXmlServerApi,
     account: Account,
@@ -361,35 +369,10 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   @MainActor
   func sync(album: Album) async throws {
     guard isSyncAllowed else { return }
-    let albumResponse = try await ampacheXmlServerApi.requestAlbumInfo(id: album.id)
     let albumObjectId = album.managedObject.objectID
-    try await storage.async.perform { asyncCompanion in
-      do {
-        let accountAsync = Account(
-          managedObject: asyncCompanion.context
-            .object(with: self.accountObjectId) as! AccountMO
-        )
-        let idParserDelegate = IDsParserDelegate(performanceMonitor: self.performanceMonitor)
-        try self.parse(
-          response: albumResponse,
-          delegate: idParserDelegate,
-          isThrowingErrorsAllowed: false
-        )
-        let prefetch = asyncCompanion.library.getElements(
-          account: accountAsync,
-          prefetchIDs: idParserDelegate.prefetchIDs
-        )
 
-        let parserDelegate = AlbumParserDelegate(
-          performanceMonitor: self.performanceMonitor, prefetch: prefetch, account: accountAsync,
-          library: asyncCompanion.library
-        )
-        try self.parse(
-          response: albumResponse,
-          delegate: parserDelegate,
-          throwForNotFoundErrors: true
-        )
-      } catch {
+    func handleNotAvailableAlbum(error: Error) async throws {
+      try await storage.async.perform { asyncCompanion in
         if let responseError = error as? ResponseError,
            let ampacheError = responseError.asAmpacheError, !ampacheError.isRemoteAvailable {
           let albumAsync = Album(
@@ -400,55 +383,120 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
             type: .resource,
             statusCode: responseError.statusCode,
             message: "Album \"\(albumAsync.name)\" is no longer available on the server.",
-            cleansedURL: albumResponse.url?.asCleansedURL(cleanser: self.ampacheXmlServerApi),
-            data: albumResponse.data
+            cleansedURL: responseError.cleansedURL,
+            data: responseError.data
           )
           albumAsync.markAsRemoteDeleted()
           throw reportError
-        } else {
-          throw error
         }
       }
+      throw error
     }
 
-    guard album.remoteStatus == .available else { return }
-    let albumSongsResponse = try await ampacheXmlServerApi.requestAlbumSongs(id: album.id)
-    try await storage.async.perform { asyncCompanion in
-      let accountAsync = Account(
-        managedObject: asyncCompanion.context
-          .object(with: self.accountObjectId) as! AccountMO
-      )
-      let albumAsync = Album(
-        managedObject: asyncCompanion.context
-          .object(with: albumObjectId) as! AlbumMO
-      )
-      let oldSongs = Set(albumAsync.songs)
-
-      let idParserDelegate = IDsParserDelegate(performanceMonitor: self.performanceMonitor)
-      try self.parse(
-        response: albumSongsResponse,
-        delegate: idParserDelegate,
-        isThrowingErrorsAllowed: false
-      )
-      let prefetch = asyncCompanion.library.getElements(
-        account: accountAsync,
-        prefetchIDs: idParserDelegate.prefetchIDs
-      )
-
-      let parserDelegate = SongParserDelegate(
-        performanceMonitor: self.performanceMonitor, prefetch: prefetch, account: accountAsync,
-        library: asyncCompanion.library
-      )
-      try self.parse(response: albumSongsResponse, delegate: parserDelegate)
-      let removedSongs = oldSongs.subtracting(parserDelegate.parsedSongs)
-      removedSongs.lazy.compactMap { $0.asSong }.forEach {
-        os_log("Song <%s> is remote deleted", log: self.log, type: .info, $0.displayString)
-        $0.remoteStatus = .deleted
-        albumAsync.managedObject.removeFromSongs($0.managedObject)
+    do {
+      let albumInfoResponse = try await ampacheXmlServerApi.requestAlbumInfo(id: album.id)
+      let albumSongsResponse = try await ampacheXmlServerApi.requestAlbumSongs(id: album.id)
+      let payload = AlbumSyncPayload(albumInfo: albumInfoResponse, albumSongs: albumSongsResponse)
+      try await storage.async.perform { asyncCompanion in
+        try self.writeAlbumSongs(
+          asyncCompanion: asyncCompanion,
+          albumObjectId: albumObjectId,
+          payload: payload
+        )
       }
-      albumAsync.isSongsMetaDataSynced = true
-      albumAsync.isCached = parserDelegate.isCollectionCached
+    } catch {
+      try await handleNotAvailableAlbum(error: error)
     }
+  }
+
+  @MainActor
+  func syncSongsInBackground(
+    targets: [AlbumSyncTarget],
+    isCancelled: @escaping @Sendable () -> Bool
+  ) async {
+    guard isSyncAllowed else { return }
+    await syncAlbumSongsBatched(
+      targets: targets,
+      batchSize: Self.songSyncBatchSize,
+      maxParallelFetches: Self.maxParallelSyncRequests,
+      isCancelled: isCancelled,
+      fetch: { albumId in
+        let albumInfo = try await self.ampacheXmlServerApi.requestAlbumInfo(id: albumId)
+        let albumSongs = try await self.ampacheXmlServerApi.requestAlbumSongs(id: albumId)
+        return AlbumSyncPayload(albumInfo: albumInfo, albumSongs: albumSongs)
+      },
+      write: { asyncCompanion, albumObjectId, payload in
+        try self.writeAlbumSongs(
+          asyncCompanion: asyncCompanion,
+          albumObjectId: albumObjectId,
+          payload: payload
+        )
+      },
+      classifyNotAvailable: { error in
+        guard let responseError = error as? ResponseError,
+              let ampacheError = responseError.asAmpacheError else { return false }
+        return !ampacheError.isRemoteAvailable
+      }
+    )
+  }
+
+  nonisolated private func writeAlbumSongs(
+    asyncCompanion: CoreDataCompanion,
+    albumObjectId: NSManagedObjectID,
+    payload: AlbumSyncPayload
+  ) throws {
+    let accountAsync = Account(
+      managedObject: asyncCompanion.context.object(with: accountObjectId) as! AccountMO
+    )
+    let albumAsync = Album(
+      managedObject: asyncCompanion.context.object(with: albumObjectId) as! AlbumMO
+    )
+    let oldSongs = Set(albumAsync.songs)
+
+    let infoIdParserDelegate = IDsParserDelegate(performanceMonitor: performanceMonitor)
+    try parse(
+      response: payload.albumInfo,
+      delegate: infoIdParserDelegate,
+      isThrowingErrorsAllowed: false
+    )
+    let infoPrefetch = asyncCompanion.library.getElements(
+      account: accountAsync,
+      prefetchIDs: infoIdParserDelegate.prefetchIDs
+    )
+    let albumParserDelegate = AlbumParserDelegate(
+      performanceMonitor: performanceMonitor, prefetch: infoPrefetch, account: accountAsync,
+      library: asyncCompanion.library
+    )
+    try parse(
+      response: payload.albumInfo,
+      delegate: albumParserDelegate,
+      throwForNotFoundErrors: true
+    )
+
+    let songsIdParserDelegate = IDsParserDelegate(performanceMonitor: performanceMonitor)
+    try parse(
+      response: payload.albumSongs,
+      delegate: songsIdParserDelegate,
+      isThrowingErrorsAllowed: false
+    )
+    let songsPrefetch = asyncCompanion.library.getElements(
+      account: accountAsync,
+      prefetchIDs: songsIdParserDelegate.prefetchIDs
+    )
+    let songParserDelegate = SongParserDelegate(
+      performanceMonitor: performanceMonitor, prefetch: songsPrefetch, account: accountAsync,
+      library: asyncCompanion.library
+    )
+    try parse(response: payload.albumSongs, delegate: songParserDelegate)
+
+    let removedSongs = oldSongs.subtracting(songParserDelegate.parsedSongs)
+    removedSongs.lazy.compactMap { $0.asSong }.forEach {
+      os_log("Song <%s> is remote deleted", log: self.log, type: .info, $0.displayString)
+      $0.remoteStatus = .deleted
+      albumAsync.managedObject.removeFromSongs($0.managedObject)
+    }
+    albumAsync.isSongsMetaDataSynced = true
+    albumAsync.isCached = songParserDelegate.isCollectionCached
   }
 
   @MainActor

--- a/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
@@ -27,9 +27,6 @@ import UIKit
 class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   private let ampacheXmlServerApi: AmpacheXmlServerApi
 
-  private static let maxParallelSyncRequests: Int = 4
-  private static let songSyncBatchSize: Int = 16
-
   private struct AlbumSyncPayload: Sendable {
     let albumInfo: APIDataResponse
     let albumSongs: APIDataResponse
@@ -438,6 +435,11 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
         return !ampacheError.isRemoteAvailable
       }
     )
+  }
+
+  @MainActor
+  func syncAllSongs(isCancelled: @escaping @Sendable () -> Bool) async throws -> Bool {
+    false
   }
 
   nonisolated private func writeAlbumSongs(

--- a/AmperfyKit/Api/AutoDownloadLibrarySyncer.swift
+++ b/AmperfyKit/Api/AutoDownloadLibrarySyncer.swift
@@ -72,14 +72,10 @@ public class AutoDownloadLibrarySyncer {
     }
 
     fetchNeededNewestAlbums = newNewestAlbums.filter { !$0.isSongsMetaDataSynced }
-    try await withThrowingTaskGroup(of: Void.self) { taskGroup in
-      for album in fetchNeededNewestAlbums {
-        taskGroup.addTask { @MainActor @Sendable in
-          try await self.librarySyncer.sync(album: album)
-        }
-      }
-      try await taskGroup.waitForAll()
+    let targets = fetchNeededNewestAlbums.map {
+      AlbumSyncTarget(objectID: $0.managedObject.objectID, id: $0.id)
     }
+    await librarySyncer.syncSongsInBackground(targets: targets) { false }
 
     if offset == 0, !oldNewestAlbums.isEmpty, !newNewestAlbums.isEmpty,
        storage.settings.accounts.getSetting(account.info).read.isAutoDownloadLatestSongsActive {

--- a/AmperfyKit/Api/BackendApi.swift
+++ b/AmperfyKit/Api/BackendApi.swift
@@ -161,6 +161,8 @@ public protocol LibrarySyncer: Sendable {
     isCancelled: @escaping @Sendable () -> Bool
   ) async
   @MainActor
+  func syncAllSongs(isCancelled: @escaping @Sendable () -> Bool) async throws -> Bool
+  @MainActor
   func sync(song: Song) async throws
   @MainActor
   func sync(podcast: Podcast) async throws

--- a/AmperfyKit/Api/BackendApi.swift
+++ b/AmperfyKit/Api/BackendApi.swift
@@ -132,6 +132,18 @@ public struct LyricsLine {
   }
 }
 
+// MARK: - AlbumSyncTarget
+
+public struct AlbumSyncTarget: Sendable {
+  public let objectID: NSManagedObjectID
+  public let id: String
+
+  public init(objectID: NSManagedObjectID, id: String) {
+    self.objectID = objectID
+    self.id = id
+  }
+}
+
 // MARK: - LibrarySyncer
 
 public protocol LibrarySyncer: Sendable {
@@ -143,6 +155,11 @@ public protocol LibrarySyncer: Sendable {
   func sync(artist: Artist) async throws
   @MainActor
   func sync(album: Album) async throws
+  @MainActor
+  func syncSongsInBackground(
+    targets: [AlbumSyncTarget],
+    isCancelled: @escaping @Sendable () -> Bool
+  ) async
   @MainActor
   func sync(song: Song) async throws
   @MainActor

--- a/AmperfyKit/Api/BackgroundLibrarySyncer.swift
+++ b/AmperfyKit/Api/BackgroundLibrarySyncer.swift
@@ -22,29 +22,10 @@
 import Foundation
 import os.log
 
-// MARK: - BackgroundSyncOperation
-
-public class BackgroundSyncOperation: AsyncOperation, @unchecked Sendable {
-  private let completeBlock: VoidAsyncClosure
-
-  public init(completeBlock: @escaping VoidAsyncClosure) {
-    self.completeBlock = completeBlock
-  }
-
-  override public func main() {
-    Task {
-      await self.completeBlock()
-      finish()
-    }
-  }
-}
-
 // MARK: - BackgroundLibrarySyncer
 
 public final class BackgroundLibrarySyncer: AbstractBackgroundLibrarySyncer, Sendable {
   private let storage: AsyncCoreDataAccessWrapper
-  @MainActor
-  private let mainStorage: CoreDataCompanion
   private let settings: AmperfySettings
   private let networkMonitor: NetworkMonitorFacade
   private let librarySyncer: LibrarySyncer
@@ -54,16 +35,16 @@ public final class BackgroundLibrarySyncer: AbstractBackgroundLibrarySyncer, Sen
   private let autoDownloadLibrarySyncer: AutoDownloadLibrarySyncer
   private let eventLogger: EventLogger
 
+  private static let albumSyncPageSize: Int = 500
+
   private let log = OSLog(subsystem: "Amperfy", category: "BackgroundLibrarySyncer")
   private let isRunning = Atomic<Bool>(wrappedValue: false)
   private let isCurrentlyActive = Atomic<Bool>(wrappedValue: false)
   private let backgroundTask = Atomic<Task<(), Never>?>(wrappedValue: nil)
-  private let taskQueue: OperationQueue
 
   @MainActor
   init(
     storage: AsyncCoreDataAccessWrapper,
-    mainStorage: CoreDataCompanion,
     settings: AmperfySettings,
     networkMonitor: NetworkMonitorFacade,
     librarySyncer: LibrarySyncer,
@@ -72,15 +53,12 @@ public final class BackgroundLibrarySyncer: AbstractBackgroundLibrarySyncer, Sen
     eventLogger: EventLogger
   ) {
     self.storage = storage
-    self.mainStorage = mainStorage
     self.settings = settings
     self.networkMonitor = networkMonitor
     self.librarySyncer = librarySyncer
     self.playableDownloadManager = playableDownloadManager
     self.autoDownloadLibrarySyncer = autoDownloadLibrarySyncer
     self.eventLogger = eventLogger
-    self.taskQueue = OperationQueue()
-    taskQueue.maxConcurrentOperationCount = 1
   }
 
   var isActive: Bool { isCurrentlyActive.wrappedValue }
@@ -95,8 +73,6 @@ public final class BackgroundLibrarySyncer: AbstractBackgroundLibrarySyncer, Sen
 
   public func stop() {
     isRunning.wrappedValue = false
-    taskQueue.cancelAllOperations()
-    addOperationsEndMessage()
   }
 
   private func syncAlbumSongsInBackground() {
@@ -117,39 +93,27 @@ public final class BackgroundLibrarySyncer: AbstractBackgroundLibrarySyncer, Sen
         }
       }
 
-      try? await storage.perform { asyncCompanion in
-        let albumsToSync = asyncCompanion.library.getAlbumWithoutSyncedSongs()
-
-        for albumToSync in albumsToSync {
-          let albumObjectID = albumToSync.managedObject.objectID
-          let asyncOperation = BackgroundSyncOperation {
-            guard !Task.isCancelled, self.isRunning.wrappedValue, self.settings.user.isOnlineMode,
-                  self.networkMonitor.isConnectedToNetwork else { return }
-            let albumMO = self.mainStorage.context.object(with: albumObjectID) as! AlbumMO
-            let album = Album(managedObject: albumMO)
-            do {
-              try await self.librarySyncer.sync(album: album)
-            } catch {
-              self.eventLogger.report(
-                topic: "Album Background Sync",
-                error: error,
-                displayPopup: false
-              )
-              album.isSongsMetaDataSynced = true
-            }
-          }
-          self.taskQueue.addOperation(asyncOperation)
+      while self.isRunning.wrappedValue, self.settings.user.isOnlineMode,
+            self.networkMonitor.isConnectedToNetwork {
+        let targets = await self.nextUnsyncedAlbumTargets()
+        guard !targets.isEmpty else { break }
+        await self.librarySyncer.syncSongsInBackground(targets: targets) {
+          !self.isRunning.wrappedValue || !self.settings.user.isOnlineMode
+            || !self.networkMonitor.isConnectedToNetwork
         }
       }
 
-      addOperationsEndMessage()
+      self.isRunning.wrappedValue = false
+      self.isCurrentlyActive.wrappedValue = false
+      os_log("stopped", log: self.log, type: .info)
     }
   }
 
-  func addOperationsEndMessage() {
-    taskQueue.addBarrierBlock {
-      self.isRunning.wrappedValue = false
-      os_log("stopped", log: self.log, type: .info)
-    }
+  @MainActor
+  private func nextUnsyncedAlbumTargets() async -> [AlbumSyncTarget] {
+    (try? await storage.performAndGet { asyncCompanion in
+      asyncCompanion.library.getAlbumWithoutSyncedSongs(fetchLimit: Self.albumSyncPageSize)
+        .map { AlbumSyncTarget(objectID: $0.managedObject.objectID, id: $0.id) }
+    }) ?? []
   }
 }

--- a/AmperfyKit/Api/BackgroundLibrarySyncer.swift
+++ b/AmperfyKit/Api/BackgroundLibrarySyncer.swift
@@ -93,6 +93,15 @@ public final class BackgroundLibrarySyncer: AbstractBackgroundLibrarySyncer, Sen
         }
       }
 
+      let hasAlbumsToSync = !(await self.nextUnsyncedAlbumTargets()).isEmpty
+      if hasAlbumsToSync, self.isRunning.wrappedValue, self.settings.user.isOnlineMode,
+         self.networkMonitor.isConnectedToNetwork {
+        _ = try? await self.librarySyncer.syncAllSongs {
+          !self.isRunning.wrappedValue || !self.settings.user.isOnlineMode
+            || !self.networkMonitor.isConnectedToNetwork
+        }
+      }
+
       while self.isRunning.wrappedValue, self.settings.user.isOnlineMode,
             self.networkMonitor.isConnectedToNetwork {
         let targets = await self.nextUnsyncedAlbumTargets()

--- a/AmperfyKit/Api/CommonLibrarySyncer.swift
+++ b/AmperfyKit/Api/CommonLibrarySyncer.swift
@@ -27,6 +27,9 @@ import os.log
 
 @MainActor
 class CommonLibrarySyncer {
+  static let maxParallelSyncRequests: Int = 4
+  static let songSyncBatchSize: Int = 16
+
   let account: Account
   let accountObjectId: NSManagedObjectID
   let networkMonitor: NetworkMonitorFacade
@@ -154,18 +157,22 @@ class CommonLibrarySyncer {
   ) async {
     var index = 0
     var lastParallelFetches = maxParallelFetches
+    var criticalThermalWaits = 0
     while index < targets.count {
       guard !isCancelled() else { return }
-      if ProcessInfo.processInfo.thermalState == .critical {
+      if ProcessInfo.processInfo.thermalState == .critical, criticalThermalWaits < 6 {
         os_log("Album songs sync paused: critical thermal state", log: log, type: .info)
-        while ProcessInfo.processInfo.thermalState == .critical {
+        while ProcessInfo.processInfo.thermalState == .critical, criticalThermalWaits < 6 {
+          criticalThermalWaits += 1
           try? await Task.sleep(nanoseconds: 10_000_000_000)
           guard !isCancelled() else { return }
         }
       }
+      let thermalState = ProcessInfo.processInfo.thermalState
       let isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
-      let isThermalThrottled = ProcessInfo.processInfo.thermalState == .serious
-      let parallelFetches = isLowPower ? 1 : (isThermalThrottled ? 2 : maxParallelFetches)
+      let isThermalThrottled = thermalState == .serious || thermalState == .critical
+      let parallelFetches = isLowPower || thermalState == .critical
+        ? 1 : (isThermalThrottled ? 2 : maxParallelFetches)
       if parallelFetches != lastParallelFetches {
         os_log(
           "Album songs sync parallel fetches: %i (thermal throttled: %s, low power: %s)",
@@ -189,6 +196,11 @@ class CommonLibrarySyncer {
             do {
               return (target.objectID, .fetched(try await fetch(target.id)))
             } catch {
+              self.eventLogger.report(
+                topic: "Album Background Sync",
+                error: error,
+                displayPopup: false
+              )
               return (target.objectID, classifyNotAvailable(error) ? .notAvailable : .failed)
             }
           }
@@ -200,6 +212,11 @@ class CommonLibrarySyncer {
             do {
               return (target.objectID, .fetched(try await fetch(target.id)))
             } catch {
+              self.eventLogger.report(
+                topic: "Album Background Sync",
+                error: error,
+                displayPopup: false
+              )
               return (target.objectID, classifyNotAvailable(error) ? .notAvailable : .failed)
             }
           }

--- a/AmperfyKit/Api/CommonLibrarySyncer.swift
+++ b/AmperfyKit/Api/CommonLibrarySyncer.swift
@@ -153,15 +153,37 @@ class CommonLibrarySyncer {
     classifyNotAvailable: @escaping @Sendable (Error) -> Bool
   ) async {
     var index = 0
+    var lastParallelFetches = maxParallelFetches
     while index < targets.count {
       guard !isCancelled() else { return }
+      if ProcessInfo.processInfo.thermalState == .critical {
+        os_log("Album songs sync paused: critical thermal state", log: log, type: .info)
+        while ProcessInfo.processInfo.thermalState == .critical {
+          try? await Task.sleep(nanoseconds: 10_000_000_000)
+          guard !isCancelled() else { return }
+        }
+      }
+      let isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+      let isThermalThrottled = ProcessInfo.processInfo.thermalState == .serious
+      let parallelFetches = isLowPower ? 1 : (isThermalThrottled ? 2 : maxParallelFetches)
+      if parallelFetches != lastParallelFetches {
+        os_log(
+          "Album songs sync parallel fetches: %i (thermal throttled: %s, low power: %s)",
+          log: log,
+          type: .info,
+          parallelFetches,
+          isThermalThrottled ? "yes" : "no",
+          isLowPower ? "yes" : "no"
+        )
+        lastParallelFetches = parallelFetches
+      }
       let batch = Array(targets[index ..< min(index + batchSize, targets.count)])
       index += batchSize
 
       var results = [(NSManagedObjectID, AlbumSongsFetchResult<Payload>)]()
       var iterator = batch.makeIterator()
       await withTaskGroup(of: (NSManagedObjectID, AlbumSongsFetchResult<Payload>).self) { group in
-        for _ in 0 ..< maxParallelFetches {
+        for _ in 0 ..< parallelFetches {
           guard let target = iterator.next() else { break }
           group.addTask { @MainActor @Sendable in
             do {

--- a/AmperfyKit/Api/CommonLibrarySyncer.swift
+++ b/AmperfyKit/Api/CommonLibrarySyncer.swift
@@ -23,6 +23,8 @@ import CoreData
 import Foundation
 import os.log
 
+// MARK: - CommonLibrarySyncer
+
 @MainActor
 class CommonLibrarySyncer {
   let account: Account
@@ -139,4 +141,82 @@ class CommonLibrarySyncer {
       }
     }
   }
+
+  @MainActor
+  func syncAlbumSongsBatched<Payload: Sendable>(
+    targets: [AlbumSyncTarget],
+    batchSize: Int,
+    maxParallelFetches: Int,
+    isCancelled: @escaping @Sendable () -> Bool,
+    fetch: @escaping @MainActor @Sendable (String) async throws -> Payload,
+    write: @escaping @Sendable (CoreDataCompanion, NSManagedObjectID, Payload) throws -> (),
+    classifyNotAvailable: @escaping @Sendable (Error) -> Bool
+  ) async {
+    var index = 0
+    while index < targets.count {
+      guard !isCancelled() else { return }
+      let batch = Array(targets[index ..< min(index + batchSize, targets.count)])
+      index += batchSize
+
+      var results = [(NSManagedObjectID, AlbumSongsFetchResult<Payload>)]()
+      var iterator = batch.makeIterator()
+      await withTaskGroup(of: (NSManagedObjectID, AlbumSongsFetchResult<Payload>).self) { group in
+        for _ in 0 ..< maxParallelFetches {
+          guard let target = iterator.next() else { break }
+          group.addTask { @MainActor @Sendable in
+            do {
+              return (target.objectID, .fetched(try await fetch(target.id)))
+            } catch {
+              return (target.objectID, classifyNotAvailable(error) ? .notAvailable : .failed)
+            }
+          }
+        }
+        while let result = await group.next() {
+          results.append(result)
+          guard let target = iterator.next() else { continue }
+          group.addTask { @MainActor @Sendable in
+            do {
+              return (target.objectID, .fetched(try await fetch(target.id)))
+            } catch {
+              return (target.objectID, classifyNotAvailable(error) ? .notAvailable : .failed)
+            }
+          }
+        }
+      }
+
+      let batchResults = results
+      guard !isCancelled() else { return }
+      try? await storage.async.perform { asyncCompanion in
+        for (objectID, result) in batchResults {
+          guard let albumMO = try? asyncCompanion.context.existingObject(with: objectID) as? AlbumMO
+          else { continue }
+          let albumAsync = Album(managedObject: albumMO)
+          switch result {
+          case let .fetched(payload):
+            do {
+              try write(asyncCompanion, objectID, payload)
+            } catch {
+              if classifyNotAvailable(error) {
+                albumAsync.markAsRemoteDeleted()
+              } else {
+                albumAsync.isSongsMetaDataSynced = true
+              }
+            }
+          case .notAvailable:
+            albumAsync.markAsRemoteDeleted()
+          case .failed:
+            albumAsync.isSongsMetaDataSynced = true
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - AlbumSongsFetchResult
+
+enum AlbumSongsFetchResult<Payload: Sendable>: Sendable {
+  case fetched(Payload)
+  case notAvailable
+  case failed
 }

--- a/AmperfyKit/Api/CommonLibrarySyncer.swift
+++ b/AmperfyKit/Api/CommonLibrarySyncer.swift
@@ -146,6 +146,25 @@ class CommonLibrarySyncer {
   }
 
   @MainActor
+  func waitWhileThermalStateCritical(
+    previousWaitCount: Int,
+    isCancelled: @escaping @Sendable () -> Bool
+  ) async
+    -> (isCancelled: Bool, waitCount: Int) {
+    var waitCount = previousWaitCount
+    guard ProcessInfo.processInfo.thermalState == .critical, waitCount < 6 else {
+      return (false, waitCount)
+    }
+    os_log("Album songs sync paused: critical thermal state", log: log, type: .info)
+    while ProcessInfo.processInfo.thermalState == .critical, waitCount < 6 {
+      waitCount += 1
+      try? await Task.sleep(nanoseconds: 10_000_000_000)
+      guard !isCancelled() else { return (true, waitCount) }
+    }
+    return (false, waitCount)
+  }
+
+  @MainActor
   func syncAlbumSongsBatched<Payload: Sendable>(
     targets: [AlbumSyncTarget],
     batchSize: Int,
@@ -160,14 +179,12 @@ class CommonLibrarySyncer {
     var criticalThermalWaits = 0
     while index < targets.count {
       guard !isCancelled() else { return }
-      if ProcessInfo.processInfo.thermalState == .critical, criticalThermalWaits < 6 {
-        os_log("Album songs sync paused: critical thermal state", log: log, type: .info)
-        while ProcessInfo.processInfo.thermalState == .critical, criticalThermalWaits < 6 {
-          criticalThermalWaits += 1
-          try? await Task.sleep(nanoseconds: 10_000_000_000)
-          guard !isCancelled() else { return }
-        }
-      }
+      let thermalWait = await waitWhileThermalStateCritical(
+        previousWaitCount: criticalThermalWaits,
+        isCancelled: isCancelled
+      )
+      criticalThermalWaits = thermalWait.waitCount
+      guard !thermalWait.isCancelled else { return }
       let thermalState = ProcessInfo.processInfo.thermalState
       let isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
       let isThermalThrottled = thermalState == .serious || thermalState == .critical

--- a/AmperfyKit/Api/LibrarySyncerProxy.swift
+++ b/AmperfyKit/Api/LibrarySyncerProxy.swift
@@ -65,6 +65,14 @@ extension LibrarySyncerProxy: LibrarySyncer {
   }
 
   @MainActor
+  func syncSongsInBackground(
+    targets: [AlbumSyncTarget],
+    isCancelled: @escaping @Sendable () -> Bool
+  ) async {
+    await activeSyncer.syncSongsInBackground(targets: targets, isCancelled: isCancelled)
+  }
+
+  @MainActor
   func sync(song: Song) async throws {
     try await activeSyncer.sync(song: song)
   }

--- a/AmperfyKit/Api/LibrarySyncerProxy.swift
+++ b/AmperfyKit/Api/LibrarySyncerProxy.swift
@@ -73,6 +73,11 @@ extension LibrarySyncerProxy: LibrarySyncer {
   }
 
   @MainActor
+  func syncAllSongs(isCancelled: @escaping @Sendable () -> Bool) async throws -> Bool {
+    try await activeSyncer.syncAllSongs(isCancelled: isCancelled)
+  }
+
+  @MainActor
   func sync(song: Song) async throws {
     try await activeSyncer.sync(song: song)
   }

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -1398,9 +1398,16 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     var pageIndex = 0
     var pendingAlbumIDs = Set<String>()
     var markedAlbumCount = 0
+    var criticalThermalWaits = 0
 
     while pageIndex < Self.maxBulkSongPages {
       guard !isCancelled() else { return false }
+      let thermalWait = await waitWhileThermalStateCritical(
+        previousWaitCount: criticalThermalWaits,
+        isCancelled: isCancelled
+      )
+      criticalThermalWaits = thermalWait.waitCount
+      guard !thermalWait.isCancelled else { return false }
       let songResponse = try await subsonicServerApi.requestAllSongs(
         songOffset: songOffset,
         count: Self.maxItemCountToPollAtOnce

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -27,6 +27,8 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   private let subsonicServerApi: SubsonicServerApi
 
   private static let maxItemCountToPollAtOnce: Int = 500
+  private static let maxParallelSyncRequests: Int = 4
+  private static let albumCheckpointSaveInterval: Int = 5
 
   init(
     subsonicServerApi: SubsonicServerApi,
@@ -48,7 +50,11 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
 
   @MainActor
   func syncInitial(statusNotifyier: SyncCallbacks?) async throws {
-    try await super.createCachedItemRepresentationsInCoreData(statusNotifyier: statusNotifyier)
+    let resumeAlbumBatches = storage.settings.accounts.getSetting(accountInfo).read
+      .initialSyncCompletedAlbumBatches
+    if resumeAlbumBatches == nil {
+      try await super.createCachedItemRepresentationsInCoreData(statusNotifyier: statusNotifyier)
+    }
 
     statusNotifyier?.notifySyncStarted(ofType: .genre, totalCount: 0)
     let genreResponse = try await subsonicServerApi.requestGenres()
@@ -119,14 +125,30 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
         Int(ceil(Double(albumCount) / Double(Self.maxItemCountToPollAtOnce)))
       )
     }
-    statusNotifyier?.notifySyncStarted(ofType: .album, totalCount: pollCountArtist)
-    try await withThrowingTaskGroup(of: Void.self) { taskGroup in
-      for index in Array(0 ... pollCountArtist) {
-        taskGroup.addTask { @MainActor @Sendable in
-          let albumsResponse = try await self.subsonicServerApi.requestAlbums(
-            offset: index * Self.maxItemCountToPollAtOnce,
-            count: Self.maxItemCountToPollAtOnce
-          )
+    var completedAlbumBatches = resumeAlbumBatches ?? Set<Int>()
+    if storage.settings.accounts.getSetting(accountInfo).read
+      .initialSyncAlbumPollCount != pollCountArtist {
+      completedAlbumBatches = Set<Int>()
+    }
+    let remainingAlbumBatches = Array(0 ... pollCountArtist)
+      .filter { !completedAlbumBatches.contains($0) }
+    statusNotifyier?.notifySyncStarted(ofType: .album, totalCount: remainingAlbumBatches.count)
+
+    var albumBatchIterator = remainingAlbumBatches.makeIterator()
+    var albumBatchesSinceCheckpoint = 0
+    do {
+      try await withThrowingTaskGroup(of: (Int, APIDataResponse).self) { taskGroup in
+        for _ in 0 ..< Self.maxParallelSyncRequests {
+          guard let batchIndex = albumBatchIterator.next() else { break }
+          taskGroup.addTask { @MainActor @Sendable in
+            let response = try await self.subsonicServerApi.requestAlbums(
+              offset: batchIndex * Self.maxItemCountToPollAtOnce,
+              count: Self.maxItemCountToPollAtOnce
+            )
+            return (batchIndex, response)
+          }
+        }
+        while let (batchIndex, albumsResponse) = try await taskGroup.next() {
           try await self.storage.async.perform { asyncCompanion in
             let accountAsync = Account(
               managedObject: asyncCompanion.context
@@ -147,17 +169,43 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
               library: asyncCompanion.library,
               parseNotifier: statusNotifyier
             )
-            parserDelegate.prefetch = prefetch
             try self.parse(
               response: albumsResponse,
               delegate: parserDelegate,
               isThrowingErrorsAllowed: false
             )
           }
+          completedAlbumBatches.insert(batchIndex)
           statusNotifyier?.notifyParsedObject(ofType: .album)
+
+          albumBatchesSinceCheckpoint += 1
+          if albumBatchesSinceCheckpoint >= Self.albumCheckpointSaveInterval {
+            albumBatchesSinceCheckpoint = 0
+            let checkpoint = completedAlbumBatches
+            self.storage.settings.accounts.updateSetting(self.accountInfo) {
+              $0.initialSyncCompletedAlbumBatches = checkpoint
+              $0.initialSyncAlbumPollCount = pollCountArtist
+            }
+          }
+
+          if let nextBatchIndex = albumBatchIterator.next() {
+            taskGroup.addTask { @MainActor @Sendable in
+              let response = try await self.subsonicServerApi.requestAlbums(
+                offset: nextBatchIndex * Self.maxItemCountToPollAtOnce,
+                count: Self.maxItemCountToPollAtOnce
+              )
+              return (nextBatchIndex, response)
+            }
+          }
         }
       }
-      try await taskGroup.waitForAll()
+    } catch {
+      let checkpoint = completedAlbumBatches
+      storage.settings.accounts.updateSetting(accountInfo) {
+        $0.initialSyncCompletedAlbumBatches = checkpoint
+        $0.initialSyncAlbumPollCount = pollCountArtist
+      }
+      throw error
     }
 
     try await storage.async.perform { asyncCompanion in
@@ -212,7 +260,13 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     }
 
     let isSupported = try await subsonicServerApi.requestServerPodcastSupport()
-    guard isSupported else { return }
+    guard isSupported else {
+      storage.settings.accounts.updateSetting(accountInfo) {
+        $0.initialSyncCompletedAlbumBatches = nil
+        $0.initialSyncAlbumPollCount = nil
+      }
+      return
+    }
     statusNotifyier?.notifySyncStarted(ofType: .podcast, totalCount: 0)
     let podcastsResponse = try await subsonicServerApi.requestPodcasts()
     try await storage.async.perform { asyncCompanion in
@@ -242,6 +296,10 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
         isThrowingErrorsAllowed: false
       )
       parserDelegate.performPostParseOperations()
+    }
+    storage.settings.accounts.updateSetting(accountInfo) {
+      $0.initialSyncCompletedAlbumBatches = nil
+      $0.initialSyncAlbumPollCount = nil
     }
   }
 

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -29,6 +29,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   private static let maxItemCountToPollAtOnce: Int = 500
   private static let maxParallelSyncRequests: Int = 4
   private static let albumCheckpointSaveInterval: Int = 5
+  private static let songSyncBatchSize: Int = 16
 
   init(
     subsonicServerApi: SubsonicServerApi,
@@ -426,67 +427,86 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
 
     do {
       try await storage.async.perform { asyncCompanion in
-        let accountAsync = Account(
-          managedObject: asyncCompanion.context
-            .object(with: self.accountObjectId) as! AccountMO
+        try self.writeAlbumSongs(
+          asyncCompanion: asyncCompanion,
+          albumObjectId: albumObjectId,
+          response: albumResponse
         )
-        let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)
-        try self.parse(
-          response: albumResponse,
-          delegate: idParserDelegate,
-          isThrowingErrorsAllowed: false
-        )
-        let prefetch = asyncCompanion.library.getElements(
-          account: accountAsync,
-          prefetchIDs: idParserDelegate.prefetchIDs
-        )
-
-        let parserDelegate = SsAlbumParserDelegate(
-          performanceMonitor: self.performanceMonitor, prefetch: prefetch, account: accountAsync,
-          library: asyncCompanion.library
-        )
-        try self.parse(response: albumResponse, delegate: parserDelegate)
       }
     } catch {
       try await handleNotAvailableAlbum(error: error)
     }
+  }
 
-    guard album.remoteStatus == .available else { return }
-    try await storage.async.perform { asyncCompanion in
-      let albumAsync = Album(
-        managedObject: asyncCompanion.context
-          .object(with: albumObjectId) as! AlbumMO
-      )
-      let accountAsync = Account(
-        managedObject: asyncCompanion.context
-          .object(with: self.accountObjectId) as! AccountMO
-      )
-      let oldSongs = Set(albumAsync.songs)
-
-      let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)
-      try self.parse(
-        response: albumResponse,
-        delegate: idParserDelegate,
-        isThrowingErrorsAllowed: false
-      )
-      let prefetch = asyncCompanion.library.getElements(
-        account: accountAsync,
-        prefetchIDs: idParserDelegate.prefetchIDs
-      )
-      let parserDelegate = SsSongParserDelegate(
-        performanceMonitor: self.performanceMonitor, prefetch: prefetch, account: accountAsync,
-        library: asyncCompanion.library
-      )
-      try self.parse(response: albumResponse, delegate: parserDelegate)
-      let removedSongs = oldSongs.subtracting(parserDelegate.parsedSongs)
-      removedSongs.lazy.compactMap { $0.asSong }.forEach {
-        os_log("Song <%s> is remote deleted", log: self.log, type: .info, $0.displayString)
-        $0.remoteStatus = .deleted
-        albumAsync.managedObject.removeFromSongs($0.managedObject)
+  @MainActor
+  func syncSongsInBackground(
+    targets: [AlbumSyncTarget],
+    isCancelled: @escaping @Sendable () -> Bool
+  ) async {
+    guard isSyncAllowed else { return }
+    await syncAlbumSongsBatched(
+      targets: targets,
+      batchSize: Self.songSyncBatchSize,
+      maxParallelFetches: Self.maxParallelSyncRequests,
+      isCancelled: isCancelled,
+      fetch: { albumId in
+        try await self.subsonicServerApi.requestAlbum(id: albumId)
+      },
+      write: { asyncCompanion, albumObjectId, response in
+        try self.writeAlbumSongs(
+          asyncCompanion: asyncCompanion,
+          albumObjectId: albumObjectId,
+          response: response
+        )
+      },
+      classifyNotAvailable: { error in
+        guard let responseError = error as? ResponseError,
+              let subsonicError = responseError.asSubsonicError else { return false }
+        return !subsonicError.isRemoteAvailable
       }
-      albumAsync.isCached = parserDelegate.isCollectionCached
-      albumAsync.isSongsMetaDataSynced = true
+    )
+  }
+
+  nonisolated private func writeAlbumSongs(
+    asyncCompanion: CoreDataCompanion,
+    albumObjectId: NSManagedObjectID,
+    response: APIDataResponse
+  ) throws {
+    let accountAsync = Account(
+      managedObject: asyncCompanion.context.object(with: accountObjectId) as! AccountMO
+    )
+    let albumAsync = Album(
+      managedObject: asyncCompanion.context.object(with: albumObjectId) as! AlbumMO
+    )
+    let oldSongs = Set(albumAsync.songs)
+
+    let idParserDelegate = SsIDsParserDelegate(performanceMonitor: performanceMonitor)
+    try parse(response: response, delegate: idParserDelegate, isThrowingErrorsAllowed: false)
+    let prefetch = asyncCompanion.library.getElements(
+      account: accountAsync,
+      prefetchIDs: idParserDelegate.prefetchIDs
+    )
+
+    let albumParserDelegate = SsAlbumParserDelegate(
+      performanceMonitor: performanceMonitor, prefetch: prefetch, account: accountAsync,
+      library: asyncCompanion.library
+    )
+    try parse(response: response, delegate: albumParserDelegate)
+
+    let songParserDelegate = SsSongParserDelegate(
+      performanceMonitor: performanceMonitor, prefetch: prefetch, account: accountAsync,
+      library: asyncCompanion.library
+    )
+    try parse(response: response, delegate: songParserDelegate)
+
+    let removedSongs = oldSongs.subtracting(songParserDelegate.parsedSongs)
+    removedSongs.lazy.compactMap { $0.asSong }.forEach {
+      os_log("Song <%s> is remote deleted", log: self.log, type: .info, $0.displayString)
+      $0.remoteStatus = .deleted
+      albumAsync.managedObject.removeFromSongs($0.managedObject)
     }
+    albumAsync.isCached = songParserDelegate.isCollectionCached
+    albumAsync.isSongsMetaDataSynced = true
   }
 
   @MainActor

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -27,9 +27,9 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   private let subsonicServerApi: SubsonicServerApi
 
   private static let maxItemCountToPollAtOnce: Int = 500
-  private static let maxParallelSyncRequests: Int = 4
   private static let albumCheckpointSaveInterval: Int = 5
-  private static let songSyncBatchSize: Int = 16
+  private static let bulkSongProbeCount: Int = 20
+  private static let maxBulkSongPages: Int = 10000
 
   init(
     subsonicServerApi: SubsonicServerApi,
@@ -117,18 +117,19 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     }
 
     var pollCountArtist = 0
+    var remoteAlbumCount = 0
     storage.main.perform { companion in
       let accountAsync = companion.library.getAccount(managedObjectId: self.accountObjectId)
       let artists = companion.library.getArtists(for: accountAsync).filter { !$0.id.isEmpty }
-      let albumCount = artists.reduce(0) { $0 + $1.remoteAlbumCount }
+      remoteAlbumCount = artists.reduce(0) { $0 + $1.remoteAlbumCount }
       pollCountArtist = max(
         1,
-        Int(ceil(Double(albumCount) / Double(Self.maxItemCountToPollAtOnce)))
+        Int(ceil(Double(remoteAlbumCount) / Double(Self.maxItemCountToPollAtOnce)))
       )
     }
     var completedAlbumBatches = resumeAlbumBatches ?? Set<Int>()
     if storage.settings.accounts.getSetting(accountInfo).read
-      .initialSyncAlbumPollCount != pollCountArtist {
+      .initialSyncAlbumCount != remoteAlbumCount {
       completedAlbumBatches = Set<Int>()
     }
     let remainingAlbumBatches = Array(0 ... pollCountArtist)
@@ -150,6 +151,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
           }
         }
         while let (batchIndex, albumsResponse) = try await taskGroup.next() {
+          try Task.checkCancellation()
           try await self.storage.async.perform { asyncCompanion in
             let accountAsync = Account(
               managedObject: asyncCompanion.context
@@ -185,7 +187,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
             let checkpoint = completedAlbumBatches
             self.storage.settings.accounts.updateSetting(self.accountInfo) {
               $0.initialSyncCompletedAlbumBatches = checkpoint
-              $0.initialSyncAlbumPollCount = pollCountArtist
+              $0.initialSyncAlbumCount = remoteAlbumCount
             }
           }
 
@@ -204,7 +206,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
       let checkpoint = completedAlbumBatches
       storage.settings.accounts.updateSetting(accountInfo) {
         $0.initialSyncCompletedAlbumBatches = checkpoint
-        $0.initialSyncAlbumPollCount = pollCountArtist
+        $0.initialSyncAlbumCount = remoteAlbumCount
       }
       throw error
     }
@@ -264,7 +266,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSupported else {
       storage.settings.accounts.updateSetting(accountInfo) {
         $0.initialSyncCompletedAlbumBatches = nil
-        $0.initialSyncAlbumPollCount = nil
+        $0.initialSyncAlbumCount = nil
       }
       return
     }
@@ -300,7 +302,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     }
     storage.settings.accounts.updateSetting(accountInfo) {
       $0.initialSyncCompletedAlbumBatches = nil
-      $0.initialSyncAlbumPollCount = nil
+      $0.initialSyncAlbumCount = nil
     }
   }
 
@@ -1369,6 +1371,97 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
         library: asyncCompanion.library
       )
       try self.parse(response: response, delegate: parserDelegate)
+    }
+  }
+
+  @MainActor
+  func syncAllSongs(isCancelled: @escaping @Sendable () -> Bool) async throws -> Bool {
+    guard isSyncAllowed,
+          storage.settings.accounts.getSetting(accountInfo).read
+          .initialSyncCompletionStatus != .aborted
+    else { return false }
+    os_log("Sync all songs via bulk search3", log: log, type: .info)
+
+    let probeResponse = try await subsonicServerApi.requestAllSongs(
+      songOffset: 0,
+      count: Self.bulkSongProbeCount
+    )
+    let probeParserDelegate = SsIDsParserDelegate(performanceMonitor: performanceMonitor)
+    try parse(
+      response: probeResponse,
+      delegate: probeParserDelegate,
+      isThrowingErrorsAllowed: false
+    )
+    guard !probeParserDelegate.prefetchIDs.songIDs.isEmpty else { return false }
+
+    var songOffset = 0
+    var pageIndex = 0
+    var pendingAlbumIDs = Set<String>()
+    var markedAlbumCount = 0
+
+    while pageIndex < Self.maxBulkSongPages {
+      guard !isCancelled() else { return false }
+      let songResponse = try await subsonicServerApi.requestAllSongs(
+        songOffset: songOffset,
+        count: Self.maxItemCountToPollAtOnce
+      )
+      let page = try await storage.async.performAndGet { asyncCompanion in
+        let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
+        let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)
+        try self.parse(
+          response: songResponse,
+          delegate: idParserDelegate,
+          isThrowingErrorsAllowed: false
+        )
+        let prefetch = asyncCompanion.library.getElements(
+          account: accountAsync,
+          prefetchIDs: idParserDelegate.prefetchIDs
+        )
+        let parserDelegate = SsSongParserDelegate(
+          performanceMonitor: self.performanceMonitor, prefetch: prefetch, account: accountAsync,
+          library: asyncCompanion.library
+        )
+        try self.parse(response: songResponse, delegate: parserDelegate)
+        return (
+          songCount: parserDelegate.parsedSongs.count,
+          albumIDs: parserDelegate.parsedSongs.compactMap { $0.album?.id }
+        )
+      }
+      guard !isCancelled() else { return false }
+      guard page.songCount > 0 else { break }
+      let pageAlbumIDs = Set(page.albumIDs)
+      let confirmedAlbumIDs = pendingAlbumIDs.subtracting(pageAlbumIDs)
+      try await markAlbumSongsSynced(albumIDs: confirmedAlbumIDs)
+      markedAlbumCount += confirmedAlbumIDs.count
+      pendingAlbumIDs = pageAlbumIDs
+      songOffset += page.songCount
+      pageIndex += 1
+    }
+
+    guard pageIndex < Self.maxBulkSongPages, !isCancelled() else { return false }
+
+    try await markAlbumSongsSynced(albumIDs: pendingAlbumIDs)
+    markedAlbumCount += pendingAlbumIDs.count
+    os_log("Bulk song sync marked %i albums", log: log, type: .info, markedAlbumCount)
+    return true
+  }
+
+  @MainActor
+  private func markAlbumSongsSynced(albumIDs: Set<String>) async throws {
+    guard !albumIDs.isEmpty else { return }
+    try await storage.async.perform { asyncCompanion in
+      let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
+      var albumPrefetchIDs = LibraryStorage.PrefetchIdContainer()
+      albumPrefetchIDs.albumIDs = albumIDs
+      let albumPrefetch = asyncCompanion.library.getElements(
+        account: accountAsync,
+        prefetchIDs: albumPrefetchIDs
+      )
+      for album in albumPrefetch.prefetchedAlbumDict.values {
+        let songs = album.songs
+        album.isCached = !songs.isEmpty && songs.allSatisfy { $0.isCached }
+        album.isSongsMetaDataSynced = true
+      }
     }
   }
 

--- a/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicServerApi.swift
@@ -718,6 +718,20 @@ final class SubsonicServerApi: URLCleanser, Sendable {
     }
   }
 
+  public func requestAllSongs(songOffset: Int, count: Int) async throws -> APIDataResponse {
+    try await request { version in
+      var urlComp = try self.createAuthApiUrlComponent(version: version, forAction: "search3")
+      urlComp.addQueryItem(name: "query", value: "")
+      urlComp.addQueryItem(name: "artistCount", value: 0)
+      urlComp.addQueryItem(name: "artistOffset", value: 0)
+      urlComp.addQueryItem(name: "albumCount", value: 0)
+      urlComp.addQueryItem(name: "albumOffset", value: 0)
+      urlComp.addQueryItem(name: "songCount", value: count)
+      urlComp.addQueryItem(name: "songOffset", value: songOffset)
+      return try self.createUrl(from: urlComp)
+    }
+  }
+
   public func requestPlaylists() async throws -> APIDataResponse {
     try await request { version in
       let urlComp = try self.createAuthApiUrlComponent(version: version, forAction: "getPlaylists")

--- a/AmperfyKit/MetaManager.swift
+++ b/AmperfyKit/MetaManager.swift
@@ -297,10 +297,8 @@ public class MetaManager {
   }
 
   private func startBackgroundLibrarySyncerIfNoResumePending() {
-    let accountSetting = storage.settings.accounts.getSetting(account.info).read
-    let isInitialSyncResumable = accountSetting.initialSyncCompletionStatus == .aborted
-      && accountSetting.initialSyncCompletedAlbumBatches != nil
-    guard !isInitialSyncResumable else { return }
+    guard !storage.settings.accounts.getSetting(account.info).read.isInitialSyncResumable
+    else { return }
     backgroundLibrarySyncer.start()
   }
 

--- a/AmperfyKit/MetaManager.swift
+++ b/AmperfyKit/MetaManager.swift
@@ -257,7 +257,6 @@ public class MetaManager {
     )
     return BackgroundLibrarySyncer(
       storage: storage.async,
-      mainStorage: storage.main,
       settings: storage.settings,
       networkMonitor: networkMonitor,
       librarySyncer: librarySyncer,
@@ -281,7 +280,7 @@ public class MetaManager {
     os_log("Start background manager after sync", log: self.log, type: .info)
     playableDownloadManager.start()
     artworkDownloadManager.start()
-    backgroundLibrarySyncer.start()
+    startBackgroundLibrarySyncerIfNoResumePending()
     let scrobbler = createScrobbleSyncer(player: player)
     player.addNotifier(notifier: scrobbler)
   }
@@ -291,10 +290,18 @@ public class MetaManager {
     duplicateEntitiesResolver.start()
     artworkDownloadManager.start()
     playableDownloadManager.start()
-    backgroundLibrarySyncer.start()
+    startBackgroundLibrarySyncerIfNoResumePending()
     let scrobbler = createScrobbleSyncer(player: player)
     player.addNotifier(notifier: scrobbler)
     scrobbler.start()
+  }
+
+  private func startBackgroundLibrarySyncerIfNoResumePending() {
+    let accountSetting = storage.settings.accounts.getSetting(account.info).read
+    let isInitialSyncResumable = accountSetting.initialSyncCompletionStatus == .aborted
+      && accountSetting.initialSyncCompletedAlbumBatches != nil
+    guard !isInitialSyncResumable else { return }
+    backgroundLibrarySyncer.start()
   }
 
   public func stopManager() {

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -1460,7 +1460,7 @@ public class LibraryStorage: PlayableFileCachable {
     return albums?.lazy.compactMap { Album(managedObject: $0) }.first
   }
 
-  func getAlbumWithoutSyncedSongs() -> [Album] {
+  func getAlbumWithoutSyncedSongs(fetchLimit: Int) -> [Album] {
     let fetchRequest: NSFetchRequest<AlbumMO> = AlbumMO.fetchRequest()
     fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
       NSPredicate(format: "%K == FALSE", #keyPath(AlbumMO.isSongsMetaDataSynced)),
@@ -1470,6 +1470,7 @@ public class LibraryStorage: PlayableFileCachable {
         RemoteStatus.available.rawValue
       ),
     ])
+    fetchRequest.fetchLimit = fetchLimit
     let albums = try? context.fetch(fetchRequest)
     return albums?.lazy.compactMap { Album(managedObject: $0) } ?? [Album]()
   }

--- a/AmperfyKit/Storage/Settings.swift
+++ b/AmperfyKit/Storage/Settings.swift
@@ -334,6 +334,18 @@ public struct AccountSetting: Sendable, Codable {
     set { _homeSections = newValue }
   }
 
+  private var _initialSyncCompletedAlbumBatches: Set<Int>? = nil
+  public var initialSyncCompletedAlbumBatches: Set<Int>? {
+    get { _initialSyncCompletedAlbumBatches }
+    set { _initialSyncCompletedAlbumBatches = newValue }
+  }
+
+  private var _initialSyncAlbumPollCount: Int? = nil
+  public var initialSyncAlbumPollCount: Int? {
+    get { _initialSyncAlbumPollCount }
+    set { _initialSyncAlbumPollCount = newValue }
+  }
+
   private var _initialSyncCompletionStatus: SyncCompletionStatus = .defaultValue
   public var initialSyncCompletionStatus: SyncCompletionStatus {
     get { _initialSyncCompletionStatus }

--- a/AmperfyKit/Storage/Settings.swift
+++ b/AmperfyKit/Storage/Settings.swift
@@ -340,16 +340,20 @@ public struct AccountSetting: Sendable, Codable {
     set { _initialSyncCompletedAlbumBatches = newValue }
   }
 
-  private var _initialSyncAlbumPollCount: Int? = nil
-  public var initialSyncAlbumPollCount: Int? {
-    get { _initialSyncAlbumPollCount }
-    set { _initialSyncAlbumPollCount = newValue }
+  private var _initialSyncAlbumCount: Int? = nil
+  public var initialSyncAlbumCount: Int? {
+    get { _initialSyncAlbumCount }
+    set { _initialSyncAlbumCount = newValue }
   }
 
   private var _initialSyncCompletionStatus: SyncCompletionStatus = .defaultValue
   public var initialSyncCompletionStatus: SyncCompletionStatus {
     get { _initialSyncCompletionStatus }
     set { _initialSyncCompletionStatus = newValue }
+  }
+
+  public var isInitialSyncResumable: Bool {
+    initialSyncCompletionStatus == .aborted && initialSyncCompletedAlbumBatches != nil
   }
 
   private var _isAutoDownloadLatestPodcastEpisodesActive: Bool = false

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -156,6 +156,7 @@ final class MOCK_LibrarySyncer: LibrarySyncer {
     targets: [AlbumSyncTarget],
     isCancelled: @escaping @Sendable () -> Bool
   ) async {}
+  func syncAllSongs(isCancelled: @escaping @Sendable () -> Bool) async throws -> Bool { false }
   func sync(song: Song) async throws {}
   func sync(podcast: Podcast) async throws {}
   func syncNewestPodcastEpisodes() async throws {}

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -152,6 +152,10 @@ final class MOCK_LibrarySyncer: LibrarySyncer {
   func sync(genre: Genre) async throws {}
   func sync(artist: Artist) async throws {}
   func sync(album: Album) async throws {}
+  func syncSongsInBackground(
+    targets: [AlbumSyncTarget],
+    isCancelled: @escaping @Sendable () -> Bool
+  ) async {}
   func sync(song: Song) async throws {}
   func sync(podcast: Podcast) async throws {}
   func syncNewestPodcastEpisodes() async throws {}


### PR DESCRIPTION
Full library sync on a 58k-song / 23.7k-album server: **35–45+ min → ~2 min** on OpenSubsonic servers (Navidrome tested) and **→ ~10 min** on any other server — cooler, resumable, and with no behavior change for servers that don't support the fast path.

## Problem

Measured on a real library (58k songs / 23.7k albums, Navidrome, iPhone):

- The background song sync issues one `getAlbum` request per album (~24k requests) strictly sequentially, and every album pays two background-context saves (~48k saves total). It ran at ~40 songs/s with CPU pinned at ~134%, Energy Impact "Very High", and the device heated up until iOS hardware-throttled it.
- An interrupted initial sync restarts from zero on the next launch, and its fully parallel writes could create duplicate artists/albums.

## Changes (one commit each)

1. **Make the initial sync resumable with bounded parallel album requests.** The album phase fetches pages with a bounded window (4 in flight) while writes stay serialized, removing the duplicate-entity window at its source. Completed pages are checkpointed in the account settings (with an album-count fingerprint that discards stale checkpoints when the server library changed), so an aborted or killed initial sync resumes where it stopped. The pre-sync library wipe only runs when not resuming; an explicit "Resync Library" always starts fresh; Skip cancels the running sync task.

2. **Parallelize background song sync fetches and batch Core Data writes.** The serial OperationQueue becomes a paged driver: song fetches run 4 in parallel, parsing/writes stay serialized and are batched — 16 albums per background context and save instead of 2 saves per album (~48k saves → ~1.5k). Cancellation is re-checked before every batch write and albums deleted in the meantime are skipped via `existingObject`, so a resync/logout can no longer receive late writes. `sync(album:)` now parses the response once into a single context (previously two performs re-parsed the same XML).

3. **Bound the newest-albums song fetch with the same machinery.** The quick "newest albums" sync (pull-to-refresh, Home) used an unbounded task group — up to 50 concurrent writers, and one failure cancelled all of them. It now reuses the bounded/batched path.

4. **Respect thermal state and Low Power Mode.** Between batches: `serious` thermal state → 2 parallel fetches, Low Power Mode → 1, `critical` → bounded pause until the device cools; transitions are logged. Measured: identical total duration on a cool device; when it heats up, the sync adapts its pace instead of running into OS hardware throttling.

5. **Add a bulk fast path via OpenSubsonic `search3`.** The [OpenSubsonic spec](https://opensubsonic.netlify.app/docs/endpoints/search3/) requires servers to support an empty `search3` query *"to allow clients to properly access all the media information for offline sync"* — this implements exactly that: a paged empty-query walk (500 songs/page) fills all albums' songs in ~120 requests instead of ~24k. A small write-free probe detects support at runtime; servers that don't support it (classic Subsonic, Airsonic, Ampache) automatically keep using the per-album path from commit 2, so no setup is worse off. Albums are marked synced per page (confirmed once a later page contains no more of their songs), so progress stays gradual and partial progress survives cancellation. The bulk path deliberately performs no deletion reconciliation: a blank/truncated response (e.g. navidrome/navidrome#2862) is indistinguishable from the end of the listing and could mass-delete real songs.

6. **Apply the critical thermal pause to the bulk path** (shared helper; the width throttling doesn't apply since the bulk walk is already sequential).

## Measured results (58k songs / 23.7k albums, Navidrome, same device and network)

| | before | after (per-album path) | after (OpenSubsonic bulk) |
|---|---|---|---|
| Full song sync | 35–45+ min | ~10 min | **~2 min** |
| Throughput | ~40 songs/s | 200 songs/s (100 when hot, self-throttled) | ~500 songs/s |
| CPU | ~134% | ~106% | low |
| Energy Impact | Very High | High | low |
| Thermals | OS hardware throttling | app-managed, stabilized | stays cool |
| Interrupted initial sync | restarts from zero | resumes | resumes |

## Verification

- `AmperfyKitTests` pass; SwiftFormat (`BuildTools/applyFormat.sh`) applied — no reformatting needed.
- Real-device testing: fresh full syncs with count verification against the server (albums/artists/songs match exactly), kill-and-relaunch mid-initial-sync (resumes), abort via airplane mode + resume, Resync Library and logout mid-sync, Skip, and Low Power Mode toggled mid-sync.

The tuning constants (4 parallel fetches, 16 albums per save, 500 songs per bulk page) are my best measured trade-offs on the hardware above — happy to adjust if you prefer different values.