### PR TITLE
Add Recent Playlist Shortcut

### DIFF
--- a/Amperfy/AppDelegate.swift
+++ b/Amperfy/AppDelegate.swift
@@ -21,6 +21,7 @@
 
 import AmperfyKit
 import BackgroundTasks
+import CoreData
 import Intents
 import MediaPlayer
 import os.log
@@ -82,6 +83,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   public lazy var userStatistics = {
     AmperKit.shared.userStatistics
   }()
+
+  private var recentPlaylistObjectIds = [AccountInfo: NSManagedObjectID]()
+
+  func rememberRecentPlaylist(_ playlist: Playlist) {
+    guard let account = playlist.account else { return }
+    recentPlaylistObjectIds[account.info] = playlist.managedObject.objectID
+  }
+
+  func recentPlaylist(for account: Account) -> Playlist? {
+    guard let objectId = recentPlaylistObjectIds[account.info],
+          let object = try? storage.main.context.existingObject(with: objectId),
+          let playlistMO = object as? PlaylistMO,
+          !playlistMO.isDeleted
+    else {
+      recentPlaylistObjectIds.removeValue(forKey: account.info)
+      return nil
+    }
+    return Playlist(library: storage.main.library, managedObject: playlistMO)
+  }
 
   public lazy var localNotificationManager = {
     AmperKit.shared.localNotificationManager

--- a/Amperfy/Screens/ViewController/EntityPreviewVC.swift
+++ b/Amperfy/Screens/ViewController/EntityPreviewVC.swift
@@ -27,6 +27,21 @@ import UIKit
 typealias GetPlayContextCallback = () -> PlayContext?
 typealias GetPlayerIndexCallback = () -> PlayerIndex?
 
+// MARK: - PlaylistOwning
+
+@MainActor
+protocol PlaylistOwning: AnyObject {
+  var playlist: Playlist { get }
+}
+
+// MARK: - PlaylistDetailVC + PlaylistOwning
+
+extension PlaylistDetailVC: PlaylistOwning {}
+
+// MARK: - PlaylistEditVC + PlaylistOwning
+
+extension PlaylistEditVC: PlaylistOwning {}
+
 // MARK: - EntityPreviewActionBuilder
 
 @MainActor
@@ -150,6 +165,11 @@ class EntityPreviewActionBuilder {
       menuActions.append(UIMenu(options: .displayInline, children: ratingFavActions))
     }
     if isAddToPlaylist {
+      if let account = entityContainer.account,
+         let recentPlaylist = appDelegate.recentPlaylist(for: account),
+         !isCurrentPlaylist(recentPlaylist) {
+        elementHandlingActions.append(createAddToRecentPlaylistAction(recentPlaylist))
+      }
       elementHandlingActions.append(createAddToPlaylistAction())
     }
     if isDownloadPossible {
@@ -664,6 +684,30 @@ class EntityPreviewActionBuilder {
       let selectPlaylistNav = UINavigationController(rootViewController: selectPlaylistVC)
       self.rootView.present(selectPlaylistNav, animated: true)
     }
+  }
+
+  private func createAddToRecentPlaylistAction(_ playlist: Playlist) -> UIAction {
+    UIAction(title: "Add to \"\(playlist.name)\"", image: .playlistPlus) { _ in
+      let songs = self.entityPlayables.filterSongs()
+      guard !songs.isEmpty else { return }
+      PlaylistSongAdder.resolveSongsToAdd(
+        songs,
+        to: playlist,
+        presenting: self.rootView
+      ) { songsToAdd in
+        PlaylistSongAdder.add(songsToAdd, to: playlist, appDelegate: self.appDelegate)
+      }
+    }
+  }
+
+  private func isCurrentPlaylist(_ playlist: Playlist) -> Bool {
+    let playlistObjectId = playlist.managedObject.objectID
+    if let entityPlaylist = entityContainer as? Playlist,
+       entityPlaylist.managedObject.objectID == playlistObjectId {
+      return true
+    }
+    guard let playlistOwner = rootView as? PlaylistOwning else { return false }
+    return playlistOwner.playlist.managedObject.objectID == playlistObjectId
   }
 
   private func createShowAlbumAction() -> UIAction {

--- a/Amperfy/Screens/ViewController/PlaylistSelectorVC.swift
+++ b/Amperfy/Screens/ViewController/PlaylistSelectorVC.swift
@@ -30,6 +30,100 @@ enum AddToPlaylistSelectMode {
   case multi
 }
 
+// MARK: - PlaylistSongAdder
+
+@MainActor
+enum PlaylistSongAdder {
+  private static var pendingSongCounts = [NSManagedObjectID: [NSManagedObjectID: Int]]()
+
+  static func resolveSongsToAdd(
+    _ songs: [Song],
+    to playlist: Playlist,
+    presenting viewController: UIViewController,
+    completion: @escaping ([Song]) -> ()
+  ) {
+    let pendingSongs = pendingSongCounts[playlist.managedObject.objectID] ?? [:]
+    let songsNotContained = Array(playlist.notContaines(playables: songs))
+      .filterSongs()
+      .filter { pendingSongs[$0.managedObject.objectID] == nil }
+    guard songsNotContained.count != songs.count else {
+      completion(songs)
+      return
+    }
+
+    let alert = UIAlertController(
+      title: nil,
+      message: "Some Songs are already in this Playlist.",
+      preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "Add Duplicates", style: .default, handler: { _ in
+      completion(songs)
+    }))
+    alert.addAction(UIAlertAction(title: "Skip Duplicates", style: .default, handler: { _ in
+      completion(songsNotContained)
+    }))
+    alert.addAction(UIAlertAction(title: "Cancel", style: .default))
+    viewController.present(alert, animated: true)
+  }
+
+  static func add(
+    _ songs: [Song],
+    to playlist: Playlist,
+    appDelegate: AppDelegate
+  ) {
+    add([playlist: songs], appDelegate: appDelegate)
+  }
+
+  static func add(
+    _ selections: [Playlist: [Song]],
+    appDelegate: AppDelegate
+  ) {
+    guard selections.contains(where: { !$0.value.isEmpty }) else { return }
+    registerPendingSongs(in: selections)
+    Task { @MainActor in do {
+      defer { unregisterPendingSongs(in: selections) }
+      for (playlist, songs) in selections where !songs.isEmpty {
+        guard let account = playlist.account else { continue }
+        try await appDelegate.getMeta(account.info).librarySyncer.syncUpload(
+          playlistToAddSongs: playlist,
+          songs: songs
+        )
+        playlist.append(playables: songs)
+      }
+    } catch {
+      appDelegate.eventLogger.report(topic: "Playlist Add Songs", error: error)
+    }}
+  }
+
+  private static func registerPendingSongs(in selections: [Playlist: [Song]]) {
+    for (playlist, songs) in selections {
+      let playlistObjectId = playlist.managedObject.objectID
+      for song in songs {
+        let songObjectId = song.managedObject.objectID
+        pendingSongCounts[playlistObjectId, default: [:]][songObjectId, default: 0] += 1
+      }
+    }
+  }
+
+  private static func unregisterPendingSongs(in selections: [Playlist: [Song]]) {
+    for (playlist, songs) in selections {
+      let playlistObjectId = playlist.managedObject.objectID
+      for song in songs {
+        let songObjectId = song.managedObject.objectID
+        guard let count = pendingSongCounts[playlistObjectId]?[songObjectId] else { continue }
+        if count > 1 {
+          pendingSongCounts[playlistObjectId]?[songObjectId] = count - 1
+        } else {
+          pendingSongCounts[playlistObjectId]?.removeValue(forKey: songObjectId)
+        }
+      }
+      if pendingSongCounts[playlistObjectId]?.isEmpty == true {
+        pendingSongCounts.removeValue(forKey: playlistObjectId)
+      }
+    }
+  }
+}
+
 // MARK: - PlaylistsSelectorDiffableDataSource
 
 class PlaylistsSelectorDiffableDataSource: BasicUITableViewDiffableDataSource {
@@ -194,18 +288,12 @@ class PlaylistSelectorVC: SingleSnapshotFetchedResultsTableViewController<Playli
     defer { selectedPlaylits.removeAll() }
     guard !selectedPlaylits.isEmpty else { return }
 
-    let localCopySelectedPlaylits = selectedPlaylits
-    Task { @MainActor in do {
-      for (playlist, songs) in localCopySelectedPlaylits {
-        try await self.appDelegate.getMeta(self.account.info).librarySyncer.syncUpload(
-          playlistToAddSongs: playlist,
-          songs: songs
-        )
-        playlist.append(playables: songs)
-      }
-    } catch {
-      self.appDelegate.eventLogger.report(topic: "Playlist Add Songs", error: error)
-    }}
+    if selectMode == .single,
+       let (playlist, songs) = selectedPlaylits.first,
+       !songs.isEmpty {
+      appDelegate.rememberRecentPlaylist(playlist)
+    }
+    PlaylistSongAdder.add(selectedPlaylits, appDelegate: appDelegate)
   }
 
   @IBAction
@@ -359,25 +447,12 @@ class PlaylistSelectorVC: SingleSnapshotFetchedResultsTableViewController<Playli
       snap.reconfigureItems([playlist.managedObject.objectID])
       diffableDataSource.apply(snap)
     } else {
-      let itemsNotContained = playlist.notContaines(playables: itemsToAdd)
-      if itemsNotContained.count != itemsToAdd.count {
-        let alert = UIAlertController(
-          title: nil,
-          message: "Some Songs are already in this Playlist.",
-          preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "Add Duplicates", style: .default, handler: { _ in
-          handleSuccessfullSelection(playables: self.itemsToAdd)
-        }))
-        alert.addAction(UIAlertAction(title: "Skip Duplicates", style: .default, handler: { _ in
-          handleSuccessfullSelection(playables: Array(itemsNotContained))
-        }))
-        alert.addAction(UIAlertAction(title: "Cancel", style: .default, handler: { _ in
-          // do nothing
-        }))
-        present(alert, animated: true, completion: nil)
-      } else {
-        handleSuccessfullSelection(playables: itemsToAdd)
+      PlaylistSongAdder.resolveSongsToAdd(
+        itemsToAdd,
+        to: playlist,
+        presenting: self
+      ) { songs in
+        handleSuccessfullSelection(playables: songs)
       }
     }
   }


### PR DESCRIPTION
Hi again, I'm back with one more thing that I feel is a nice quality-of-life improvement :) Hope it makes sense!

After adding a song to a playlist, its context menu now offers `Add to "Playlist Name"` for that playlist. The shortcut lasts for the current session and only updates after adding to a single playlist. It stays out of the way when viewing that same playlist.

Implementation-wise, the app keeps the recent playlist per account and reuses the existing duplicate handling and upload path. Multi-select does not replace the shortcut.

Screenshot after already adding a song to "Songs" playlist right before:
<img width="249" height="97" alt="Screenshot 2026-08-18 at 18 27 52" src="https://github.com/user-attachments/assets/0531c0e7-b7cd-4136-9dac-d21827e33da1" />



