### PR TITLE
feat: downloads view

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		50BE5D4D2850F4C900156FC6 /* ArtworkTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F81E8F23BCDE1600EAAC3E /* ArtworkTest.swift */; };
 		50BE5D4E2850F4C900156FC6 /* PlayerDataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F81E9123BD29BB00EAAC3E /* PlayerDataTest.swift */; };
 		50BE5D4F2850F4C900156FC6 /* AlbumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F81E8723BB29CD00EAAC3E /* AlbumTest.swift */; };
+		7A1C0D5F2E00000100AAAA02 /* CachedDisplayFilterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C0D5E2E00000100AAAA01 /* CachedDisplayFilterTest.swift */; };
 		50BE5D522850F4D700156FC6 /* HelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B798B323B8664700551E62 /* HelperTest.swift */; };
 		50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */; };
 		50BE5D542850F4E700156FC6 /* SubsonicVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */; };
@@ -1116,6 +1117,7 @@
 		50F800202685B8DA0015844D /* Amperfy v10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v10.xcdatamodel"; sourceTree = "<group>"; };
 		50F81E8523BAF25900EAAC3E /* Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Album.swift; sourceTree = "<group>"; };
 		50F81E8723BB29CD00EAAC3E /* AlbumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTest.swift; sourceTree = "<group>"; };
+		7A1C0D5E2E00000100AAAA01 /* CachedDisplayFilterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedDisplayFilterTest.swift; sourceTree = "<group>"; };
 		50F81E8923BB5FC500EAAC3E /* Artist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artist.swift; sourceTree = "<group>"; };
 		50F81E8B23BB666100EAAC3E /* ArtistTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistTest.swift; sourceTree = "<group>"; };
 		50F81E8D23BC6FEA00EAAC3E /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
@@ -1601,6 +1603,7 @@
 			isa = PBXGroup;
 			children = (
 				5095F98F23CA94BC008B0805 /* ManagedObjects */,
+				7A1C0D5E2E00000100AAAA01 /* CachedDisplayFilterTest.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -2861,6 +2864,7 @@
 				50BE5D742850F4FB00156FC6 /* SsAlbumMultidiscExample1ParserTest.swift in Sources */,
 				50BE5D872850F50F00156FC6 /* AbstractAmpacheTest.swift in Sources */,
 				50BE5D4F2850F4C900156FC6 /* AlbumTest.swift in Sources */,
+				7A1C0D5F2E00000100AAAA02 /* CachedDisplayFilterTest.swift in Sources */,
 				50BE5D8E2850F50F00156FC6 /* PodcastEpisodesParserTest.swift in Sources */,
 				50CEC6432D1F38F800D0E696 /* SsRadioExampleParserTest.swift in Sources */,
 				50BE5D882850F50F00156FC6 /* SongParserTest.swift in Sources */,

