### PR TITLE
Performance: batch playback queue persistence

### DIFF
--- a/AmperfyKit/Player/AudioPlayer.swift
+++ b/AmperfyKit/Player/AudioPlayer.swift
@@ -161,11 +161,7 @@ public class AudioPlayer: NSObject, BackendAudioPlayerNotifiable {
     guard let activePlayable = context.getActivePlayable() else { return }
     let topUserQueueItem = queueHandler.getUserQueueItem(at: 0)
     let wasUserQueuePlaying = queueHandler.isUserQueuePlaying
-    queueHandler.clearActiveQueue()
-    queueHandler.appendActiveQueue(playables: context.playables)
-    if context.type == .music {
-      queueHandler.setContextName(context.name)
-    }
+    queueHandler.replaceActiveQueue(playables: context.playables, contextName: context.name)
 
     if queueHandler.isUserQueuePlaying {
       play(playerIndex: PlayerIndex(queueType: .next, index: context.index))

--- a/AmperfyKit/Player/PlayQueueHandler.swift
+++ b/AmperfyKit/Player/PlayQueueHandler.swift
@@ -195,6 +195,10 @@ public class PlayQueueHandler {
     playerQueues.appendActiveQueue(playables: playables)
   }
 
+  func replaceActiveQueue(playables: [AbstractPlayable], contextName: String) {
+    playerQueues.replaceActiveQueue(playables: playables, contextName: contextName)
+  }
+
   func insertContextQueue(playables: [AbstractPlayable]) {
     playerQueues.setContextName("")
     playerQueues.insertContextQueue(playables: playables)

--- a/AmperfyKit/Storage/EntityWrappers/PlayerData.swift
+++ b/AmperfyKit/Storage/EntityWrappers/PlayerData.swift
@@ -69,6 +69,7 @@ protocol PlayerQueuesPersistent {
 
   func insertActiveQueue(playables: [AbstractPlayable])
   func appendActiveQueue(playables: [AbstractPlayable])
+  func replaceActiveQueue(playables: [AbstractPlayable], contextName: String)
   func insertContextQueue(playables: [AbstractPlayable])
   func appendContextQueue(playables: [AbstractPlayable])
   func insertUserQueue(playables: [AbstractPlayable])
@@ -290,8 +291,14 @@ extension PlayerData: PlayerQueuesPersistent {
   private var isUserQueuPlayingInternal: Bool { managedObject.isUserQueuePlaying }
 
   private func setUserQueuPlayingInternal(_ newValue: Bool) {
+    setUserQueuPlayingInternal(newValue, saveContext: true)
+  }
+
+  private func setUserQueuPlayingInternal(_ newValue: Bool, saveContext: Bool) {
     managedObject.isUserQueuePlaying = newValue
-    library.saveContext()
+    if saveContext {
+      library.saveContext()
+    }
   }
 
   var isUserQueueVisible: Bool {
@@ -347,7 +354,12 @@ extension PlayerData: PlayerQueuesPersistent {
   }
 
   func setContextName(_ newValue: String) {
-    contextPlaylist.name = newValue
+    setContextName(newValue, saveContext: true)
+  }
+
+  private func setContextName(_ newValue: String, saveContext: Bool) {
+    guard contextPlaylist.setNameWithoutSaving(newValue), saveContext else { return }
+    library.saveContext()
   }
 
   var currentIndex: Int {
@@ -360,13 +372,19 @@ extension PlayerData: PlayerQueuesPersistent {
   }
 
   func setCurrentIndex(_ newValue: Int) {
+    setCurrentIndex(newValue, saveContext: true)
+  }
+
+  private func setCurrentIndex(_ newValue: Int, saveContext: Bool) {
     switch playerMode {
     case .music:
       currentMusicIndex = newValue
     case .podcast:
       currentPodcastIndex = newValue
     }
-    library.saveContext()
+    if saveContext {
+      library.saveContext()
+    }
   }
 
   private var currentMusicIndex: Int {
@@ -455,6 +473,28 @@ extension PlayerData: PlayerQueuesPersistent {
     case .podcast:
       appendPodcastQueue(playables: playables)
     }
+  }
+
+  func replaceActiveQueue(playables: [AbstractPlayable], contextName: String) {
+    switch playerMode {
+    case .music:
+      setContextName(contextName, saveContext: false)
+      contextPlaylist.removeAllItemsWithoutSaving()
+      shuffledContextPlaylist.removeAllItemsWithoutSaving()
+      if userQueuePlaylistInternal.songCount > 0 {
+        setUserQueuPlayingInternal(true, saveContext: false)
+        currentMusicIndex = -1
+      } else {
+        currentMusicIndex = 0
+      }
+      contextPlaylist.appendWithoutSaving(playables: playables)
+      shuffledContextPlaylist.appendWithoutSaving(playables: playables)
+    case .podcast:
+      podcastPlaylist.removeAllItemsWithoutSaving()
+      setCurrentIndex(0, saveContext: false)
+      podcastPlaylist.appendWithoutSaving(playables: playables)
+    }
+    library.saveContext()
   }
 
   func insertContextQueue(playables: [AbstractPlayable]) {

--- a/AmperfyKit/Storage/EntityWrappers/Playlist.swift
+++ b/AmperfyKit/Storage/EntityWrappers/Playlist.swift
@@ -149,13 +149,21 @@ public class Playlist: Identifyable {
       managedObject.name ?? ""
     }
     set {
-      if managedObject.name != newValue {
-        managedObject.name = newValue
-        updateAlphabeticSectionInitial(section: newValue)
-        updateChangeDate()
+      if setNameWithoutSaving(newValue) {
         library.saveContext()
       }
     }
+  }
+
+  @discardableResult
+  func setNameWithoutSaving(_ newValue: String) -> Bool {
+    if managedObject.name != newValue {
+      managedObject.name = newValue
+      updateAlphabeticSectionInitial(section: newValue)
+      updateChangeDate()
+      return true
+    }
+    return false
   }
 
   func updateAlphabeticSectionInitial(section: String) {
@@ -250,13 +258,17 @@ public class Playlist: Identifyable {
   }
 
   public func append(playables playablesToAppend: [AbstractPlayable]) {
+    appendWithoutSaving(playables: playablesToAppend)
+    library.saveContext()
+  }
+
+  func appendWithoutSaving(playables playablesToAppend: [AbstractPlayable]) {
     for playable in playablesToAppend {
       createAndAppendPlaylistItem(for: playable)
     }
     updateChangeDate()
     updateDuration(byIncreasingDuration: playablesToAppend.reduce(0) { $0 + $1.duration })
     updateArtworkItems()
-    library.saveContext()
   }
 
   public func createAndAppendPlaylistItem(for playable: AbstractPlayable) {
@@ -448,12 +460,16 @@ public class Playlist: Identifyable {
   }
 
   public func removeAllItems() {
+    removeAllItemsWithoutSaving()
+    library.saveContext()
+  }
+
+  func removeAllItemsWithoutSaving() {
     managedObject.removeAllItems()
     updateChangeDate()
     updateArtworkItems()
     managedObject.duration = 0
     managedObject.remoteDuration = 0
-    library.saveContext()
   }
 
   public func shuffle() {

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -703,6 +703,23 @@ class MusicPlayerTest: XCTestCase {
     XCTAssertEqual(testPlayer.contextName, "asdf")
   }
 
+  func testQueueReplacementPersistsContextNameWithOneSave() {
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testQueueHandler.replaceActiveQueue(playables: [songCached], contextName: "Replacement")
+
+    XCTAssertEqual(saveCount, 1)
+    XCTAssertEqual(testQueueHandler.contextName, "Replacement")
+  }
+
   func testContextName_changeContext() {
     testPlayer.play(context: PlayContext(name: "asdf", playables: [songCached]))
     XCTAssertEqual(testPlayer.contextName, "asdf")

--- a/AmperfyKitTests/Cases/Storage/ManagedObjects/PlayerDataTest.swift
+++ b/AmperfyKitTests/Cases/Storage/ManagedObjects/PlayerDataTest.swift
@@ -20,6 +20,7 @@
 //
 
 @testable import AmperfyKit
+import CoreData
 import XCTest
 
 @MainActor
@@ -82,6 +83,148 @@ class PlayerDataTest: XCTestCase {
     fillPlayerWithSomeSongs()
     XCTAssertEqual(testPlayer.activeQueue.playables.count, fillCount)
     checkCorrectDefaultPlaylist()
+  }
+
+  func testReplaceActiveQueueSavesOnce() {
+    fillPlayerWithSomeSongs()
+    let songs = (0 ... 2).compactMap {
+      library.getSong(for: account, id: cdHelper.seeder.songs[$0].id)
+    }
+    XCTAssertEqual(songs.count, 3)
+
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testPlayer.replaceActiveQueue(playables: songs, contextName: "Replacement")
+
+    XCTAssertEqual(saveCount, 1)
+    XCTAssertEqual(testPlayer.contextName, "Replacement")
+    testPlayer.setShuffle(false)
+    XCTAssertEqual(testPlayer.activeQueue.playables.map(\.id), songs.map(\.id))
+    testPlayer.setShuffle(true)
+    XCTAssertEqual(Set(testPlayer.activeQueue.playables.map(\.id)), Set(songs.map(\.id)))
+    XCTAssertEqual(testPlayer.activeQueue.songCount, songs.count)
+  }
+
+  func testReplaceActiveQueueWithUserQueueSavesOnce() {
+    let songs = (0 ... 2).compactMap {
+      library.getSong(for: account, id: cdHelper.seeder.songs[$0].id)
+    }
+    XCTAssertEqual(songs.count, 3)
+    testPlayer.appendUserQueue(playables: [songs[0]])
+
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testPlayer.replaceActiveQueue(
+      playables: Array(songs.dropFirst()),
+      contextName: "User Queue Replacement"
+    )
+
+    XCTAssertEqual(saveCount, 1)
+    XCTAssertEqual(testPlayer.contextName, "User Queue Replacement")
+    XCTAssertTrue(testPlayer.isUserQueuePlaying)
+    XCTAssertEqual(testPlayer.currentIndex, -1)
+    XCTAssertEqual(testPlayer.contextQueue.playables.map(\.id), songs.dropFirst().map(\.id))
+    XCTAssertEqual(
+      Set(testPlayer.inactiveQueue.playables.map(\.id)),
+      Set(songs.dropFirst().map(\.id))
+    )
+  }
+
+  func testReplacePodcastQueueSavesOnce() {
+    let songs = (0 ... 2).compactMap {
+      library.getSong(for: account, id: cdHelper.seeder.songs[$0].id)
+    }
+    XCTAssertEqual(songs.count, 3)
+    testPlayer.setPlayerMode(.podcast)
+    testPlayer.appendActiveQueue(playables: [songs[0]])
+
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testPlayer.replaceActiveQueue(playables: Array(songs.dropFirst()), contextName: "Ignored")
+
+    XCTAssertEqual(saveCount, 1)
+    XCTAssertEqual(testPlayer.playerMode, .podcast)
+    XCTAssertEqual(testPlayer.currentIndex, 0)
+    XCTAssertEqual(testPlayer.podcastQueue.playables.map(\.id), songs.dropFirst().map(\.id))
+  }
+
+  func testPlaylistBatchAppendSavesByDefault() {
+    guard let song = library.getSong(for: account, id: cdHelper.seeder.songs[0].id)
+    else { XCTFail(); return }
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testNormalPlaylist.append(playables: [song])
+
+    XCTAssertEqual(saveCount, 1)
+  }
+
+  func testPlaylistRemoveAllItemsSavesByDefault() {
+    guard let song = library.getSong(for: account, id: cdHelper.seeder.songs[0].id)
+    else { XCTFail(); return }
+    testNormalPlaylist.append(playables: [song])
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testNormalPlaylist.removeAllItems()
+
+    XCTAssertEqual(saveCount, 1)
+    XCTAssertTrue(testNormalPlaylist.playables.isEmpty)
+  }
+
+  func testPlaylistNameSavesByDefault() {
+    var saveCount = 0
+    let observer = NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextDidSave,
+      object: cdHelper.persistentContainer.viewContext,
+      queue: nil
+    ) { _ in
+      saveCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    testNormalPlaylist.name = "Renamed"
+
+    XCTAssertEqual(saveCount, 1)
+    XCTAssertEqual(testNormalPlaylist.name, "Renamed")
   }
 
   func testCurrentSong() {


### PR DESCRIPTION
## What changed

- replace active playback queues through one Core Data save
- persist the playback context name in the same transaction
- preserve normal, shuffled, podcast, user-queue, and public Playlist save behavior
- add regression tests for save count, context name, queue state, and default-saving APIs

## Root cause

CarPlay track selection calls context playback on the main actor. Replacing the queue previously
cleared and repopulated the persisted normal/shuffled playlists through multiple synchronous Core
Data saves. The playback context name was also saved separately. These commits caused avoidable
main-thread persistence work before the CarPlay selection could complete.

The new replacement boundary defers the internal queue/name/index mutations and performs one final
`LibraryStorage.saveContext()`.

## Validation

- SwiftFormat: clean (`0/440 files formatted`)
- `git diff --check`: clean
- Mac Catalyst `build-for-testing`: succeeded
- targeted queue regressions: **7 passed, 0 failed**
- `PlayerDataTest` + `PlayQueueHandlerTest` + `MusicPlayerTest`: **165 passed, 0 failed**
- manual Core Data/thread-confinement security review: no new findings

The full Mac Catalyst test bundle executed 369 tests. Its only failures were 18 timestamp assertions
in three pre-existing/environment-sensitive `PodcastEpisodesParserTest` methods; there were no
queue or player failures. An iPhone simulator runtime and entitled real-CarPlay validation were not
available in this environment.

## Scope

This addresses one measured source of CarPlay tap latency. CarPlay template navigation, network URL
generation, artwork loading, and menu rendering remain separate follow-ups.

Related to #647.
