### PR TITLE
Search: improve responsiveness, find songs by artist and rank results by relevance

### DIFF
--- a/Amperfy/Screens/View/PlayableTableCell.swift
+++ b/Amperfy/Screens/View/PlayableTableCell.swift
@@ -322,6 +322,9 @@ class PlayableTableCell: BasicTableCell {
 
   func refresh() {
     guard let playable = playable else { return }
+    let themePreference = appDelegate.storage.settings.accounts
+      .getSetting(playable.account?.info).read.themePreference
+    let userSettings = appDelegate.storage.settings.user
     titleLabel.text = playable.title
     artistLabel.text = playable.creatorName
 
@@ -330,24 +333,18 @@ class PlayableTableCell: BasicTableCell {
       newStyle: isDislayAlbumTrackNumberStyle ? .trackNumber : .artwork
     )
     entityImage.display(
-      theme: appDelegate.storage.settings.accounts.getSetting(playable.account?.info).read
-        .themePreference,
+      theme: themePreference,
       container: playable
     )
     configurePlayIndicator(playable: playable)
 
     if displayMode == .selection {
       let img = UIImageView(image: isMarked ? .checkmark : .circle)
-      img.tintColor = isMarked ? appDelegate.storage.settings.accounts
-        .getSetting(playable.account?.info).read
-        .themePreference
-        .asColor : .secondaryLabelColor
+      img.tintColor = isMarked ? themePreference.asColor : .secondaryLabelColor
       accessoryView = img
     } else if displayMode == .add {
       let img = UIImageView(image: isMarked ? .checkmark : .plusCircle)
-      img.tintColor = appDelegate.storage.settings.accounts.getSetting(playable.account?.info).read
-        .themePreference
-        .asColor
+      img.tintColor = themePreference.asColor
       accessoryView = img
     } else if displayMode == .reorder || playerIndexCb != nil {
       let img = UIImageView(image: .bars)
@@ -375,10 +372,10 @@ class PlayableTableCell: BasicTableCell {
     }
 
     refreshSubtitleColor()
-    refreshCacheAndDuration()
+    refreshCacheAndDuration(userSettings: userSettings)
 
     // Update rating display for songs (only if setting is enabled)
-    if appDelegate.storage.settings.user.isShowRating, let song = playable.asSong {
+    if userSettings.isShowRating, let song = playable.asSong {
       updateRatingDisplay(rating: song.rating)
     } else {
       ratingStackView?.isHidden = true
@@ -390,15 +387,14 @@ class PlayableTableCell: BasicTableCell {
     trackNumberLabel.text = playable.track > 0 ? "\(playable.track)" : ""
   }
 
-  func refreshCacheAndDuration() {
+  func refreshCacheAndDuration(userSettings: UserSettings) {
     guard let playable = playable else { return }
     favoriteIconImage.isHidden = !playable.isFavorite
     favoriteIconImage.tintColor = .red
 
     let isDurationVisible = !playable.isRadio &&
       (
-        appDelegate.storage.settings.user
-          .isShowSongDuration || (traitCollection.horizontalSizeClass == .regular)
+        userSettings.isShowSongDuration || (traitCollection.horizontalSizeClass == .regular)
       )
     let cacheIconWidth = (traitCollection.horizontalSizeClass == .regular) ? 17.0 : 15.0
     let durationWidth = (
@@ -440,7 +436,7 @@ class PlayableTableCell: BasicTableCell {
     // Each star is 10pt with -2pt spacing: width = rating * 8 + 2
     // We only need extra space beyond what optionsButton area (30pt) already provides
     let songRating = playable.asSong?.rating ?? 0
-    let isRatingVisible = appDelegate.storage.settings.user.isShowRating && songRating > 0
+    let isRatingVisible = userSettings.isShowRating && songRating > 0
     let starWidth = CGFloat(songRating * 8 + 2) // Actual star width for this rating
     let ratingExtraSpace: CGFloat = isRatingVisible ? max(0, starWidth - 26) + 6 : 0.0
 

--- a/Amperfy/Screens/ViewController/AlbumsCommonVCInteractions.swift
+++ b/Amperfy/Screens/ViewController/AlbumsCommonVCInteractions.swift
@@ -532,10 +532,13 @@ class AlbumsCommonVCInteractions {
     )
   }
 
+  private let searchTaskRunner = SearchTaskRunner()
+
   func updateSearchResults(for searchController: UISearchController) {
     let searchText = searchController.searchBar.text ?? ""
+    searchTaskRunner.cancelAll()
     if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 0 {
-      Task { @MainActor in do {
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
         try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchAlbums(searchText: searchText)
       } catch {

--- a/Amperfy/Screens/ViewController/ArtistsVC.swift
+++ b/Amperfy/Screens/ViewController/ArtistsVC.swift
@@ -376,8 +376,11 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
     )
   }
 
+  private let searchTaskRunner = SearchTaskRunner()
+
   override func updateSearchResults(for searchController: UISearchController) {
     let searchText = searchController.searchBar.text ?? ""
+    searchTaskRunner.cancelAll()
     fetchedResultsController.search(
       searchText: searchText,
       onlyCached: searchController.searchBar.selectedScopeButtonIndex == 1,
@@ -385,7 +388,7 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
     )
     tableView.reloadData()
     if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 0 {
-      Task { @MainActor in do {
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
         try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchArtists(searchText: searchText)
       } catch {

--- a/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddArtistsVC.swift
+++ b/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddArtistsVC.swift
@@ -182,8 +182,11 @@ class PlaylistAddArtistsVC: SingleSnapshotFetchedResultsTableViewController<Arti
     navigationController?.pushViewController(nextVC, animated: true)
   }
 
+  private let searchTaskRunner = SearchTaskRunner()
+
   override func updateSearchResults(for searchController: UISearchController) {
     let searchText = searchController.searchBar.text ?? ""
+    searchTaskRunner.cancelAll()
     fetchedResultsController.search(
       searchText: searchText,
       onlyCached: searchController.searchBar.selectedScopeButtonIndex == 1,
@@ -191,8 +194,8 @@ class PlaylistAddArtistsVC: SingleSnapshotFetchedResultsTableViewController<Arti
     )
     tableView.reloadData()
     if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 0 {
-      Task { @MainActor in do {
-        try await self.appDelegate.getMeta(account.info).librarySyncer
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
+        try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchArtists(searchText: searchText)
       } catch {
         self.appDelegate.eventLogger.report(topic: "Artists Search", error: error)

--- a/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddSongsVC.swift
+++ b/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddSongsVC.swift
@@ -222,11 +222,14 @@ class PlaylistAddSongsVC: SingleFetchedResultsTableViewController<SongMO>, Playl
     }
   }
 
+  private let searchTaskRunner = SearchTaskRunner()
+
   override func updateSearchResults(for searchController: UISearchController) {
     guard let searchText = searchController.searchBar.text else { return }
+    searchTaskRunner.cancelAll()
     if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 0 {
-      Task { @MainActor in do {
-        try await self.appDelegate.getMeta(account.info).librarySyncer
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
+        try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchSongs(searchText: searchText)
       } catch {
         self.appDelegate.eventLogger.report(topic: "Songs Search", error: error)

--- a/Amperfy/Screens/ViewController/SearchVC.swift
+++ b/Amperfy/Screens/ViewController/SearchVC.swift
@@ -72,6 +72,7 @@ class SearchVC: BasicTableViewController {
   nonisolated private static let categoryItemLimit = 10
 
   private var diffableDataSource: SearchDiffableDataSource?
+  private let searchTaskRunner = SearchTaskRunner()
   fileprivate var searchHistory: [SearchHistoryItem] = []
   fileprivate var artists: [Artist] = []
   fileprivate var albums: [Album] = []
@@ -501,74 +502,76 @@ class SearchVC: BasicTableViewController {
 
   override func updateSearchResults(for searchController: UISearchController) {
     guard let searchText = searchController.searchBar.text, let accountObjectId else { return }
+    searchTaskRunner.cancelAll()
     if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 0 {
-      Task { @MainActor in do {
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
         try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchArtists(searchText: searchText)
       } catch {
         self.appDelegate.eventLogger.report(topic: "Artists Search", error: error)
       }}
 
-      Task { @MainActor in do {
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
         try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchAlbums(searchText: searchText)
       } catch {
         self.appDelegate.eventLogger.report(topic: "Albums Search", error: error)
       }}
 
-      Task { @MainActor in do {
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
         try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchSongs(searchText: searchText)
       } catch {
         self.appDelegate.eventLogger.report(topic: "Songs Search", error: error)
       }}
 
-      Task { @MainActor in do {
-        let searchResult = try await appDelegate.storage.async.performAndGet { asyncCompanion in
-          let accountAsync = asyncCompanion.library.getAccount(managedObjectId: accountObjectId)
-          let artists = asyncCompanion.library.searchArtists(
-            for: accountAsync,
-            searchText: searchText,
-            onlyCached: false,
-            displayFilter: .all
-          )
-          let albums = asyncCompanion.library.searchAlbums(
-            for: accountAsync,
-            searchText: searchText,
-            onlyCached: false,
-            displayFilter: .all
-          )
-          let playlists = asyncCompanion.library.searchPlaylists(
-            for: accountAsync,
-            searchText: searchText,
-            playlistSearchCategory: .all
-          )
-          let songs = asyncCompanion.library.searchSongs(
-            for: accountAsync,
-            searchText: searchText,
-            onlyCached: false,
-            displayFilter: .all
-          )
+      searchTaskRunner.run { do {
+        let searchResult = try await self.appDelegate.storage.async
+          .performAndGet { asyncCompanion in
+            let accountAsync = asyncCompanion.library.getAccount(managedObjectId: accountObjectId)
+            let artists = asyncCompanion.library.searchArtists(
+              for: accountAsync,
+              searchText: searchText,
+              onlyCached: false,
+              displayFilter: .all
+            )
+            let albums = asyncCompanion.library.searchAlbums(
+              for: accountAsync,
+              searchText: searchText,
+              onlyCached: false,
+              displayFilter: .all
+            )
+            let playlists = asyncCompanion.library.searchPlaylists(
+              for: accountAsync,
+              searchText: searchText,
+              playlistSearchCategory: .all
+            )
+            let songs = asyncCompanion.library.searchSongs(
+              for: accountAsync,
+              searchText: searchText,
+              onlyCached: false,
+              displayFilter: .all
+            )
 
-          var result = SearchResultObjectContainer()
-          result.artistsIDs = FuzzySearcher.findBestMatch(in: artists, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Artist }
-            .compactMap { $0.managedObject.objectID }
-          result.albumsIDs = FuzzySearcher.findBestMatch(in: albums, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Album }
-            .compactMap { $0.managedObject.objectID }
-          result.playlistsIDs = FuzzySearcher.findBestMatch(in: playlists, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Playlist }
-            .compactMap { $0.managedObject.objectID }
-          result.songsIDs = FuzzySearcher.findBestMatch(in: songs, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Song }
-            .compactMap { $0.managedObject.objectID }
-          return result
-        }
+            var result = SearchResultObjectContainer()
+            result.artistsIDs = FuzzySearcher.findBestMatch(in: artists, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Artist }
+              .compactMap { $0.managedObject.objectID }
+            result.albumsIDs = FuzzySearcher.findBestMatch(in: albums, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Album }
+              .compactMap { $0.managedObject.objectID }
+            result.playlistsIDs = FuzzySearcher.findBestMatch(in: playlists, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Playlist }
+              .compactMap { $0.managedObject.objectID }
+            result.songsIDs = FuzzySearcher.findBestMatch(in: songs, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Song }
+              .compactMap { $0.managedObject.objectID }
+            return result
+          }
 
         guard searchText == self.searchController.searchBar.text else { return }
         self.isSearchActive = true
@@ -593,52 +596,53 @@ class SearchVC: BasicTableViewController {
         // do nothing
       }}
     } else if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 1 {
-      Task { @MainActor in do {
-        let searchResult = try await appDelegate.storage.async.performAndGet { asyncCompanion in
-          let accountAsync = asyncCompanion.library.getAccount(managedObjectId: accountObjectId)
-          let artists = asyncCompanion.library.searchArtists(
-            for: accountAsync,
-            searchText: searchText,
-            onlyCached: true,
-            displayFilter: .all
-          )
-          let albums = asyncCompanion.library.searchAlbums(
-            for: accountAsync,
-            searchText: searchText,
-            onlyCached: true,
-            displayFilter: .all
-          )
-          let playlists = asyncCompanion.library.searchPlaylists(
-            for: accountAsync,
-            searchText: searchText,
-            playlistSearchCategory: .cached
-          )
-          let songs = asyncCompanion.library.searchSongs(
-            for: accountAsync,
-            searchText: searchText,
-            onlyCached: true,
-            displayFilter: .all
-          )
+      searchTaskRunner.run { do {
+        let searchResult = try await self.appDelegate.storage.async
+          .performAndGet { asyncCompanion in
+            let accountAsync = asyncCompanion.library.getAccount(managedObjectId: accountObjectId)
+            let artists = asyncCompanion.library.searchArtists(
+              for: accountAsync,
+              searchText: searchText,
+              onlyCached: true,
+              displayFilter: .all
+            )
+            let albums = asyncCompanion.library.searchAlbums(
+              for: accountAsync,
+              searchText: searchText,
+              onlyCached: true,
+              displayFilter: .all
+            )
+            let playlists = asyncCompanion.library.searchPlaylists(
+              for: accountAsync,
+              searchText: searchText,
+              playlistSearchCategory: .cached
+            )
+            let songs = asyncCompanion.library.searchSongs(
+              for: accountAsync,
+              searchText: searchText,
+              onlyCached: true,
+              displayFilter: .all
+            )
 
-          var result = SearchResultObjectContainer()
-          result.artistsIDs = FuzzySearcher.findBestMatch(in: artists, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Artist }
-            .compactMap { $0.managedObject.objectID }
-          result.albumsIDs = FuzzySearcher.findBestMatch(in: albums, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Album }
-            .compactMap { $0.managedObject.objectID }
-          result.playlistsIDs = FuzzySearcher.findBestMatch(in: playlists, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Playlist }
-            .compactMap { $0.managedObject.objectID }
-          result.songsIDs = FuzzySearcher.findBestMatch(in: songs, search: searchText)
-            .prefix(upToAsArray: Self.categoryItemLimit)
-            .compactMap { $0 as? Song }
-            .compactMap { $0.managedObject.objectID }
-          return result
-        }
+            var result = SearchResultObjectContainer()
+            result.artistsIDs = FuzzySearcher.findBestMatch(in: artists, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Artist }
+              .compactMap { $0.managedObject.objectID }
+            result.albumsIDs = FuzzySearcher.findBestMatch(in: albums, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Album }
+              .compactMap { $0.managedObject.objectID }
+            result.playlistsIDs = FuzzySearcher.findBestMatch(in: playlists, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Playlist }
+              .compactMap { $0.managedObject.objectID }
+            result.songsIDs = FuzzySearcher.findBestMatch(in: songs, search: searchText)
+              .prefix(upToAsArray: Self.categoryItemLimit)
+              .compactMap { $0 as? Song }
+              .compactMap { $0.managedObject.objectID }
+            return result
+          }
 
         guard searchText == self.searchController.searchBar.text else { return }
         self.isSearchActive = true

--- a/Amperfy/Screens/ViewController/SearchVC.swift
+++ b/Amperfy/Screens/ViewController/SearchVC.swift
@@ -566,10 +566,15 @@ class SearchVC: BasicTableViewController {
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Playlist }
               .compactMap { $0.managedObject.objectID }
-            result.songsIDs = FuzzySearcher.findBestMatch(in: songs, search: searchText)
-              .prefix(upToAsArray: Self.categoryItemLimit)
-              .compactMap { $0 as? Song }
-              .compactMap { $0.managedObject.objectID }
+            result.songsIDs = FuzzySearcher.findBestMatch(
+              in: songs,
+              search: searchText,
+              isTokenized: true,
+              searchableText: { "\($0.name) \(($0 as? Song)?.creatorName ?? "")" }
+            )
+            .prefix(upToAsArray: Self.categoryItemLimit)
+            .compactMap { $0 as? Song }
+            .compactMap { $0.managedObject.objectID }
             return result
           }
 
@@ -637,10 +642,15 @@ class SearchVC: BasicTableViewController {
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Playlist }
               .compactMap { $0.managedObject.objectID }
-            result.songsIDs = FuzzySearcher.findBestMatch(in: songs, search: searchText)
-              .prefix(upToAsArray: Self.categoryItemLimit)
-              .compactMap { $0 as? Song }
-              .compactMap { $0.managedObject.objectID }
+            result.songsIDs = FuzzySearcher.findBestMatch(
+              in: songs,
+              search: searchText,
+              isTokenized: true,
+              searchableText: { "\($0.name) \(($0 as? Song)?.creatorName ?? "")" }
+            )
+            .prefix(upToAsArray: Self.categoryItemLimit)
+            .compactMap { $0 as? Song }
+            .compactMap { $0.managedObject.objectID }
             return result
           }
 

--- a/Amperfy/Screens/ViewController/SearchVC.swift
+++ b/Amperfy/Screens/ViewController/SearchVC.swift
@@ -69,7 +69,7 @@ class SearchDiffableDataSource: BasicUITableViewDiffableDataSource {
 class SearchVC: BasicTableViewController {
   override var sceneTitle: String { "Search" }
 
-  nonisolated private static let categoryItemLimit = 10
+  nonisolated private static let categoryItemLimit = 20
 
   private var diffableDataSource: SearchDiffableDataSource?
   private let searchTaskRunner = SearchTaskRunner()
@@ -554,15 +554,18 @@ class SearchVC: BasicTableViewController {
             )
 
             var result = SearchResultObjectContainer()
-            result.artistsIDs = FuzzySearcher.findBestMatch(in: artists, search: searchText)
+            result.artistsIDs = FuzzySearcher
+              .findBestMatch(in: artists, search: searchText, isTokenized: true)
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Artist }
               .compactMap { $0.managedObject.objectID }
-            result.albumsIDs = FuzzySearcher.findBestMatch(in: albums, search: searchText)
+            result.albumsIDs = FuzzySearcher
+              .findBestMatch(in: albums, search: searchText, isTokenized: true)
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Album }
               .compactMap { $0.managedObject.objectID }
-            result.playlistsIDs = FuzzySearcher.findBestMatch(in: playlists, search: searchText)
+            result.playlistsIDs = FuzzySearcher
+              .findBestMatch(in: playlists, search: searchText, isTokenized: true)
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Playlist }
               .compactMap { $0.managedObject.objectID }
@@ -630,15 +633,18 @@ class SearchVC: BasicTableViewController {
             )
 
             var result = SearchResultObjectContainer()
-            result.artistsIDs = FuzzySearcher.findBestMatch(in: artists, search: searchText)
+            result.artistsIDs = FuzzySearcher
+              .findBestMatch(in: artists, search: searchText, isTokenized: true)
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Artist }
               .compactMap { $0.managedObject.objectID }
-            result.albumsIDs = FuzzySearcher.findBestMatch(in: albums, search: searchText)
+            result.albumsIDs = FuzzySearcher
+              .findBestMatch(in: albums, search: searchText, isTokenized: true)
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Album }
               .compactMap { $0.managedObject.objectID }
-            result.playlistsIDs = FuzzySearcher.findBestMatch(in: playlists, search: searchText)
+            result.playlistsIDs = FuzzySearcher
+              .findBestMatch(in: playlists, search: searchText, isTokenized: true)
               .prefix(upToAsArray: Self.categoryItemLimit)
               .compactMap { $0 as? Playlist }
               .compactMap { $0.managedObject.objectID }

--- a/Amperfy/Screens/ViewController/SongsVC.swift
+++ b/Amperfy/Screens/ViewController/SongsVC.swift
@@ -293,10 +293,13 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
     return convertIndexPathToPlayContext(songIndexPath: indexPath)
   }
 
+  private let searchTaskRunner = SearchTaskRunner()
+
   override func updateSearchResults(for searchController: UISearchController) {
     guard let searchText = searchController.searchBar.text else { return }
+    searchTaskRunner.cancelAll()
     if !searchText.isEmpty, searchController.searchBar.selectedScopeButtonIndex == 0 {
-      Task { @MainActor in do {
+      searchTaskRunner.runRemoteSearch(searchText: searchText) { do {
         try await self.appDelegate.getMeta(self.account.info).librarySyncer
           .searchSongs(searchText: searchText)
       } catch {

--- a/Amperfy/Screens/ViewController/TableViewHelper/SearchDebouncer.swift
+++ b/Amperfy/Screens/ViewController/TableViewHelper/SearchDebouncer.swift
@@ -43,6 +43,29 @@ final class DebouncedSearchResultsUpdater: NSObject, UISearchResultsUpdating {
   }
 }
 
+// MARK: - SearchTaskRunner
+
+@MainActor
+final class SearchTaskRunner {
+  static let remoteSearchTextMinLength = 2
+
+  private var tasks = [Task<(), Never>]()
+
+  func run(_ operation: @escaping @MainActor () async -> ()) {
+    tasks.append(Task { @MainActor in await operation() })
+  }
+
+  func runRemoteSearch(searchText: String, _ operation: @escaping @MainActor () async -> ()) {
+    guard searchText.count >= Self.remoteSearchTextMinLength else { return }
+    run(operation)
+  }
+
+  func cancelAll() {
+    tasks.forEach { $0.cancel() }
+    tasks.removeAll()
+  }
+}
+
 // MARK: - SearchDebouncer
 
 @MainActor

--- a/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheLibrarySyncer.swift
@@ -1343,6 +1343,7 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSyncAllowed, !searchText.isEmpty else { return }
     os_log("Search artists via API: \"%s\"", log: log, type: .info, searchText)
     let response = try await ampacheXmlServerApi.requestSearchArtists(searchText: searchText)
+    guard !Task.isCancelled else { return }
     try await storage.async.perform { asyncCompanion in
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let idParserDelegate = IDsParserDelegate(performanceMonitor: self.performanceMonitor)
@@ -1369,6 +1370,7 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSyncAllowed, !searchText.isEmpty else { return }
     os_log("Search albums via API: \"%s\"", log: log, type: .info, searchText)
     let response = try await ampacheXmlServerApi.requestSearchAlbums(searchText: searchText)
+    guard !Task.isCancelled else { return }
     try await storage.async.perform { asyncCompanion in
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let idParserDelegate = IDsParserDelegate(performanceMonitor: self.performanceMonitor)
@@ -1395,6 +1397,7 @@ class AmpacheLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSyncAllowed, !searchText.isEmpty else { return }
     os_log("Search songs via API: \"%s\"", log: log, type: .info, searchText)
     let response = try await ampacheXmlServerApi.requestSearchSongs(searchText: searchText)
+    guard !Task.isCancelled else { return }
     try await storage.async.perform { asyncCompanion in
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let idParserDelegate = IDsParserDelegate(performanceMonitor: self.performanceMonitor)

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -1221,6 +1221,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSyncAllowed, !searchText.isEmpty else { return }
     os_log("Search artists via API: \"%s\"", log: log, type: .info, searchText)
     let response = try await subsonicServerApi.requestSearchArtists(searchText: searchText)
+    guard !Task.isCancelled else { return }
     try await storage.async.perform { asyncCompanion in
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)
@@ -1247,6 +1248,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSyncAllowed, !searchText.isEmpty else { return }
     os_log("Search albums via API: \"%s\"", log: log, type: .info, searchText)
     let response = try await subsonicServerApi.requestSearchAlbums(searchText: searchText)
+    guard !Task.isCancelled else { return }
     try await storage.async.perform { asyncCompanion in
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)
@@ -1273,6 +1275,7 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
     guard isSyncAllowed, !searchText.isEmpty else { return }
     os_log("Search songs via API: \"%s\"", log: log, type: .info, searchText)
     let response = try await subsonicServerApi.requestSearchSongs(searchText: searchText)
+    guard !Task.isCancelled else { return }
     try await storage.async.perform { asyncCompanion in
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let idParserDelegate = SsIDsParserDelegate(performanceMonitor: self.performanceMonitor)

--- a/AmperfyKit/Common/FuzzySearcher.swift
+++ b/AmperfyKit/Common/FuzzySearcher.swift
@@ -33,16 +33,18 @@ public struct MatchResult {
 public class FuzzySearcher {
   public static func findBestMatch(
     in items: [PlayableContainable],
-    search: String
+    search: String,
+    isTokenized: Bool = false,
+    searchableText: (PlayableContainable) -> String = { $0.name }
   )
     -> [PlayableContainable] {
-    let fuse = Fuse()
+    let fuse = Fuse(tokenize: isTokenized)
     // Improve performance by creating the pattern once
     let pattern = fuse.createPattern(from: search)
 
     var matches = [MatchResult]()
     items.forEach {
-      let result = fuse.search(pattern, in: $0.name)
+      let result = fuse.search(pattern, in: searchableText($0))
       if let result = result {
         matches.append(MatchResult(item: $0, score: result.score))
       }

--- a/AmperfyKit/Common/FuzzySearcher.swift
+++ b/AmperfyKit/Common/FuzzySearcher.swift
@@ -31,6 +31,11 @@ public struct MatchResult {
 // MARK: - FuzzySearcher
 
 public class FuzzySearcher {
+  nonisolated private static let foldOptions: String.CompareOptions = [
+    .caseInsensitive,
+    .diacriticInsensitive,
+  ]
+
   public static func findBestMatch(
     in items: [PlayableContainable],
     search: String,
@@ -38,7 +43,72 @@ public class FuzzySearcher {
     searchableText: (PlayableContainable) -> String = { $0.name }
   )
     -> [PlayableContainable] {
-    let fuse = Fuse(tokenize: isTokenized)
+    guard isTokenized else {
+      return findBestFuzzyMatch(in: items, search: search, searchableText: searchableText)
+    }
+
+    let fuse = Fuse()
+    let foldedSearch = search.folding(options: foldOptions, locale: nil)
+    let searchWords = splitInWords(foldedSearch)
+    guard !searchWords.isEmpty else { return [] }
+    // Improve performance by creating the patterns once
+    let patterns = searchWords.map { fuse.createPattern(from: $0) }
+
+    var matches = [(item: PlayableContainable, rank: Int, name: String, score: Double)]()
+    for item in items {
+      let foldedName = item.name.folding(options: foldOptions, locale: nil)
+      let text = searchableText(item)
+
+      let rank: Int
+      if foldedName == foldedSearch {
+        rank = 0
+      } else if foldedName.hasPrefix(foldedSearch) {
+        rank = 1
+      } else if isEveryWordMatching(searchWords: searchWords, in: foldedName) {
+        rank = 2
+      } else if isEveryWordMatching(
+        searchWords: searchWords,
+        in: text.folding(options: foldOptions, locale: nil)
+      ) {
+        rank = 3
+      } else {
+        let score = patterns
+          .reduce(0.0) { $0 + (fuse.search($1, in: text)?.score ?? 1) } / Double(patterns.count)
+        guard score < 1 else { continue }
+        matches.append((item, 4, foldedName, score))
+        continue
+      }
+      matches.append((item, rank, foldedName, 0))
+    }
+    return matches.sorted {
+      if $0.rank != $1.rank { return $0.rank < $1.rank }
+      if $0.rank < 4 { return $0.name < $1.name }
+      return $0.score < $1.score
+    }.map(\.item)
+  }
+
+  nonisolated private static func splitInWords(_ text: String) -> [String] {
+    text.split { !$0.isLetter && !$0.isNumber }.map { String($0) }
+  }
+
+  nonisolated private static func isEveryWordMatching(
+    searchWords: [String],
+    in text: String
+  )
+    -> Bool {
+    let textWords = splitInWords(text)
+    return searchWords.allSatisfy { searchWord in
+      textWords.contains { $0.hasPrefix(searchWord) }
+    }
+  }
+
+  private static func findBestFuzzyMatch(
+    in items: [PlayableContainable],
+    search: String,
+    searchableText: (PlayableContainable) -> String
+  )
+    -> [PlayableContainable] {
+    let fuse = Fuse()
     // Improve performance by creating the pattern once
     let pattern = fuse.createPattern(from: search)
 

--- a/AmperfyKit/Storage/EntityWrappers/Artist.swift
+++ b/AmperfyKit/Storage/EntityWrappers/Artist.swift
@@ -123,10 +123,13 @@ extension Artist: PlayableContainable {
   public var subsubtitle: String? { nil }
   public func infoDetails(for api: ServerApiType?, details: DetailInfoType) -> [String] {
     var infoContent = [String]()
-    if let managedObjectContext = managedObject.managedObjectContext, let account {
+    if details.type == .long, let managedObjectContext = managedObject.managedObjectContext,
+       let account {
       let library = LibraryStorage(context: managedObjectContext)
-      let relatedAlbumCount = library.getAlbums(for: account, whichContainsSongsWithArtist: self)
-        .count
+      let relatedAlbumCount = library.getAlbumsCount(
+        for: account,
+        whichContainsSongsWithArtist: self
+      )
       if relatedAlbumCount == 1 {
         infoContent.append("1 Album")
       } else if relatedAlbumCount > 1 {
@@ -138,11 +141,13 @@ extension Artist: PlayableContainable {
       infoContent.append("\(albumCount) Albums")
     }
 
-    if details.artistFilterSetting == .albumArtists,
+    if details.type == .long, details.artistFilterSetting == .albumArtists,
        let managedObjectContext = managedObject.managedObjectContext, let account {
       let library = LibraryStorage(context: managedObjectContext)
-      let relatedSongsCount = library.getSongs(for: account, whichContainsSongsWithArtist: self)
-        .count
+      let relatedSongsCount = library.getSongsCount(
+        for: account,
+        whichContainsSongsWithArtist: self
+      )
       if relatedSongsCount == 1 {
         infoContent.append("1 Song")
       } else if relatedSongsCount > 1 {

--- a/AmperfyKit/Storage/EntityWrappers/PlayableContainable.swift
+++ b/AmperfyKit/Storage/EntityWrappers/PlayableContainable.swift
@@ -42,10 +42,11 @@ public struct DetailInfoType {
 
   public init(type: DetailType, settings: AmperfySettings) {
     self.type = type
-    self.isShowDetailedInfo = settings.user.isShowDetailedInfo
-    self.isShowAlbumDuration = settings.user.isShowAlbumDuration
-    self.isShowArtistDuration = settings.user.isShowArtistDuration
-    self.artistFilterSetting = settings.user.artistsFilterSetting
+    let userSettings = settings.user
+    self.isShowDetailedInfo = userSettings.isShowDetailedInfo
+    self.isShowAlbumDuration = userSettings.isShowAlbumDuration
+    self.isShowArtistDuration = userSettings.isShowArtistDuration
+    self.artistFilterSetting = userSettings.artistsFilterSetting
   }
 }
 

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -2328,7 +2328,7 @@ public class LibraryStorage: PlayableFileCachable {
     let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
       getFetchPredicate(forAccount: account),
       SongMO.excludeServerDeleteUncachedSongsFetchPredicate,
-      SongMO.getIdentifierBasedSearchPredicate(searchText: searchText),
+      SongMO.getTitleAndArtistSearchPredicate(searchText: searchText),
       getFetchPredicate(onlyCachedSongs: onlyCached),
       getFetchPredicate(songsDisplayFilter: displayFilter),
     ])

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -1438,6 +1438,22 @@ public class LibraryStorage: PlayableFileCachable {
     return albums ?? [Album]()
   }
 
+  public func getAlbumsCount(
+    for account: Account,
+    whichContainsSongsWithArtist artist: Artist
+  )
+    -> Int {
+    let fetchRequest: NSFetchRequest<AlbumMO> = AlbumMO.fetchRequest()
+    fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+      getFetchPredicate(forAccount: account),
+      NSCompoundPredicate(orPredicateWithSubpredicates: [
+        getFetchPredicate(forArtist: artist),
+        AlbumMO.getFetchPredicateForAlbumsWhoseSongsHave(artist: artist),
+      ]),
+    ])
+    return (try? context.count(for: fetchRequest)) ?? 0
+  }
+
   public func getAlbum(for account: Account, id: String, isDetailFaultResolution: Bool) -> Album? {
     let fetchRequest: NSFetchRequest<AlbumMO> = AlbumMO.fetchRequest()
     fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
@@ -1630,6 +1646,23 @@ public class LibraryStorage: PlayableFileCachable {
     let foundSongs = try? context.fetch(fetchRequest)
     let songs = foundSongs?.compactMap { Song(managedObject: $0) }
     return songs ?? [Song]()
+  }
+
+  public func getSongsCount(
+    for account: Account,
+    whichContainsSongsWithArtist artist: Artist
+  )
+    -> Int {
+    let fetchRequest: NSFetchRequest<SongMO> = SongMO.fetchRequest()
+    fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+      getFetchPredicate(forAccount: account),
+      SongMO.excludeServerDeleteUncachedSongsFetchPredicate,
+      NSCompoundPredicate(orPredicateWithSubpredicates: [
+        getFetchPredicate(forArtist: artist),
+        getFetchPredicate(forSongsOfArtistWithCommonAlbum: artist),
+      ]),
+    ])
+    return (try? context.count(for: fetchRequest)) ?? 0
   }
 
   public func getCachedSongs(for account: Account) -> [Song] {
@@ -2189,7 +2222,7 @@ public class LibraryStorage: PlayableFileCachable {
     displayFilter: ArtistCategoryFilter
   )
     -> [Artist] {
-    let fetchRequest = ArtistMO.identifierSortedFetchRequest
+    let fetchRequest: NSFetchRequest<ArtistMO> = ArtistMO.fetchRequest()
     fetchRequest.predicate = getSearchArtistsPredicate(
       for: account,
       searchText: searchText,
@@ -2228,7 +2261,7 @@ public class LibraryStorage: PlayableFileCachable {
     displayFilter: DisplayCategoryFilter
   )
     -> [Album] {
-    let fetchRequest = AlbumMO.identifierSortedFetchRequest
+    let fetchRequest: NSFetchRequest<AlbumMO> = AlbumMO.fetchRequest()
     fetchRequest.predicate = getSearchAlbumsPredicate(
       for: account,
       searchText: searchText,
@@ -2261,7 +2294,7 @@ public class LibraryStorage: PlayableFileCachable {
     playlistSearchCategory: PlaylistSearchCategory
   )
     -> [Playlist] {
-    let fetchRequest = PlaylistMO.identifierSortedFetchRequest
+    let fetchRequest: NSFetchRequest<PlaylistMO> = PlaylistMO.fetchRequest()
     fetchRequest.predicate = getSearchPlaylistsPredicate(
       for: account,
       searchText: searchText,
@@ -2309,7 +2342,7 @@ public class LibraryStorage: PlayableFileCachable {
     displayFilter: DisplayCategoryFilter
   )
     -> [Song] {
-    let fetchRequest = SongMO.identifierSortedFetchRequest
+    let fetchRequest: NSFetchRequest<SongMO> = SongMO.fetchRequest()
     fetchRequest.predicate = getSearchSongsPredicate(
       for: account,
       searchText: searchText,

--- a/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataClass.swift
+++ b/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataClass.swift
@@ -34,6 +34,17 @@ extension SongMO: CoreDataIdentifyable {
     \SongMO.title
   }
 
+  static func getTitleAndArtistSearchPredicate(searchText: String) -> NSPredicate {
+    guard !searchText.isEmpty else { return NSPredicate(value: true) }
+    let searchWords = searchText.split(whereSeparator: \.isWhitespace).map { String($0) }
+    return NSCompoundPredicate(andPredicateWithSubpredicates: searchWords.map { searchWord in
+      NSCompoundPredicate(orPredicateWithSubpredicates: [
+        NSPredicate(format: "%K contains[cd] %@", #keyPath(SongMO.title), searchWord),
+        NSPredicate(format: "%K contains[cd] %@", #keyPath(SongMO.artist.name), searchWord),
+      ])
+    })
+  }
+
   static var excludeServerDeleteUncachedSongsFetchPredicate: NSPredicate {
     // see also Song Array extension [Song].filterServerDeleteUncachedSongs()
     NSCompoundPredicate(orPredicateWithSubpredicates: [


### PR DESCRIPTION
This PR improves the global search (and the per-list searches) in three areas: responsiveness while typing, finding songs by artist, and result ranking. Measured on a real device against a Navidrome library with ~58k songs / ~3.1k artists.

### Motivation

On a large library the search screen had three problems:

1. **The keyboard froze for 0.6–1.3 s** every time results were rendered while typing.
2. **"artist + song" queries returned nothing** (e.g. `guetta titanium`), although the server-side `search3` already matches artist fields.
3. **Songs the user knows they have were invisible**: results were ranked by the character position of the match inside the title and cut to 10 per category, so e.g. searching `myself` never showed *If I Lose Myself* because enough titles had the word earlier in the string.

### Changes (one commit each)

- **Search: cancel stale search tasks and skip single-character remote search** — a small `SearchTaskRunner` (next to the existing `SearchDebouncer`) is used by SearchVC and the five list searchers: in-flight search tasks are cancelled on every keystroke, remote API search is only triggered for 2+ characters, and the library syncers skip parsing/persisting a search response whose task was already cancelled. Local (offline) search behavior is unchanged.

- **Performance: avoid heavy fetches and repeated settings decodes when rendering cells** — `Artist.infoDetails` executed two fetch requests *per cell* on the main thread (each scanning the songs table; 40–320 ms per artist cell on device). Cells now use the stored `albumCount`/`songCount` (kept up to date in `ArtistMO`'s save hooks) and only the entity preview keeps the precise relationship-based counts, now via `count(for:)` fetches. Additionally `DetailInfoType.init` and `PlayableTableCell` read the decoded user settings once instead of 4–5 times per cell, and the search fetch requests no longer sort (the ranking reorders anyway). Result rendering went from 600–1300 ms of main-thread work to 8–42 ms; this also removes the artist-cell cost from all lists.

- **Search: match songs by artist name and rank multi-word searches per word** — the song search predicate now requires every query word to appear in the title *or* the artist name, and the ranking text for songs includes the artist. This is purely additive (everything that matched before still matches) and aligns the local search with what `search3` already does on the server. The Songs tab and playlist-add search share the predicate, so they benefit as well. `guetta titanium` and `onerepublic lose` used to return nothing; now they find the songs.

- **Search: rank whole-word matches first and show more results per category** — results are ranked in tiers instead of by match position: exact title, title prefix, all query words matching words of the title, all query words matching words of title+artist, and fuzzy matches last; ties within a tier are alphabetical. Comparison is case- and diacritic-insensitive and word splitting ignores punctuation. The per-category limit goes from 10 to 20 (cells are cheap to render now). The Siri/Intents fuzzy search path is untouched. Searching `myself` or `lose` now shows *If I Lose Myself*; `closer` no longer outranks whole-word `lose` matches.

### Testing

- Manual testing on device (iPhone, Navidrome, ~58k songs): typing is smooth (main-thread render measured 8–42 ms, was 600–1300 ms), offline/airplane-mode search works unchanged, Songs/Artists/Albums/playlist-add searches verified, Siri "play …" intents unaffected.
- `AmperfyKitTests` pass and SwiftFormat has been applied.