--- a/Amperfy/CarPlay/CarPlayCachedTabExtension.swift
+++ b/Amperfy/CarPlay/CarPlayCachedTabExtension.swift
@@ -30,7 +30,7 @@ extension LibraryDisplayType {
     case .albums, .artists, .favoriteAlbums, .favoriteArtists, .favoriteSongs, .genres,
          .newestAlbums, .podcasts, .recentAlbums:
       return true
-    case .directories, .downloads, .radios, .songs:
+    case .directories, .downloadedAlbums, .downloadedArtists, .downloads, .radios, .songs:
       return false
     case .playlists:
       return false // playlists have their own tab
@@ -89,7 +89,7 @@ extension CarPlaySceneDelegate {
         sectionToDisplay = albumsRecentCachedSection
       case .radios:
         sectionToDisplay = radioSection
-      case .directories, .downloads, .playlists, .songs:
+      case .directories, .downloadedAlbums, .downloadedArtists, .downloads, .playlists, .songs:
         break // do nothing
       }
       guard let sectionToDisplay else { completion(); return }

--- a/Amperfy/CarPlay/CarPlayLibraryTabExtension.swift
+++ b/Amperfy/CarPlay/CarPlayLibraryTabExtension.swift
@@ -32,7 +32,7 @@ extension LibraryDisplayType {
          .podcasts,
          .radios, .recentAlbums:
       return true
-    case .directories, .downloads, .songs:
+    case .directories, .downloadedAlbums, .downloadedArtists, .downloads, .songs:
       return false
     case .playlists:
       return false // playlists have their own tab
@@ -114,7 +114,7 @@ extension CarPlaySceneDelegate {
         sectionToDisplay = albumsRecentSection
       case .radios:
         sectionToDisplay = radioSection
-      case .directories, .downloads, .playlists, .songs:
+      case .directories, .downloadedAlbums, .downloadedArtists, .downloads, .playlists, .songs:
         break // do nothing
       }
       guard let sectionToDisplay else { completion(); return }

--- a/Amperfy/LibraryDisplayType+Extension.swift
+++ b/Amperfy/LibraryDisplayType+Extension.swift
@@ -69,6 +69,14 @@ extension LibraryDisplayType {
       )
     case .radios:
       return AppStoryboard.Main.segueToRadios(account: account)
+    case .downloadedAlbums:
+      return AppStoryboard.Main.createAlbumsVC(
+        account: account,
+        style: settings.user.albumsStyleSetting,
+        category: .cached
+      )
+    case .downloadedArtists:
+      return AppStoryboard.Main.segueToDownloadedArtists(account: account)
     }
   }
 }

--- a/Amperfy/Screens/AppStoryboard.swift
+++ b/Amperfy/Screens/AppStoryboard.swift
@@ -126,6 +126,12 @@ enum AppStoryboard: String {
     return artistsVC
   }
 
+  func segueToDownloadedArtists(account: Account)
+    -> UIViewController { let artistsVC = ArtistsVC(account: account)
+    artistsVC.displayFilter = .cached
+    return artistsVC
+  }
+
   func segueToMusicFolders(account: Account) -> UIViewController {
     MusicFoldersVC(account: account)
   }

--- a/Amperfy/Screens/ViewController/AlbumsCommonVCInteractions.swift
+++ b/Amperfy/Screens/ViewController/AlbumsCommonVCInteractions.swift
@@ -95,6 +95,7 @@ class AlbumsCommonVCInteractions {
     case .newest: "Newest Albums"
     case .recent: "Recently Played Albums"
     case .favorites: "Favorite Albums"
+    case .cached: "Downloaded Albums"
     }
   }
 
@@ -167,6 +168,10 @@ class AlbumsCommonVCInteractions {
       change(sortType: .recent)
     case .favorites:
       filterTitle = "Favorite Albums"
+      isIndexTitelsHidden = false
+      change(sortType: appDelegate.storage.settings.user.albumsSortSetting)
+    case .cached:
+      filterTitle = "Downloaded Albums"
       isIndexTitelsHidden = false
       change(sortType: appDelegate.storage.settings.user.albumsSortSetting)
     }
@@ -255,6 +260,8 @@ class AlbumsCommonVCInteractions {
         }
         self.updateSearchResultsCB?()
       }
+    case .cached:
+      break
     }
   }
 
@@ -270,7 +277,7 @@ class AlbumsCommonVCInteractions {
     }
     actions.append(createStyleButtonMenu())
 
-    if appDelegate.storage.settings.user.isOnlineMode {
+    if appDelegate.storage.settings.user.isOnlineMode, displayFilter != .cached {
       actions.append(createActionButtonMenu())
     }
 
@@ -470,6 +477,8 @@ class AlbumsCommonVCInteractions {
         case .recent:
           albums = self.appDelegate.storage.main.library
             .getRecentAlbums(for: self.account)
+        case .cached:
+          albums = []
         case .favorites:
           albums = self.appDelegate.storage.main.library
             .getFavoriteAlbums(for: self.account)

--- a/Amperfy/Screens/ViewController/ArtistsVC.swift
+++ b/Amperfy/Screens/ViewController/ArtistsVC.swift
@@ -113,6 +113,7 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
     switch displayFilter {
     case .albumArtists, .all: "Artists"
     case .favorites: "Favorite Artists"
+    case .cached: "Downloaded Artists"
     }
   }
 
@@ -241,6 +242,8 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
       filterTitle = "Favorite Artists"
     case .albumArtists:
       filterTitle = "Album Artists"
+    case .cached:
+      filterTitle = "Downloaded Artists"
     }
     setNavBarTitle(title: filterTitle)
   }
