### PR TITLE
feat: using multi-artist tags when available

### DIFF
--- a/AmperfyKit/Api/Ampache/IDsParserDelegate.swift
+++ b/AmperfyKit/Api/Ampache/IDsParserDelegate.swift
@@ -50,7 +50,7 @@ class IDsParserDelegate: AmpacheNotifiableXmlParser {
       if let id = attributeDict["id"] {
         prefetchIDs.musicFolderIDs.insert(id)
       }
-    case "artist":
+    case "albumartist", "artist":
       if let id = attributeDict["id"] {
         prefetchIDs.artistIDs.insert(id)
       }

--- a/AmperfyKit/Api/Ampache/SongParserDelegate.swift
+++ b/AmperfyKit/Api/Ampache/SongParserDelegate.swift
@@ -28,6 +28,7 @@ class SongParserDelegate: PlayableParserDelegate {
   var songBuffer: Song?
   var parsedSongs = [Song]()
   var artistIdToCreate: String?
+  var albumArtistIdToCreate: String?
   var albumIdToCreate: String?
   var genreIdToCreate: String?
 
@@ -80,6 +81,13 @@ class SongParserDelegate: PlayableParserDelegate {
       } else {
         artistIdToCreate = artistId
       }
+    case "albumartist":
+      guard songBuffer != nil, let artistId = attributeDict["id"] else { return }
+      if let prefetchedArtist = prefetch.prefetchedArtistDict[artistId] {
+        songBuffer?.albumArtists = [prefetchedArtist]
+      } else {
+        albumArtistIdToCreate = artistId
+      }
     case "album":
       guard let song = songBuffer, let albumId = attributeDict["id"] else { return }
       if let guessedAlbum, guessedAlbum.id == albumId {
@@ -119,6 +127,22 @@ class SongParserDelegate: PlayableParserDelegate {
         artist.name = buffer
         songBuffer?.artist = artist
         artistIdToCreate = nil
+      }
+    case "albumartist":
+      if let artistId = albumArtistIdToCreate {
+        os_log(
+          "AlbumArtist <%s> with id %s has been created",
+          log: log,
+          type: .error,
+          buffer,
+          artistId
+        )
+        let artist = library.createArtist(account: account)
+        prefetch.prefetchedArtistDict[artistId] = artist
+        artist.id = artistId
+        artist.name = buffer
+        songBuffer?.albumArtists = [artist]
+        albumArtistIdToCreate = nil
       }
     case "album":
       if let albumId = albumIdToCreate {

--- a/AmperfyKit/Api/Subsonic/SsIDsParserDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SsIDsParserDelegate.swift
@@ -87,6 +87,16 @@ class SsIDsParserDelegate: SsNotifiableXmlParser {
       prefetchIDs.localArtistNames.insert(artistName)
     }
 
+    // OpenSubsonic multi-artist: <artists id="...">
+    if elementName == "artists", let artistId = attributeDict["id"] {
+      prefetchIDs.artistIDs.insert(artistId)
+    }
+
+    // OpenSubsonic album-artist: <albumArtists id="...">
+    if elementName == "albumArtists", let artistId = attributeDict["id"] {
+      prefetchIDs.artistIDs.insert(artistId)
+    }
+
     if let albumId = attributeDict["albumId"] {
       prefetchIDs.albumIDs.insert(albumId)
     }

--- a/AmperfyKit/Api/Subsonic/SsSongParserDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SsSongParserDelegate.swift
@@ -30,6 +30,8 @@ class SsSongParserDelegate: SsPlayableParserDelegate {
   var guessedArtist: Artist?
   var guessedAlbum: Album?
   var guessedGenre: Genre?
+  var collectedMultiArtists = [Artist]()
+  var collectedAlbumArtists = [Artist]()
 
   override func parser(
     _ parser: XMLParser,
@@ -59,6 +61,8 @@ class SsSongParserDelegate: SsPlayableParserDelegate {
         guessedGenre = nil
       }
       playableBuffer = songBuffer
+      collectedMultiArtists = []
+      collectedAlbumArtists = []
 
       if let artistId = attributeDict["artistId"] {
         if let guessedArtist, guessedArtist.id == artistId {
@@ -138,6 +142,36 @@ class SsSongParserDelegate: SsPlayableParserDelegate {
       }
     }
 
+    // OpenSubsonic multi-artist: <artists id="..." name="..."/>
+    if elementName == "artists", songBuffer != nil,
+       let artistId = attributeDict["id"] {
+      if let prefetchedArtist = prefetch.prefetchedArtistDict[artistId] {
+        collectedMultiArtists.append(prefetchedArtist)
+      } else if let artistName = attributeDict["name"] {
+        let artist = library.createArtist(account: account)
+        prefetch.prefetchedArtistDict[artistId] = artist
+        artist.id = artistId
+        artist.name = artistName
+        os_log("Multi-artist <%s> id %s created", log: log, type: .error, artistName, artistId)
+        collectedMultiArtists.append(artist)
+      }
+    }
+
+    // OpenSubsonic album artist: <albumArtists id="..." name="..."/>
+    if elementName == "albumArtists", songBuffer != nil,
+       let artistId = attributeDict["id"] {
+      if let prefetchedArtist = prefetch.prefetchedArtistDict[artistId] {
+        collectedAlbumArtists.append(prefetchedArtist)
+      } else if let artistName = attributeDict["name"] {
+        let artist = library.createArtist(account: account)
+        prefetch.prefetchedArtistDict[artistId] = artist
+        artist.id = artistId
+        artist.name = artistName
+        os_log("Album artist <%s> id %s created", log: log, type: .error, artistName, artistId)
+        collectedAlbumArtists.append(artist)
+      }
+    }
+
     super.parser(
       parser,
       didStartElement: elementName,
@@ -155,6 +189,14 @@ class SsSongParserDelegate: SsPlayableParserDelegate {
   ) {
     if elementName == "song" || elementName == "entry" || elementName == "child" || elementName ==
       "episode", songBuffer != nil {
+      if !collectedMultiArtists.isEmpty {
+        songBuffer?.multiArtists = collectedMultiArtists
+      }
+      if !collectedAlbumArtists.isEmpty {
+        songBuffer?.albumArtists = collectedAlbumArtists
+      }
+      collectedMultiArtists = []
+      collectedAlbumArtists = []
       parsedCount += 1
       resetPlayableBuffer()
       if let song = songBuffer {

--- a/AmperfyKit/Storage/EntityWrappers/Song.swift
+++ b/AmperfyKit/Storage/EntityWrappers/Song.swift
@@ -106,8 +106,38 @@ public class Song: AbstractPlayable, Identifyable {
     }
   }
 
+  public var artistsString: String? {
+    guard let multiArtists = multiArtists, !multiArtists.isEmpty else { return artist?.name }
+    return multiArtists.map { $0.name }.joined(separator: ", ")
+  }
+
+  public var albumArtistsString: String? {
+    guard let albumArtists = albumArtists, !albumArtists.isEmpty else { return nil }
+    return albumArtists.map { $0.name }.joined(separator: ", ")
+  }
+
+  public var multiArtists: [Artist]? {
+    get {
+      guard let orderedSet = managedObject.multiArtists else { return nil }
+      return (orderedSet.array as? [ArtistMO])?.map { Artist(managedObject: $0) }
+    }
+    set {
+      managedObject.multiArtists = newValue.map { NSOrderedSet(array: $0.map { $0.managedObject }) }
+    }
+  }
+
+  public var albumArtists: [Artist]? {
+    get {
+      guard let orderedSet = managedObject.albumArtists else { return nil }
+      return (orderedSet.array as? [ArtistMO])?.map { Artist(managedObject: $0) }
+    }
+    set {
+      managedObject.albumArtists = newValue.map { NSOrderedSet(array: $0.map { $0.managedObject }) }
+    }
+  }
+
   override public var creatorName: String {
-    artist?.name ?? "Unknown Artist"
+    artistsString ?? artist?.name ?? "Unknown Artist"
   }
 
   public var detailInfo: String {

--- a/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/.xccurrentversion
+++ b/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Amperfy v49.xcdatamodel</string>
+	<string>Amperfy v50.xcdatamodel</string>
 </dict>
 </plist>

--- a/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/Amperfy v50.xcdatamodel/contents
+++ b/AmperfyKit/Storage/ManagedObjects/Amperfy.xcdatamodeld/Amperfy v50.xcdatamodel/contents
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AbstractLibraryEntity" representedClassName="AbstractLibraryEntityMO" isAbstract="YES" elementID="AbstractLibraryElementMO" syncable="YES">
+        <attribute name="alphabeticSectionInitial" attributeType="String" defaultValueString="?"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="playCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rating" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteStatus" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="starredDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="entities" inverseEntity="Account"/>
+        <relationship name="artwork" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Artwork" inverseName="owners" inverseEntity="Artwork"/>
+        <relationship name="searchHistory" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SearchHistoryItem" inverseName="searchedLibraryEntity" inverseEntity="SearchHistoryItem"/>
+        <fetchIndex name="byAbstractLibraryEntityIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="AbstractPlayable" representedClassName="AbstractPlayableMO" isAbstract="YES" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="bitrate" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="combinedDuration" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="contentType" optional="YES" attributeType="String"/>
+        <attribute name="contentTypeTranscoded" optional="YES" attributeType="String"/>
+        <attribute name="disk" optional="YES" attributeType="String"/>
+        <attribute name="playDuration" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playProgress" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="relFilePath" optional="YES" attributeType="String"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 16" usesScalarValueType="YES" elementID="duration"/>
+        <attribute name="replayGainAlbumGain" optional="YES" attributeType="Float" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="replayGainAlbumPeak" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="replayGainTrackGain" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="replayGainTrackPeak" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="size" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="track" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="year" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="download" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Download" inverseName="playable" inverseEntity="Download"/>
+        <relationship name="embeddedArtwork" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="EmbeddedArtwork" inverseName="owner" inverseEntity="EmbeddedArtwork"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PlaylistItem" inverseName="playable" inverseEntity="PlaylistItem" elementID="playlistElements"/>
+        <relationship name="scrobbleEntries" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ScrobbleEntry" inverseName="playable" inverseEntity="ScrobbleEntry"/>
+        <fetchIndex name="byAbstractPlayableIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Account" representedClassName="AccountMO" syncable="YES">
+        <attribute name="apiType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="serverHash" optional="YES" attributeType="String"/>
+        <attribute name="serverUrl" optional="YES" attributeType="String"/>
+        <attribute name="userHash" optional="YES" attributeType="String"/>
+        <attribute name="userName" optional="YES" attributeType="String"/>
+        <relationship name="artworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Artwork" inverseName="account" inverseEntity="Artwork"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Download" inverseName="account" inverseEntity="Download"/>
+        <relationship name="embeddedArtworks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EmbeddedArtwork" inverseName="account" inverseEntity="EmbeddedArtwork"/>
+        <relationship name="entities" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractLibraryEntity" inverseName="account" inverseEntity="AbstractLibraryEntity"/>
+        <relationship name="musicFolders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MusicFolder" inverseName="account" inverseEntity="MusicFolder"/>
+        <relationship name="player" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Player" inverseName="account" inverseEntity="Player"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PlaylistItem" inverseName="account" inverseEntity="PlaylistItem"/>
+        <relationship name="playlists" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Playlist" inverseName="account" inverseEntity="Playlist"/>
+        <relationship name="scrobbleEntries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ScrobbleEntry" inverseName="account" inverseEntity="ScrobbleEntry"/>
+        <relationship name="searchHistories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SearchHistoryItem" inverseName="account" inverseEntity="SearchHistoryItem"/>
+    </entity>
+    <entity name="Album" representedClassName="AlbumMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isCached" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSongsMetaDataSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="newestIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="recentIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteSongCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="songCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="year" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="albums" inverseEntity="Artist"/>
+        <relationship name="genre" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Genre" inverseName="albums" inverseEntity="Genre"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="album" inverseEntity="Song" elementID="songsMO"/>
+        <fetchIndex name="byAlbumIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Artist" representedClassName="ArtistMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="albumCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="remoteAlbumCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="albums" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Album" inverseName="artist" inverseEntity="Album"/>
+        <relationship name="genre" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Genre" inverseName="artists" inverseEntity="Genre"/>
+        <relationship name="albumArtistSongs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="albumArtists" inverseEntity="Song"/>
+        <relationship name="multiArtistSongs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="multiArtists" inverseEntity="Song"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="artist" inverseEntity="Song" elementID="songsMO"/>
+        <fetchIndex name="byArtistIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byArtistNameIndex">
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Artwork" representedClassName="ArtworkMO" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="relFilePath" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" elementID="statusMO"/>
+        <attribute name="type" attributeType="String" defaultValueString=""/>
+        <attribute name="url" optional="YES" attributeType="String" elementID="urlMO"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="artworks" inverseEntity="Account"/>
+        <relationship name="download" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Download" inverseName="artwork" inverseEntity="Download"/>
+        <relationship name="owners" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractLibraryEntity" inverseName="artwork" inverseEntity="AbstractLibraryEntity"/>
+        <fetchIndex name="byArtworkIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Directory" representedClassName="DirectoryMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="isCached" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subdirectoryCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="musicFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MusicFolder" inverseName="directories" inverseEntity="MusicFolder"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Directory" inverseName="subdirectories" inverseEntity="Directory"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="directory" inverseEntity="Song"/>
+        <relationship name="subdirectories" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Directory" inverseName="parent" inverseEntity="Directory"/>
+        <fetchIndex name="byDirectoryIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Download" representedClassName="DownloadMO" syncable="YES">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="errorDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="errorType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="finishDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="progressPercent" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="totalSize" optional="YES" attributeType="String"/>
+        <attribute name="urlString" attributeType="String" defaultValueString=""/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="downloads" inverseEntity="Account"/>
+        <relationship name="artwork" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artwork" inverseName="download" inverseEntity="Artwork"/>
+        <relationship name="playable" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="download" inverseEntity="AbstractPlayable"/>
+        <fetchIndex name="byDownloadIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="EmbeddedArtwork" representedClassName="EmbeddedArtworkMO" syncable="YES">
+        <attribute name="imageData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="relFilePath" optional="YES" attributeType="String"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="embeddedArtworks" inverseEntity="Account"/>
+        <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="embeddedArtwork" inverseEntity="AbstractPlayable"/>
+    </entity>
+    <entity name="Genre" representedClassName="GenreMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="albumCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="artistCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="albums" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Album" inverseName="genre" inverseEntity="Album"/>
+        <relationship name="artists" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Artist" inverseName="genre" inverseEntity="Artist"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="genre" inverseEntity="Song"/>
+        <fetchIndex name="byGenreIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byGenreNameIndex">
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="LogEntry" representedClassName="LogEntryMO" syncable="YES">
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="message" attributeType="String"/>
+        <attribute name="statusCode" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="suppressionTimeInterval" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="MusicFolder" representedClassName="MusicFolderMO" syncable="YES">
+        <attribute name="directoryCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isCached" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="songCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="musicFolders" inverseEntity="Account"/>
+        <relationship name="directories" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Directory" inverseName="musicFolder" inverseEntity="Directory"/>
+        <relationship name="songs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Song" inverseName="musicFolder" inverseEntity="Song"/>
+        <fetchIndex name="byMusicFolderIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Player" representedClassName="PlayerMO" syncable="YES">
+        <attribute name="autoCachePlayedItemSetting" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES" elementID="autoCachePlayedSongSetting"/>
+        <attribute name="isUserQueuePlaying" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES" elementID="isWaitingQueuePlaying"/>
+        <attribute name="musicIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" elementID="currentSongIndex"/>
+        <attribute name="musicPlaybackRate" optional="YES" attributeType="Double" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="playerMode" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="podcastIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="podcastPlaybackRate" optional="YES" attributeType="Double" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="repeatSetting" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="shuffleSetting" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" elementID="shuffelSetting"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="player" inverseEntity="Account"/>
+        <relationship name="contextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersContextPlaylist" inverseEntity="Playlist" elementID="playlist"/>
+        <relationship name="podcastPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersPodcastPlaylist" inverseEntity="Playlist"/>
+        <relationship name="shuffledContextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersShuffledContextPlaylist" inverseEntity="Playlist" elementID="shuffledPlaylist"/>
+        <relationship name="userQueuePlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="playersUserQueuePlaylist" inverseEntity="Playlist" elementID="waitingQueuePlaylist"/>
+    </entity>
+    <entity name="Playlist" representedClassName="PlaylistMO" syncable="YES">
+        <attribute name="alphabeticSectionInitial" attributeType="String" defaultValueString="?"/>
+        <attribute name="changeDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isCached" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="playCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="remoteSongCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="songCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="playlists" inverseEntity="Account"/>
+        <relationship name="artworkItems" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PlaylistItem" inverseName="playlistArtworkItem" inverseEntity="PlaylistItem"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PlaylistItem" inverseName="playlist" inverseEntity="PlaylistItem" elementID="entries"/>
+        <relationship name="playersContextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="contextPlaylist" inverseEntity="Player" elementID="currentlyPlaying"/>
+        <relationship name="playersPodcastPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="podcastPlaylist" inverseEntity="Player"/>
+        <relationship name="playersShuffledContextPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="shuffledContextPlaylist" inverseEntity="Player" elementID="playersShuffledPlaylist"/>
+        <relationship name="playersUserQueuePlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Player" inverseName="userQueuePlaylist" inverseEntity="Player" elementID="playersWaitingQueuePlaylist"/>
+        <relationship name="searchHistory" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SearchHistoryItem" inverseName="searchedPlaylist" inverseEntity="SearchHistoryItem"/>
+        <fetchIndex name="byPlaylistIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PlaylistItem" representedClassName="PlaylistItemMO" syncable="YES">
+        <attribute name="order" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="playlistItems" inverseEntity="Account"/>
+        <relationship name="playable" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="playlistItems" inverseEntity="AbstractPlayable" elementID="song"/>
+        <relationship name="playlist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="items" inverseEntity="Playlist"/>
+        <relationship name="playlistArtworkItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="artworkItems" inverseEntity="Playlist"/>
+    </entity>
+    <entity name="Podcast" representedClassName="PodcastMO" parentEntity="AbstractLibraryEntity" syncable="YES">
+        <attribute name="depiction" attributeType="String" defaultValueString=""/>
+        <attribute name="episodeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isCached" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="episodes" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="PodcastEpisode" inverseName="podcast" inverseEntity="PodcastEpisode"/>
+        <fetchIndex name="byPodcastIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PodcastEpisode" representedClassName="PodcastEpisodeMO" parentEntity="AbstractPlayable" syncable="YES">
+        <attribute name="depiction" optional="YES" attributeType="String"/>
+        <attribute name="publishDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="streamId" optional="YES" attributeType="String"/>
+        <relationship name="podcast" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Podcast" inverseName="episodes" inverseEntity="Podcast"/>
+        <fetchIndex name="byPodcastEpisodeIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Radio" representedClassName="RadioMO" parentEntity="AbstractPlayable" syncable="YES">
+        <attribute name="siteUrl" optional="YES" attributeType="String"/>
+        <fetchIndex name="byRadioIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ScrobbleEntry" representedClassName="ScrobbleEntryMO" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isUploaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="scrobbleEntries" inverseEntity="Account"/>
+        <relationship name="playable" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPlayable" inverseName="scrobbleEntries" inverseEntity="AbstractPlayable"/>
+    </entity>
+    <entity name="SearchHistoryItem" representedClassName="SearchHistoryItemMO" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="searchHistories" inverseEntity="Account"/>
+        <relationship name="searchedLibraryEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractLibraryEntity" inverseName="searchHistory" inverseEntity="AbstractLibraryEntity"/>
+        <relationship name="searchedPlaylist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Playlist" inverseName="searchHistory" inverseEntity="Playlist"/>
+        <fetchIndex name="bySearchHistoryDateIndex">
+            <fetchIndexElement property="date" type="Binary" order="descending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Song" representedClassName="SongMO" parentEntity="AbstractPlayable" syncable="YES">
+        <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lyricsRelFilePath" optional="YES" attributeType="String"/>
+        <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="songs" inverseEntity="Album"/>
+        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="songs" inverseEntity="Artist"/>
+        <relationship name="directory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Directory" inverseName="songs" inverseEntity="Directory"/>
+        <relationship name="genre" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Genre" inverseName="songs" inverseEntity="Genre"/>
+        <relationship name="albumArtists" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Artist" inverseName="albumArtistSongs" inverseEntity="Artist"/>
+        <relationship name="multiArtists" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Artist" inverseName="multiArtistSongs" inverseEntity="Artist"/>
+        <relationship name="musicFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MusicFolder" inverseName="songs" inverseEntity="Song"/>
+        <fetchIndex name="bySongIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="UserStatistics" representedClassName="UserStatisticsMO" syncable="YES">
+        <attribute name="activeRepeatAllSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeRepeatOffSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeRepeatSingleSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeShuffleOffSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="activeShuffleOnSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="appSessionsStartedCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="appStartedViaNotificationCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="appVersion" attributeType="String" defaultValueString=""/>
+        <attribute name="backgroundFetchFailedCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backgroundFetchNewDataCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backgroundFetchNoDataCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="localNotificationCreationCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playedSongFromCacheCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playedSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playedSongViaStreamCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAirplayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAlertGoToAlbumCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAlertGoToArtistCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedAlertGoToPodcastCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedChangePlayerDisplayStyleCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedPlayerOptionsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedPlayerSeekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedAlbumDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedAlbumsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedArtistDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedArtistsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedDirectoriesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedDownloadsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedEventLogCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedGenreDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedGenresCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedIndexesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedLibraryCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedLicenseCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedMusicFoldersCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPlaylistDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPlaylistsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPlaylistSelectorCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPodcastDetailCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPodcastsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedPopupPlayerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedRadiosCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSearchCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsLibraryCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsPlayerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsPlayerSongTabCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsServerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSettingsSupportCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitedSongsCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/AmperfyKit/Storage/ManagedObjects/ArtistMO+CoreDataProperties.swift
+++ b/AmperfyKit/Storage/ManagedObjects/ArtistMO+CoreDataProperties.swift
@@ -41,9 +41,13 @@ extension ArtistMO {
   @NSManaged
   public var name: String?
   @NSManaged
+  public var albumArtistSongs: NSOrderedSet?
+  @NSManaged
   public var albums: NSOrderedSet?
   @NSManaged
   public var genre: GenreMO?
+  @NSManaged
+  public var multiArtistSongs: NSOrderedSet?
   @NSManaged
   public var songs: NSOrderedSet?
 
@@ -94,6 +98,46 @@ extension ArtistMO {
   @objc(removeAlbums:)
   @NSManaged
   public func removeFromAlbums(_ values: NSOrderedSet)
+}
+
+// MARK: Generated accessors for multiArtistSongs
+
+extension ArtistMO {
+  @objc(addMultiArtistSongsObject:)
+  @NSManaged
+  public func addToMultiArtistSongs(_ value: SongMO)
+
+  @objc(removeMultiArtistSongsObject:)
+  @NSManaged
+  public func removeFromMultiArtistSongs(_ value: SongMO)
+
+  @objc(addMultiArtistSongs:)
+  @NSManaged
+  public func addToMultiArtistSongs(_ values: NSOrderedSet)
+
+  @objc(removeMultiArtistSongs:)
+  @NSManaged
+  public func removeFromMultiArtistSongs(_ values: NSOrderedSet)
+}
+
+// MARK: Generated accessors for albumArtistSongs
+
+extension ArtistMO {
+  @objc(addAlbumArtistSongsObject:)
+  @NSManaged
+  public func addToAlbumArtistSongs(_ value: SongMO)
+
+  @objc(removeAlbumArtistSongsObject:)
+  @NSManaged
+  public func removeFromAlbumArtistSongs(_ value: SongMO)
+
+  @objc(addAlbumArtistSongs:)
+  @NSManaged
+  public func addToAlbumArtistSongs(_ values: NSOrderedSet)
+
+  @objc(removeAlbumArtistSongs:)
+  @NSManaged
+  public func removeFromAlbumArtistSongs(_ values: NSOrderedSet)
 }
 
 // MARK: Generated accessors for songs

--- a/AmperfyKit/Storage/ManagedObjects/Migration/CoreDataMigrationVersion.swift
+++ b/AmperfyKit/Storage/ManagedObjects/Migration/CoreDataMigrationVersion.swift
@@ -60,6 +60,7 @@ enum CoreDataMigrationVersion: String, CaseIterable {
   case v48 = "Amperfy v48" // Account support: add account (url + user)
   case v49 =
     "Amperfy v49" // Remove PlayableFile and Artwork data (they were already deprecated); Account: add apiType
+  case v50 = "Amperfy v50" // Song: add multiArtists, albumArtists
 
   // MARK: - Current
 
@@ -172,6 +173,8 @@ enum CoreDataMigrationVersion: String, CaseIterable {
     case .v48:
       return .v49
     case .v49:
+      return .v50
+    case .v50:
       return nil
     }
   }

--- a/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataProperties.swift
+++ b/AmperfyKit/Storage/ManagedObjects/SongMO+CoreDataProperties.swift
@@ -35,7 +35,11 @@ extension SongMO {
   @NSManaged
   public var album: AlbumMO?
   @NSManaged
+  public var albumArtists: NSOrderedSet?
+  @NSManaged
   public var artist: ArtistMO?
+  @NSManaged
+  public var multiArtists: NSOrderedSet?
   @NSManaged
   public var directory: DirectoryMO?
   @NSManaged
@@ -50,4 +54,44 @@ extension SongMO {
     #keyPath(SongMO.artwork),
     #keyPath(SongMO.embeddedArtwork),
   ]
+}
+
+// MARK: Generated accessors for multiArtists
+
+extension SongMO {
+  @objc(addMultiArtistsObject:)
+  @NSManaged
+  public func addToMultiArtists(_ value: ArtistMO)
+
+  @objc(removeMultiArtistsObject:)
+  @NSManaged
+  public func removeFromMultiArtists(_ value: ArtistMO)
+
+  @objc(addMultiArtists:)
+  @NSManaged
+  public func addToMultiArtists(_ values: NSOrderedSet)
+
+  @objc(removeMultiArtists:)
+  @NSManaged
+  public func removeFromMultiArtists(_ values: NSOrderedSet)
+}
+
+// MARK: Generated accessors for albumArtists
+
+extension SongMO {
+  @objc(addAlbumArtistsObject:)
+  @NSManaged
+  public func addToAlbumArtists(_ value: ArtistMO)
+
+  @objc(removeAlbumArtistsObject:)
+  @NSManaged
+  public func removeFromAlbumArtists(_ value: ArtistMO)
+
+  @objc(addAlbumArtists:)
+  @NSManaged
+  public func addToAlbumArtists(_ values: NSOrderedSet)
+
+  @objc(removeAlbumArtists:)
+  @NSManaged
+  public func removeFromAlbumArtists(_ values: NSOrderedSet)
 }

--- a/AmperfyKitTests/Cases/API/Ampache/PlaylistSongsParserTest.swift
+++ b/AmperfyKitTests/Cases/API/Ampache/PlaylistSongsParserTest.swift
@@ -59,6 +59,10 @@ class PlaylistSongsParserTest: AbstractAmpacheTest {
     artist = library.createArtist(account: account)
     artist.id = "2"
     artist.name = "Synthetic"
+
+    artist = library.createArtist(account: account)
+    artist.id = "19"
+    artist.name = "Various Artists"
   }
 
   func createTestAlbums() {
@@ -130,7 +134,7 @@ class PlaylistSongsParserTest: AbstractAmpacheTest {
     prefetchIdTester.checkPrefetchIdCounts(
       artworkCount: 3,
       genreIdCount: 4,
-      artistCount: 4,
+      artistCount: 5,
       albumCount: 2,
       songCount: 4,
       songLibraryCount: 4 + createdSongCount

--- a/AmperfyKitTests/Cases/API/Ampache/SongParserTest.swift
+++ b/AmperfyKitTests/Cases/API/Ampache/SongParserTest.swift
@@ -41,7 +41,7 @@ class SongParserTest: AbstractAmpacheTest {
     prefetchIdTester.checkPrefetchIdCounts(
       artworkCount: 3,
       genreIdCount: 4,
-      artistCount: 4,
+      artistCount: 5,
       albumCount: 2,
       songCount: 4
     )


### PR DESCRIPTION
### Summary

Display all artists on a song (not just the first `<artist>` tag) using multi-artist tags from both Subsonic/OpenSubsonic and Ampache APIs.

### Changes

**Core Data**
- New `Amperfy v50.xcdatamodel` with `multiArtists` (to-many, ordered → Artist) and `albumArtists` (to-many, ordered → Artist) relationships on `SongMO`, plus inverse relationships on `ArtistMO`
- Generated accessors in `SongMO+CoreDataProperties` and `ArtistMO+CoreDataProperties`
- Migration path `v49 → v50` in `CoreDataMigrationVersion.swift`

**Song model** (`Song.swift`)
- Added `multiArtists` and `albumArtists` computed properties
- Added `artistsString` and `albumArtistsString` for display
- `creatorName` now prefers `artistsString` over the single `artist?.name`

**Subsonic/OpenSubsonic** (`SsSongParserDelegate`, `SsIDsParserDelegate`)
- Parse `<artists>` and `<albumArtists>` child elements from OpenSubsonic responses
- Prefetch artist IDs from these elements for batch resolution

**Ampache** (`SongParserDelegate`, `IDsParserDelegate`)
- Handle `<albumartist>` element in song parsing, creating artists on-the-fly if not yet cached
- Collect album artist IDs during prefetch

**Tests**
- Updated `PlaylistSongsParserTest` and `SongParserTest` expectations to account for album artist IDs