@@ -266,7 +269,7 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
 
   func change(filterType: ArtistCategoryFilter) {
     // favorite views can't change the display filter
-    guard displayFilter != .favorites else { return }
+    guard displayFilter != .favorites, displayFilter != .cached else { return }
     displayFilter = filterType
     appDelegate.storage.settings.user.artistsFilterSetting = filterType
     updateSearchResults(for: searchController)
@@ -289,10 +292,10 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
   func updateRightBarButtonItems() {
     var actions = [UIMenu]()
     actions.append(createSortButtonMenu())
-    if displayFilter != .favorites {
+    if displayFilter != .favorites, displayFilter != .cached {
       actions.append(createFilterButtonMenu())
     }
-    if appDelegate.storage.settings.user.isOnlineMode {
+    if appDelegate.storage.settings.user.isOnlineMode, displayFilter != .cached {
       actions.append(createActionButtonMenu())
     }
     optionsButton = UIBarButtonItem.createOptionsBarButton()
@@ -303,7 +306,7 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
   func updateFromRemote() {
     guard appDelegate.storage.settings.user.isOnlineMode else { return }
     switch displayFilter {
-    case .albumArtists, .all:
+    case .albumArtists, .all, .cached:
       break
     case .favorites:
       Task { @MainActor in
@@ -481,6 +484,8 @@ class ArtistsVC: SingleSnapshotFetchedResultsTableViewController<ArtistMO> {
         case .favorites:
           artists = self.appDelegate.storage.main.library
             .getFavoriteArtists(for: self.account)
+        case .cached:
+          artists = []
         }
         let artistSongs = Array(artists.compactMap { $0.playables }.joined())
         if artistSongs.count > AppDelegate.maxPlayablesDownloadsToAddAtOnceWithoutWarning {

--- a/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddArtistsVC.swift
+++ b/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddArtistsVC.swift
@@ -29,6 +29,7 @@ class PlaylistAddArtistsVC: SingleSnapshotFetchedResultsTableViewController<Arti
     switch displayFilter {
     case .albumArtists, .all: "Artists"
     case .favorites: "Favorite Artists"
+    case .cached: "Downloaded Artists"
     }
   }
 

--- a/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddSongsVC.swift
+++ b/Amperfy/Screens/ViewController/PlaylistAdd/PlaylistAddSongsVC.swift
@@ -28,6 +28,7 @@ class PlaylistAddSongsVC: SingleFetchedResultsTableViewController<SongMO>, Playl
     switch displayFilter {
     case .all, .newest, .recent: "Songs"
     case .favorites: "Favorite Songs"
+    case .cached: "Downloaded Songs"
     }
   }
 
@@ -101,6 +102,8 @@ class PlaylistAddSongsVC: SingleFetchedResultsTableViewController<SongMO>, Playl
       break
     case .newest, .recent:
       break
+    case .cached:
+      break
     case .favorites:
       Task { @MainActor in
         do {
@@ -121,6 +124,9 @@ class PlaylistAddSongsVC: SingleFetchedResultsTableViewController<SongMO>, Playl
       change(sortType: appDelegate.storage.settings.user.songsSortSetting)
     case .newest, .recent:
       break
+    case .cached:
+      isIndexTitelsHidden = false
+      change(sortType: appDelegate.storage.settings.user.songsSortSetting)
     case .favorites:
       isIndexTitelsHidden = false
       if account.apiType.asServerApiType != .ampache {

--- a/Amperfy/Screens/ViewController/SongsVC.swift
+++ b/Amperfy/Screens/ViewController/SongsVC.swift
@@ -28,6 +28,7 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
     switch displayFilter {
     case .all, .newest, .recent: "Songs"
     case .favorites: "Favorite Songs"
+    case .cached: "Downloaded Songs"
     }
   }
 
@@ -134,6 +135,10 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
       change(sortType: appDelegate.storage.settings.user.songsSortSetting)
     case .newest, .recent:
       break
+    case .cached:
+      filterTitle = "Downloaded Songs"
+      isIndexTitelsHidden = false
+      change(sortType: appDelegate.storage.settings.user.songsSortSetting)
     case .favorites:
       filterTitle = "Favorite Songs"
       isIndexTitelsHidden = false
@@ -204,6 +209,8 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
     case .all:
       break
     case .newest, .recent:
+      break
+    case .cached:
       break
     case .favorites:
       Task { @MainActor in
@@ -470,6 +477,8 @@ class SongsVC: SingleFetchedResultsTableViewController<SongMO> {
         case .all:
           songs = self.appDelegate.storage.main.library.getSongs(for: self.account)
         case .newest, .recent:
+          break
+        case .cached:
           break
         case .favorites:
           songs = self.appDelegate.storage.main.library

--- a/AmperfyKit/Storage/LibraryDisplaySettings.swift
+++ b/AmperfyKit/Storage/LibraryDisplaySettings.swift
@@ -43,6 +43,8 @@ public enum LibraryDisplayType: Int, CaseIterable, Sendable {
   case newestAlbums = 12
   case recentAlbums = 13
   case radios = 14
+  case downloadedAlbums = 15
+  case downloadedArtists = 16
 
   public static func createByDisplayName(name: String) -> LibraryDisplayType? {
     .allCases.first {
@@ -80,6 +82,10 @@ public enum LibraryDisplayType: Int, CaseIterable, Sendable {
       return "Recently Played Albums"
     case .radios:
       return "Radios"
+    case .downloadedAlbums:
+      return "Downloaded Albums"
+    case .downloadedArtists:
+      return "Downloaded Artists"
     }
   }
 
@@ -113,6 +119,10 @@ public enum LibraryDisplayType: Int, CaseIterable, Sendable {
       return UIImage.albumRecent
     case .radios:
       return UIImage.radio
+    case .downloadedAlbums:
+      return UIImage.download
+    case .downloadedArtists:
+      return UIImage.download
     }
   }
 }
@@ -149,7 +159,14 @@ public struct LibraryDisplaySettings: Sendable, Codable {
     }
 
     if mapped.count == 2 {
-      self.combined = mapped
+      // A library type added by a newer app version is in neither stored group,
+      // which would leave it unreachable from the library editor.
+      // Fold any such type into notUsed so it stays selectable.
+      let known = Set(mapped[0]).union(mapped[1])
+      let missing = LibraryDisplayType.allCases
+        .filter { !known.contains($0) }
+        .sorted { $0.rawValue < $1.rawValue }
+      self.combined = [mapped[0], mapped[1] + missing]
     } else if let first = mapped.first {
       // If only one group present, treat it as inUse and compute notUsed
       self = LibraryDisplaySettings(inUse: first)

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -1111,6 +1111,8 @@ public class LibraryStorage: PlayableFileCachable {
       return NSPredicate(value: true)
     case .favorites:
       return NSPredicate(format: "%K == TRUE", #keyPath(SongMO.isFavorite))
+    case .cached:
+      return getFetchPredicate(onlyCachedSongs: true)
     }
   }
 
@@ -1124,6 +1126,8 @@ public class LibraryStorage: PlayableFileCachable {
       return NSPredicate(format: "%K > 0", #keyPath(AlbumMO.recentIndex))
     case .favorites:
       return NSPredicate(format: "%K == TRUE", #keyPath(AlbumMO.isFavorite))
+    case .cached:
+      return getFetchPredicate(onlyCachedAlbums: true)
     }
   }
 
@@ -1135,6 +1139,8 @@ public class LibraryStorage: PlayableFileCachable {
       return NSPredicate(format: "%K.@count > 0", #keyPath(ArtistMO.albums))
     case .favorites:
       return NSPredicate(format: "%K == TRUE", #keyPath(ArtistMO.isFavorite))
+    case .cached:
+      return getFetchPredicate(onlyCachedArtists: true)
     }
   }
 

--- a/AmperfyKit/Storage/ResultController/FetchedResultsControllers.swift
+++ b/AmperfyKit/Storage/ResultController/FetchedResultsControllers.swift
@@ -153,6 +153,9 @@ public enum DisplayCategoryFilter: Codable {
   case newest
   case recent
   case favorites
+  /// Only elements with at least one downloaded song. Purely local state, so
+  /// unlike the other cases it never triggers a remote sync.
+  case cached
 }
 
 // MARK: - ArtistCategoryFilter
@@ -161,6 +164,8 @@ public enum ArtistCategoryFilter: Int, Sendable, Codable {
   case all = 0
   case favorites = 1
   case albumArtists = 2
+  /// Only artists with at least one downloaded song.
+  case cached = 3
 
   public static let defaultValue: ArtistCategoryFilter = .albumArtists
 }
@@ -600,7 +605,7 @@ public class ArtistSongsItemsFetchedResultsController: BasicFetchedResultsContro
     self.displayFilter = displayFilter
     let fetchRequest = SongMO.alphabeticSortedFetchRequest
     switch self.displayFilter {
-    case .all, .favorites:
+    case .all, .cached, .favorites:
       fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
         SongMO.excludeServerDeleteUncachedSongsFetchPredicate,
         coreDataCompanion.library.getFetchPredicate(forArtist: artist),
@@ -631,7 +636,7 @@ public class ArtistSongsItemsFetchedResultsController: BasicFetchedResultsContro
     if !searchText.isEmpty || onlyCachedSongs {
       var predicate = NSCompoundPredicate()
       switch displayFilter {
-      case .all, .favorites:
+      case .all, .cached, .favorites:
         predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
           SongMO.excludeServerDeleteUncachedSongsFetchPredicate,
           coreDataCompanion.library.getFetchPredicate(forArtist: artist),

--- a/AmperfyKitTests/Cases/Storage/CachedDisplayFilterTest.swift
+++ b/AmperfyKitTests/Cases/Storage/CachedDisplayFilterTest.swift
@@ -1,0 +1,120 @@
+//
+//  CachedDisplayFilterTest.swift
+//  AmperfyKitTests
+//
+//  Created by Jayce Slesar on 25.07.26.
+//  Copyright (c) 2026 Jayce Slesar. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import AmperfyKit
+import XCTest
+
+/// Covers the `.cached` display filters backing the "Downloaded Albums" and
+/// "Downloaded Artists" library entries. Downloading itself cannot be exercised
+/// here — the playable downloader uses a background URLSession — so these tests
+/// simulate a downloaded song by setting `relFilePath`, which is exactly what
+/// `isCached` and the cached fetch predicates key off.
+@MainActor
+class CachedDisplayFilterTest: XCTestCase {
+  var cdHelper: CoreDataHelper!
+  var library: LibraryStorage!
+  var account: Account!
+
+  override func setUp() async throws {
+    cdHelper = CoreDataHelper()
+    library = cdHelper.createSeededStorage()
+    account = library.getAccount(info: TestAccountInfo.create1())
+  }
+
+  override func tearDown() {}
+
+  /// artist -> album -> song, with the song optionally marked as downloaded.
+  @discardableResult
+  private func makeChain(downloaded: Bool, id: String) -> (Artist, Album, Song) {
+    let artist = library.createArtist(account: account)
+    artist.id = "artist-\(id)"
+    let album = library.createAlbum(account: account)
+    album.id = "album-\(id)"
+    album.artist = artist
+    let song = library.createSong(account: account)
+    song.id = "song-\(id)"
+    song.album = album
+    song.artist = artist
+    if downloaded {
+      song.relFilePath = URL(string: "downloaded-\(id).flac")
+    }
+    library.saveContext()
+    return (artist, album, song)
+  }
+
+  func testDownloadedSongIsCached() {
+    let (_, _, downloaded) = makeChain(downloaded: true, id: "a")
+    let (_, _, streamed) = makeChain(downloaded: false, id: "b")
+    XCTAssertTrue(downloaded.isCached)
+    XCTAssertFalse(streamed.isCached)
+  }
+
+  func testCachedAlbumFilterMatchesOnlyDownloaded() {
+    let (_, downloadedAlbum, _) = makeChain(downloaded: true, id: "a")
+    let (_, streamedAlbum, _) = makeChain(downloaded: false, id: "b")
+    let predicate = library.getFetchPredicate(albumsDisplayFilter: .cached)
+    XCTAssertTrue(predicate.evaluate(with: downloadedAlbum.managedObject))
+    XCTAssertFalse(predicate.evaluate(with: streamedAlbum.managedObject))
+  }
+
+  func testCachedArtistFilterMatchesOnlyDownloaded() {
+    let (downloadedArtist, _, _) = makeChain(downloaded: true, id: "a")
+    let (streamedArtist, _, _) = makeChain(downloaded: false, id: "b")
+    let predicate = library.getFetchPredicate(artistsDisplayFilter: .cached)
+    XCTAssertTrue(predicate.evaluate(with: downloadedArtist.managedObject))
+    XCTAssertFalse(predicate.evaluate(with: streamedArtist.managedObject))
+  }
+
+  func testCachedSongFilterMatchesOnlyDownloaded() {
+    let (_, _, downloadedSong) = makeChain(downloaded: true, id: "a")
+    let (_, _, streamedSong) = makeChain(downloaded: false, id: "b")
+    let predicate = library.getFetchPredicate(songsDisplayFilter: .cached)
+    XCTAssertTrue(predicate.evaluate(with: downloadedSong.managedObject))
+    XCTAssertFalse(predicate.evaluate(with: streamedSong.managedObject))
+  }
+
+  /// The `.all` filter must keep matching everything — the new case must not
+  /// narrow the existing screens.
+  func testAllFilterStillMatchesUndownloaded() {
+    let (_, streamedAlbum, _) = makeChain(downloaded: false, id: "b")
+    let predicate = library.getFetchPredicate(albumsDisplayFilter: .all)
+    XCTAssertTrue(predicate.evaluate(with: streamedAlbum.managedObject))
+  }
+
+  /// A library type introduced by a newer app version must land in `notUsed`
+  /// rather than vanishing, otherwise it is unreachable from the Library editor.
+  func testNewLibraryTypesRemainReachableAfterDecoding() throws {
+    // Simulate settings persisted before the downloaded entries existed.
+    let legacyInUse: [LibraryDisplayType] = [.artists, .albums, .songs]
+    let legacyNotUsed: [LibraryDisplayType] = [.genres, .playlists]
+    let encoded = try JSONEncoder().encode([
+      "combined": [legacyInUse.map(\.rawValue), legacyNotUsed.map(\.rawValue)],
+    ])
+    let decoded = try JSONDecoder().decode(LibraryDisplaySettings.self, from: encoded)
+
+    XCTAssertEqual(decoded.inUse, legacyInUse)
+    XCTAssertTrue(decoded.notUsed.contains(.downloadedAlbums))
+    XCTAssertTrue(decoded.notUsed.contains(.downloadedArtists))
+    // Nothing may be lost or duplicated in the process.
+    let all = Set(decoded.inUse).union(decoded.notUsed)
+    XCTAssertEqual(all, Set(LibraryDisplayType.allCases))
+  }
+}


### PR DESCRIPTION
add a feature to show downloaded albums. Totally clauded this up because I have 0 swift experience!

tl;dr when an album is downloaded there is currently no way to tell that from the UI which is difficult when I am on the go and don't have tailscale/direct access to my navidrome instance.

let me know what needs to change, or if this is implemented wrong.

should partially address https://github.com/BLeeEZ/amperfy/issues/745