### PR TITLE
Settings: add Storage Overview screen

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,6 @@
+# Copy to .env.local (gitignored) and fill in real values.
+# .env.local is for your eyes only — never commit it, never put its contents in a PR.
+
+NAVIDROME_URL=http://your-server:4533
+NAVIDROME_USER=your-username
+NAVIDROME_PASSWORD=your-password

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Local-only notes/secrets (never intended for upstream) — see CLAUDE.md
+.env.local

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		09EB5F102F93B96E00B1C71C /* ShareSongAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EB5F0D2F93B65400B1C71C /* ShareSongAction.swift */; };
+		27EB1C38402CA80F8B0B537D /* SearchDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7049C69DC0AAE33A2158D8F5 /* SearchDebouncer.swift */; };
 		43FBE27F250D4DFD00D5F9B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43FBE27E250D4DFD00D5F9B3 /* LaunchScreen.storyboard */; };
 		5003D8FB267B3390006946BF /* LibrarySyncPopupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5003D8FA267B3390006946BF /* LibrarySyncPopupVC.swift */; };
 		5005938928E2D4EF008C8DF6 /* CommonCollectionSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5005938828E2D4EF008C8DF6 /* CommonCollectionSectionHeader.xib */; };
@@ -81,7 +82,6 @@
 		505CA1FC2B87387600AA81CD /* SearchHistoryItemMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505CA1F82B87387600AA81CD /* SearchHistoryItemMO+CoreDataProperties.swift */; };
 		505CA1FE2B8739AE00AA81CD /* SearchHistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505CA1FD2B8739AE00AA81CD /* SearchHistoryItem.swift */; };
 		505CA2082B88E8F400AA81CD /* BasicTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50120A2426281C1900B037B1 /* BasicTableViewController.swift */; };
-		27EB1C38402CA80F8B0B537D /* SearchDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7049C69DC0AAE33A2158D8F5 /* SearchDebouncer.swift */; };
 		505CA2092B88E8F400AA81CD /* BasicCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5005938E28E2EDDB008C8DF6 /* BasicCollectionViewController.swift */; };
 		505CA20A2B88E94800AA81CD /* MultiSourceTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505CA2032B88E69500AA81CD /* MultiSourceTableViewController.swift */; };
 		505CA20C2B88E9D300AA81CD /* FetchUpdateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505CA2002B88DF3B00AA81CD /* FetchUpdateHandler.swift */; };
@@ -106,7 +106,6 @@
 		5078AFB42B44AE260038FD17 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5078AFB32B44AE260038FD17 /* AppIntentVocabulary.plist */; };
 		50791E7828D25845006CE6E5 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7728D25845006CE6E5 /* AccountSettingsView.swift */; };
 		50791E7A28D31090006CE6E5 /* ServerURLsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */; };
-		50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */; };
 		50791E7C28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */; };
 		50791E7F28D363F0006CE6E5 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */; };
 		50791E8128D365E9006CE6E5 /* UpdatePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */; };
@@ -207,7 +206,6 @@
 		50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */; };
 		50BE5D542850F4E700156FC6 /* SubsonicVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E964AE25E8E25E00E3210F /* SubsonicVersionTest.swift */; };
 		50BE5D552850F4E700156FC6 /* UtilitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5090963726496A9500DD9826 /* UtilitiesTest.swift */; };
-		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
 		50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */; };
 		50BE5D572850F4F600156FC6 /* album_missing_artistId.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50ED2B9227BB932700331BF7 /* album_missing_artistId.xml */; };
 		50BE5D582850F4F600156FC6 /* artist_example_1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 50AB92C526661F5800DCE45C /* artist_example_1.xml */; };
@@ -275,6 +273,7 @@
 		50BE5D9728511C3200156FC6 /* Amperfy.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 500BB49521CAAA2700D367CF /* Amperfy.xcdatamodeld */; };
 		50BE5D9828511C3800156FC6 /* Amperfy.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 500BB49521CAAA2700D367CF /* Amperfy.xcdatamodeld */; };
 		50BE5DA7285714A200156FC6 /* CallbackURLKit in Frameworks */ = {isa = PBXBuildFile; productRef = 50BE5DA6285714A200156FC6 /* CallbackURLKit */; };
+		50C0FFEE0000000000A00001 /* CustomHTTPHeadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */; };
 		50C16C0621E241B200F086F0 /* SearchVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C16C0521E241B200F086F0 /* SearchVC.swift */; };
 		50C16C0C21E52BBB00F086F0 /* PlayableTableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 50C16C0B21E52BBB00F086F0 /* PlayableTableCell.xib */; };
 		50C16C1021E5463E00F086F0 /* ArtistsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C16C0F21E5463E00F086F0 /* ArtistsVC.swift */; };
@@ -532,10 +531,11 @@
 		632F51262C83A8400032860D /* LyricsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632F51252C83A8400032860D /* LyricsVC.swift */; };
 		6333C8E12C6FDB5200CCA50A /* SecondaryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */; };
 		637A28B52C79409C0082FACC /* MiniPlayerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */; };
-		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		B5A5CE010000000000000001 /* ShareSongActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5CE010000000000000002 /* ShareSongActionTest.swift */; };
+		C0A1B0032EEE000000000003 /* MacWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1B0022EEE000000000002 /* MacWindowHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -646,7 +646,6 @@
 		501171352756A8E100B7C08D /* NowPlayingInfoCenterHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoCenterHandler.swift; sourceTree = "<group>"; };
 		50120A2026280C9200B037B1 /* FetchedResultsControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedResultsControllers.swift; sourceTree = "<group>"; };
 		50120A2426281C1900B037B1 /* BasicTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTableViewController.swift; sourceTree = "<group>"; };
-		7049C69DC0AAE33A2158D8F5 /* SearchDebouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDebouncer.swift; sourceTree = "<group>"; };
 		501267B6264C058500E13F08 /* SsXmlParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SsXmlParser.swift; sourceTree = "<group>"; };
 		501267B8264C187600E13F08 /* AmpacheXmlParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpacheXmlParser.swift; sourceTree = "<group>"; };
 		5013DC8B2B49997F00EC191E /* Amperfy v30.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v30.xcdatamodel"; sourceTree = "<group>"; };
@@ -789,7 +788,6 @@
 		5078AFB32B44AE260038FD17 /* AppIntentVocabulary.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		50791E7728D25845006CE6E5 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		50791E7928D31090006CE6E5 /* ServerURLsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURLsSettingsView.swift; sourceTree = "<group>"; };
-		50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHTTPHeadersView.swift; sourceTree = "<group>"; };
 		50791E7B28D32B8A006CE6E5 /* AlternativeURLAddDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeURLAddDialogView.swift; sourceTree = "<group>"; };
 		50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBannerView.swift; sourceTree = "<group>"; };
 		50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePasswordView.swift; sourceTree = "<group>"; };
@@ -844,7 +842,6 @@
 		509001C027182A1300A8056D /* CatalogParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserTest.swift; sourceTree = "<group>"; };
 		509001C227182A4700A8056D /* CatalogParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogParserDelegate.swift; sourceTree = "<group>"; };
 		5090963726496A9500DD9826 /* UtilitiesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTest.swift; sourceTree = "<group>"; };
-		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
 		509357512E3BF47800CD4075 /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
 		509362EC28E041FF005C2AAC /* Amperfy v28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v28.xcdatamodel"; sourceTree = "<group>"; };
 		50947E0227DA011F00C368D7 /* ScrobbleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleEntry.swift; sourceTree = "<group>"; };
@@ -970,6 +967,7 @@
 		50BA930721D75C5600E5901D /* AuthentificationHandshake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthentificationHandshake.swift; sourceTree = "<group>"; };
 		50BE5D442850EFE100156FC6 /* PlayMediaIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayMediaIntentHandler.swift; sourceTree = "<group>"; };
 		50BE5D9D2851D5DE00156FC6 /* IntentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentManager.swift; sourceTree = "<group>"; };
+		50C0FFEE0000000000A00002 /* CustomHTTPHeadersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHTTPHeadersView.swift; sourceTree = "<group>"; };
 		50C16BEF21E0A3B500F086F0 /* PlayerData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerData.swift; sourceTree = "<group>"; };
 		50C16BF721E10E7500F086F0 /* Playlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
 		50C16C0521E241B200F086F0 /* SearchVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVC.swift; sourceTree = "<group>"; };
@@ -1152,12 +1150,14 @@
 		632F51252C83A8400032860D /* LyricsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsVC.swift; sourceTree = "<group>"; };
 		6333C8E02C6FDB5200CCA50A /* SecondaryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryText.swift; sourceTree = "<group>"; };
 		637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerSceneDelegate.swift; sourceTree = "<group>"; };
-		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 		638920EF2C8C8E9000932EE8 /* SettingsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsList.swift; sourceTree = "<group>"; };
 		63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSceneDelegate.swift; sourceTree = "<group>"; };
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		7049C69DC0AAE33A2158D8F5 /* SearchDebouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDebouncer.swift; sourceTree = "<group>"; };
+		B5A5CE010000000000000002 /* ShareSongActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSongActionTest.swift; sourceTree = "<group>"; };
+		C0A1B0022EEE000000000002 /* MacWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacWindowHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3077,6 +3077,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4UM92Y5NRT;
 				INFOPLIST_FILE = Amperfy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3085,7 +3086,7 @@
 				);
 				MARKETING_VERSION = 2.1.1;
 				"MARKETING_VERSION[sdk=macosx*]" = 2.1.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "de.familie-zimba.amperfy-music";
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidmasek.amperfy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -3116,6 +3117,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4UM92Y5NRT;
 				INFOPLIST_FILE = Amperfy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3124,7 +3126,7 @@
 				);
 				MARKETING_VERSION = 2.1.1;
 				"MARKETING_VERSION[sdk=macosx*]" = 2.1.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "de.familie-zimba.amperfy-music";
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidmasek.amperfy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5020D51A2E3B6FF6000A6F85 /* WelcomePopupPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5020D5192E3B6FF0000A6F85 /* WelcomePopupPresenter.swift */; };
 		5021B1282BC723F400893C33 /* FuzzySearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5021B1272BC723F400893C33 /* FuzzySearcher.swift */; };
 		5023D9B02BD9A55E00310144 /* CacheFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5023D9AF2BD9A55E00310144 /* CacheFileManager.swift */; };
+		5D57046E0A6E202600000002 /* StorageUsageCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D57046E0A6E202600000001 /* StorageUsageCalculator.swift */; };
 		5023D9B22BDAA48200310144 /* UpdateVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5023D9B12BDAA48200310144 /* UpdateVC.swift */; };
 		502B8A4D2EE0CE40004CA3AD /* AudioStreaming in Frameworks */ = {isa = PBXBuildFile; productRef = 502B8A4C2EE0CE40004CA3AD /* AudioStreaming */; };
 		502B8A532EE0D354004CA3AD /* AccountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502B8A522EE0D354004CA3AD /* AccountTest.swift */; };
@@ -110,6 +111,7 @@
 		50791E7F28D363F0006CE6E5 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */; };
 		50791E8128D365E9006CE6E5 /* UpdatePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */; };
 		50791E8528D36F1F006CE6E5 /* LibrarySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8428D36F1F006CE6E5 /* LibrarySettingsView.swift */; };
+		5D57046E0A6E202600000004 /* StorageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D57046E0A6E202600000003 /* StorageSettingsView.swift */; };
 		50791E8728D3B7BF006CE6E5 /* PlayerSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8628D3B7BF006CE6E5 /* PlayerSettingsView.swift */; };
 		50791E8928D3BC4D006CE6E5 /* SwipeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50791E8828D3BC4D006CE6E5 /* SwipeSettingsView.swift */; };
 		507BA5C32F01B9A400B4EA8B /* SetShuffleIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507BA5C22F01B9A400B4EA8B /* SetShuffleIntent.swift */; };
@@ -198,6 +200,7 @@
 		50BE5D482850F4C900156FC6 /* PlaylistTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B798B123B7F51000551E62 /* PlaylistTest.swift */; };
 		50BE5D492850F4C900156FC6 /* ArtistTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F81E8B23BB666100EAAC3E /* ArtistTest.swift */; };
 		50BE5D4A2850F4C900156FC6 /* SongTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504C719023BAD112001F82C7 /* SongTest.swift */; };
+		5D57046E0A6E202600000006 /* StorageUsageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D57046E0A6E202600000005 /* StorageUsageTest.swift */; };
 		50BE5D4C2850F4C900156FC6 /* PlaylistItemTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504C718E23BAC8F2001F82C7 /* PlaylistItemTest.swift */; };
 		50BE5D4D2850F4C900156FC6 /* ArtworkTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F81E8F23BCDE1600EAAC3E /* ArtworkTest.swift */; };
 		50BE5D4E2850F4C900156FC6 /* PlayerDataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F81E9123BD29BB00EAAC3E /* PlayerDataTest.swift */; };
@@ -689,6 +692,7 @@
 		50223EF2264543EA007445BC /* LibrarySyncVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySyncVersion.swift; sourceTree = "<group>"; };
 		5023D9AE2BD8408B00310144 /* Amperfy v37.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v37.xcdatamodel"; sourceTree = "<group>"; };
 		5023D9AF2BD9A55E00310144 /* CacheFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFileManager.swift; sourceTree = "<group>"; };
+		5D57046E0A6E202600000001 /* StorageUsageCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageUsageCalculator.swift; sourceTree = "<group>"; };
 		5023D9B12BDAA48200310144 /* UpdateVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateVC.swift; sourceTree = "<group>"; };
 		50253F78284614A100BCCFB2 /* DuplicateEntitiesResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateEntitiesResolver.swift; sourceTree = "<group>"; };
 		50253F7A284A566700BCCFB2 /* Intents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = Intents.intentdefinition; sourceTree = "<group>"; };
@@ -730,6 +734,7 @@
 		504B442128D8EBB20033982C /* MailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailView.swift; sourceTree = "<group>"; };
 		504C718E23BAC8F2001F82C7 /* PlaylistItemTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistItemTest.swift; sourceTree = "<group>"; };
 		504C719023BAD112001F82C7 /* SongTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongTest.swift; sourceTree = "<group>"; };
+		5D57046E0A6E202600000005 /* StorageUsageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageUsageTest.swift; sourceTree = "<group>"; };
 		504D26262D4168DE003FDEB3 /* Amperfy v41.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v41.xcdatamodel"; sourceTree = "<group>"; };
 		505362D02C23682500846C53 /* AlbumsCollectionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsCollectionVC.swift; sourceTree = "<group>"; };
 		505362D22C2425C200846C53 /* AlbumsCommonVCInteractions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsCommonVCInteractions.swift; sourceTree = "<group>"; };
@@ -792,6 +797,7 @@
 		50791E7E28D363F0006CE6E5 /* InfoBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBannerView.swift; sourceTree = "<group>"; };
 		50791E8028D365E9006CE6E5 /* UpdatePasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePasswordView.swift; sourceTree = "<group>"; };
 		50791E8428D36F1F006CE6E5 /* LibrarySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySettingsView.swift; sourceTree = "<group>"; };
+		5D57046E0A6E202600000003 /* StorageSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettingsView.swift; sourceTree = "<group>"; };
 		50791E8628D3B7BF006CE6E5 /* PlayerSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSettingsView.swift; sourceTree = "<group>"; };
 		50791E8828D3BC4D006CE6E5 /* SwipeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeSettingsView.swift; sourceTree = "<group>"; };
 		507BA5C22F01B9A400B4EA8B /* SetShuffleIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetShuffleIntent.swift; sourceTree = "<group>"; };
@@ -1420,6 +1426,7 @@
 				5078AFB12B40CA5E0038FD17 /* DisplaySettingsView.swift */,
 				50AE79AB2C1CCBEC0085CBB3 /* DeveloperView.swift */,
 				50791E8428D36F1F006CE6E5 /* LibrarySettingsView.swift */,
+				5D57046E0A6E202600000003 /* StorageSettingsView.swift */,
 				504B441828D6F0920033982C /* LicenseSettingsView.swift */,
 				504B441C28D7A6330033982C /* XCallbackURLsSetttingsView.swift */,
 				502041962E2A37D6003CE29A /* Player */,
@@ -1601,6 +1608,7 @@
 			isa = PBXGroup;
 			children = (
 				5095F98F23CA94BC008B0805 /* ManagedObjects */,
+				5D57046E0A6E202600000005 /* StorageUsageTest.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -1739,6 +1747,7 @@
 				50E59A4C2ED7541900F2B65C /* HomeSection.swift */,
 				50C9D6EC284FADB8007F18D0 /* PlayerDisplayStyleType.swift */,
 				5023D9AF2BD9A55E00310144 /* CacheFileManager.swift */,
+				5D57046E0A6E202600000001 /* StorageUsageCalculator.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -2591,6 +2600,7 @@
 				50A30E542B7408DB00722894 /* ContextQueueNextSectionHeader.swift in Sources */,
 				50CEC64B2D1F4C0A00D0E696 /* RadiosVC.swift in Sources */,
 				50791E8528D36F1F006CE6E5 /* LibrarySettingsView.swift in Sources */,
+				5D57046E0A6E202600000004 /* StorageSettingsView.swift in Sources */,
 				50DE29ED2B8FCFC500ABA78E /* LibraryDisplayType+Extension.swift in Sources */,
 				5019441D2B7ACB0800082D2E /* PopupPlayer+Animations.swift in Sources */,
 				50BA92F821CC318D00E5901D /* PlayableTableCell.swift in Sources */,
@@ -2761,6 +2771,7 @@
 				50C9D690284FAA6C007F18D0 /* ArtworkMO+CoreDataProperties.swift in Sources */,
 				50C9D657284FAA02007F18D0 /* SsSongParserDelegate.swift in Sources */,
 				5023D9B02BD9A55E00310144 /* CacheFileManager.swift in Sources */,
+				5D57046E0A6E202600000002 /* StorageUsageCalculator.swift in Sources */,
 				50C9D6C1284FAACE007F18D0 /* PlayableDownloadDelegate.swift in Sources */,
 				50AE79AE2C1E23930085CBB3 /* SsOpenSubsonicExtensionsParserDelegate.swift in Sources */,
 				50C9D671284FAA4D007F18D0 /* Identifyable.swift in Sources */,
@@ -2895,6 +2906,7 @@
 				50BE5D902850F50F00156FC6 /* PodcastEpisodesExample2ParserTest.swift in Sources */,
 				50BE5D562850F4E700156FC6 /* PlayQueueHandlerTest.swift in Sources */,
 				50BE5D4A2850F4C900156FC6 /* SongTest.swift in Sources */,
+				5D57046E0A6E202600000006 /* StorageUsageTest.swift in Sources */,
 				50CEC6492D1F41A400D0E696 /* RadiosExampleParserTest.swift in Sources */,
 				50BE5D772850F4FB00156FC6 /* SsSongExample2ParserTest.swift in Sources */,
 				50BE5D762850F4FB00156FC6 /* SsArtistParserTest.swift in Sources */,

--- a/Amperfy/Amperfy.entitlements
+++ b/Amperfy/Amperfy.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.carplay-audio</key>
-	<true/>
-	<key>com.apple.developer.siri</key>
-	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Amperfy/Info.plist
+++ b/Amperfy/Info.plist
@@ -8,6 +8,8 @@
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Amperfy Local</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Amperfy/SwiftUI/Settings/LibrarySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/LibrarySettingsView.swift
@@ -195,6 +195,11 @@ struct LibrarySettingsView: View {
           SettingsRow(title: "Complete Cache Size") {
             SecondaryText(completeCacheSize.description)
           }
+          NavigationLink {
+            StorageSettingsView()
+          } label: {
+            Text("Storage Overview")
+          }
 
           #if targetEnvironment(macCatalyst) // ok
             // We can not present the picker in wheel style on macOS. It is not supported.

--- a/Amperfy/SwiftUI/Settings/NavigationTarget.swift
+++ b/Amperfy/SwiftUI/Settings/NavigationTarget.swift
@@ -26,6 +26,7 @@ enum NavigationTarget: String, CaseIterable, @MainActor Identifiable {
   case account
   case displayAndInteraction
   case library
+  case storage
   case player
   case equalizer
   case swipe
@@ -45,6 +46,7 @@ enum NavigationTarget: String, CaseIterable, @MainActor Identifiable {
     case .displayAndInteraction: DisplaySettingsView()
     case .account: AccountSettingsView()
     case .library: LibrarySettingsView()
+    case .storage: StorageSettingsView()
     case .player: PlayerSettingsView()
     case .equalizer: EqualizerSettingsView()
     case .swipe: SwipeSettingsView()
@@ -64,6 +66,7 @@ enum NavigationTarget: String, CaseIterable, @MainActor Identifiable {
     case .displayAndInteraction: "Display & Interaction"
     case .account: "Account"
     case .library: "Library"
+    case .storage: "Storage"
     case .swipe: "Swipe"
     case .artwork: "Artwork"
     case .support: "Support"
@@ -84,6 +87,7 @@ enum NavigationTarget: String, CaseIterable, @MainActor Identifiable {
     case .displayAndInteraction: .display
     case .account: .userPerson
     case .library: .musicLibrary
+    case .storage: .internalDrive
     case .player: .playCircle
     case .equalizer: .equalizer
     case .swipe: .arrowRight
@@ -103,6 +107,7 @@ enum NavigationTarget: String, CaseIterable, @MainActor Identifiable {
     case .displayAndInteraction: "display"
     case .account: "person.fill"
     case .library: "music.note.house"
+    case .storage: "internaldrive.fill"
     case .player: "play.circle.fill"
     case .equalizer: "chart.bar.xaxis"
     case .swipe: "arrow.right.circle.fill"

--- a/Amperfy/SwiftUI/Settings/SettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/SettingsView.swift
@@ -96,6 +96,7 @@ struct SettingsView: View {
             navigationLink(.account)
             navigationLink(.displayAndInteraction)
             navigationLink(.library)
+            navigationLink(.storage)
             navigationLink(.player)
             navigationLink(.equalizer)
             navigationLink(.swipe)

--- a/Amperfy/SwiftUI/Settings/StorageSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/StorageSettingsView.swift
@@ -1,0 +1,173 @@
+//
+//  StorageSettingsView.swift
+//  Amperfy
+//
+//  Created by David Masek on 22.08.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AmperfyKit
+import SwiftUI
+
+// MARK: - StorageSettingsView
+
+struct StorageSettingsView: View {
+  @EnvironmentObject
+  private var settings: Settings
+
+  @State
+  private var usage: StorageUsage?
+
+  private static let topAlbumCount = 20
+
+  private func updateValues() async {
+    guard let activeAccountInfo = settings.activeAccountInfo else { return }
+    usage = try? await StorageUsageCalculator.calculate(
+      storage: appDelegate.storage,
+      accountInfo: activeAccountInfo
+    )
+  }
+
+  private func refresh() {
+    usage = nil
+    Task { await updateValues() }
+  }
+
+  private func albumRow(_ album: StorageUsage.AlbumUsage) -> some View {
+    HStack {
+      VStack(alignment: .leading) {
+        Text(album.albumName)
+          .lineLimit(1)
+        Text(album.artistName)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .lineLimit(1)
+      }
+      Spacer()
+      SecondaryText(album.sizeInByte.asByteString)
+    }
+  }
+
+  private func allAlbumsView(albums: [StorageUsage.AlbumUsage]) -> some View {
+    SettingsList {
+      SettingsSection(content: {
+        ForEach(albums) { album in
+          albumRow(album)
+        }
+      })
+    }
+    .navigationTitle("Cached Albums")
+    .navigationBarTitleDisplayMode(.inline)
+  }
+
+  var body: some View {
+    ZStack {
+      if let usage = usage {
+        SettingsList {
+          SettingsSection(
+            content: {
+              SettingsRow(title: "Total") {
+                SecondaryText(usage.totalSize.asByteString)
+              }
+            },
+            footer: "Cache + database for this account. Excludes the app itself and other accounts, so it will read lower than the number shown in iOS Settings ▸ General ▸ iPhone Storage."
+          )
+
+          SettingsSection(content: {
+            SettingsRow(title: "Songs") {
+              SecondaryText(usage.songsSize.asByteString)
+            }
+            SettingsRow(title: "Podcast Episodes") {
+              SecondaryText(usage.episodesSize.asByteString)
+            }
+            SettingsRow(title: "Artwork") {
+              SecondaryText(usage.artworkSize.asByteString)
+            }
+            SettingsRow(title: "Embedded Artwork") {
+              SecondaryText(usage.embeddedArtworkSize.asByteString)
+            }
+            SettingsRow(title: "Lyrics") {
+              SecondaryText(usage.lyricsSize.asByteString)
+            }
+            SettingsRow(title: "Total Cache") {
+              SecondaryText(usage.cacheTotal.asByteString)
+            }
+          }, header: "Cache")
+
+          SettingsSection(content: {
+            SettingsRow(title: "Internal Database") {
+              SecondaryText(usage.databaseSize.asByteString)
+            }
+          }, footer: "The database is shared across all accounts.", header: "Database")
+
+          if let availableDiskCapacity = UIDevice.current.availableDiskCapacityInByte {
+            SettingsSection(content: {
+              SettingsRow(title: "Available on Device") {
+                SecondaryText(availableDiskCapacity.asByteString)
+              }
+            }, header: "Device")
+          }
+
+          if !usage.albums.isEmpty {
+            SettingsSection(content: {
+              ForEach(usage.albums.prefix(Self.topAlbumCount)) { album in
+                albumRow(album)
+              }
+              if usage.albums.count > Self.topAlbumCount {
+                NavigationLink {
+                  allAlbumsView(albums: usage.albums)
+                } label: {
+                  Text("Show All")
+                }
+              }
+            }, header: "Cached Albums (\(usage.albums.count))")
+          }
+        }
+      } else {
+        ProgressView("Calculating…")
+      }
+    }
+    .navigationTitle("Storage")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .navigationBarTrailing) {
+        Button(action: {
+          refresh()
+        }) {
+          Image(systemName: "arrow.clockwise")
+        }
+        .disabled(usage == nil)
+      }
+    }
+    .task {
+      await updateValues()
+    }
+    .onChange(of: settings.activeAccountInfo) {
+      refresh()
+    }
+  }
+}
+
+// MARK: - StorageSettingsView_Previews
+
+struct StorageSettingsView_Previews: PreviewProvider {
+  @State
+  static var settings = Settings()
+
+  static var previews: some View {
+    StorageSettingsView().environmentObject(settings)
+  }
+}

--- a/AmperfyKit/Assets/AmperfyAppIcon.icon/icon.json
+++ b/AmperfyKit/Assets/AmperfyAppIcon.icon/icon.json
@@ -1,6 +1,6 @@
 {
   "fill" : {
-    "automatic-gradient" : "extended-srgb:0.00000,0.53333,1.00000,1.00000"
+    "automatic-gradient" : "extended-srgb:1.00000,0.58431,0.00000,1.00000"
   },
   "groups" : [
     {

--- a/AmperfyKit/Assets/UIImageAssetsExtension.swift
+++ b/AmperfyKit/Assets/UIImageAssetsExtension.swift
@@ -184,6 +184,7 @@ public struct AmperfyImage: Sendable {
   public static let heartSlash = Self("heart.slash")
   public static let home = Self("house.fill")
   public static let info = Self("info.circle")
+  public static let internalDrive = Self("internaldrive.fill")
   public static let isSelected = Self("checkmark.circle.fill")
   public static let leftRightPlay = Self("play.rectangle.on.rectangle")
   public static let listBullet = Self("list.bullet")
@@ -330,6 +331,8 @@ extension UIImage {
   public static let heartSlash = UIImage.create(systemName: AmperfyImage.heartSlash.systemName)
   public static let home = UIImage.create(systemName: AmperfyImage.home.systemName)
   public static let info = UIImage.create(systemName: AmperfyImage.info.systemName)
+  public static let internalDrive = UIImage
+    .create(systemName: AmperfyImage.internalDrive.systemName)
   public static let isSelected = UIImage.create(systemName: AmperfyImage.isSelected.systemName)
   public static let listBullet = UIImage.create(systemName: AmperfyImage.listBullet.systemName)
   public static let login = UIImage.create(systemName: AmperfyImage.login.systemName)

--- a/AmperfyKit/Storage/CacheFileManager.swift
+++ b/AmperfyKit/Storage/CacheFileManager.swift
@@ -307,6 +307,36 @@ final public class CacheFileManager: Sendable {
     return bytes
   }
 
+  public func getSongsCacheSize(for accountInfo: AccountInfo) -> Int64 {
+    guard let absSongsDir = getOrCreateAbsoluteSongsDirectory(for: accountInfo) else { return 0 }
+    return directorySize(url: absSongsDir)
+  }
+
+  public func getEpisodesCacheSize(for accountInfo: AccountInfo) -> Int64 {
+    guard let absEpisodesDir = getOrCreateAbsolutePodcastEpisodesDirectory(for: accountInfo)
+    else { return 0 }
+    return directorySize(url: absEpisodesDir)
+  }
+
+  public func getArtworkCacheSize(for accountInfo: AccountInfo) -> Int64 {
+    guard let absArtworksDir = getOrCreateAbsoluteArtworksDirectory(for: accountInfo)
+    else { return 0 }
+    return directorySize(url: absArtworksDir)
+  }
+
+  public func getEmbeddedArtworkCacheSize(for accountInfo: AccountInfo) -> Int64 {
+    guard let absEmbeddedArtworksDir = getOrCreateAbsoluteEmbeddedArtworksDirectory(
+      for: accountInfo
+    ) else { return 0 }
+    return directorySize(url: absEmbeddedArtworksDir)
+  }
+
+  public func getLyricsCacheSize(for accountInfo: AccountInfo) -> Int64 {
+    guard let absLyricsDir = getOrCreateAbsoluteLyricsDirectory(for: accountInfo)
+    else { return 0 }
+    return directorySize(url: absLyricsDir)
+  }
+
   private static let artworkFileExtension = "png"
   private static let lyricsFileExtension = "xml"
   private static let accountsDir = URL(string: "accounts")!
@@ -827,7 +857,7 @@ final public class CacheFileManager: Sendable {
     return contents ?? [URL]()
   }
 
-  private func directorySize(url: URL) -> Int64 {
+  public func directorySize(url: URL) -> Int64 {
     let contents: [URL]
     do {
       contents = try FileManager.default.contentsOfDirectory(

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -1644,6 +1644,33 @@ public class LibraryStorage: PlayableFileCachable {
     return songs ?? [Song]()
   }
 
+  public struct CachedAlbumFilesInfo: Sendable {
+    public let albumId: String
+    public let albumName: String
+    public let artistName: String
+    public let songCount: Int
+    public let relFilePaths: [URL]
+  }
+
+  public func getCachedSongsFileInfosGroupedByAlbum(for account: Account)
+    -> [CachedAlbumFilesInfo] {
+    let cachedSongs = getCachedSongs(for: account)
+    let songsByAlbum = Dictionary(grouping: cachedSongs) {
+      $0.album?.managedObject.objectID
+    }
+    return songsByAlbum.map { albumObjectId, songs in
+      let relFilePaths = songs.compactMap { $0.relFilePath }
+      let album = songs.first?.album
+      return CachedAlbumFilesInfo(
+        albumId: albumObjectId?.uriRepresentation().absoluteString ?? "unknown-album",
+        albumName: album?.name ?? "Unknown Album",
+        artistName: album?.subtitle ?? "Unknown Artist",
+        songCount: relFilePaths.count,
+        relFilePaths: relFilePaths
+      )
+    }
+  }
+
   public func getRandomSongs(for account: Account, count: Int = 100, onlyCached: Bool) -> [Song] {
     let fetchRequest = SongMO.identifierSortedFetchRequest
     fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [

--- a/AmperfyKit/Storage/PersistentStorage.swift
+++ b/AmperfyKit/Storage/PersistentStorage.swift
@@ -186,6 +186,38 @@ public class PersistentStorage {
   public var async: AsyncCoreDataAccessWrapper {
     AsyncCoreDataAccessWrapper(persistentContainer: coreDataManager.persistentContainer)
   }
+
+  @MainActor
+  public var databaseStoreURL: URL? {
+    coreDataManager.persistentContainer.persistentStoreDescriptions.first?.url
+  }
+
+  /// Size of the SQLite store including its -wal/-shm files and the hidden
+  /// external binary data support directory next to it.
+  public static func getDatabaseSizeInByte(storeURL: URL) -> Int64 {
+    let storeDirectory = storeURL.deletingLastPathComponent()
+    let storeFileName = storeURL.lastPathComponent
+    let supportDirectoryPrefix = "." + storeURL.deletingPathExtension()
+      .lastPathComponent + "_SUPPORT"
+    guard let contents = try? FileManager.default.contentsOfDirectory(
+      at: storeDirectory,
+      includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey]
+    ) else { return 0 }
+
+    var size = Int64(0)
+    for url in contents {
+      let name = url.lastPathComponent
+      guard name.hasPrefix(storeFileName) || name.hasPrefix(supportDirectoryPrefix)
+      else { continue }
+      let resourceValues = try? url.resourceValues(forKeys: [.isDirectoryKey])
+      if resourceValues?.isDirectory == true {
+        size += CacheFileManager.shared.directorySize(url: url)
+      } else if let fileSize = CacheFileManager.shared.getFileSize(url: url) {
+        size += fileSize
+      }
+    }
+    return size
+  }
 }
 
 // MARK: - CoreDataManagable

--- a/AmperfyKit/Storage/StorageUsageCalculator.swift
+++ b/AmperfyKit/Storage/StorageUsageCalculator.swift
@@ -1,0 +1,116 @@
+//
+//  StorageUsageCalculator.swift
+//  AmperfyKit
+//
+//  Created by David Masek on 22.08.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+// MARK: - StorageUsage
+
+public struct StorageUsage: Sendable {
+  public struct AlbumUsage: Sendable, Identifiable, Hashable {
+    public let id: String
+    public let albumName: String
+    public let artistName: String
+    public let songCount: Int
+    public let sizeInByte: Int64
+  }
+
+  public let songsSize: Int64
+  public let episodesSize: Int64
+  public let artworkSize: Int64
+  public let embeddedArtworkSize: Int64
+  public let lyricsSize: Int64
+  /// size of the Core Data store, shared across all accounts
+  public let databaseSize: Int64
+  /// cached albums sorted by size descending
+  public let albums: [AlbumUsage]
+
+  public var cacheTotal: Int64 {
+    songsSize + episodesSize + artworkSize + embeddedArtworkSize + lyricsSize
+  }
+
+  /// cacheTotal + databaseSize for this account. Does NOT include the app bundle itself
+  /// or other accounts' caches, so it will read lower than the OS-reported app size.
+  public var totalSize: Int64 {
+    cacheTotal + databaseSize
+  }
+}
+
+// MARK: - StorageUsageCalculator
+
+public enum StorageUsageCalculator {
+  @MainActor
+  public static func calculate(
+    storage: PersistentStorage,
+    accountInfo: AccountInfo
+  ) async throws
+    -> StorageUsage {
+    let accountObjectId = storage.main.library.getAccount(info: accountInfo).managedObject
+      .objectID
+    let databaseStoreURL = storage.databaseStoreURL
+    let albumFilesInfos = try await storage.async.performAndGet { asyncCompanion in
+      let accountAsync = asyncCompanion.library.getAccount(managedObjectId: accountObjectId)
+      return asyncCompanion.library.getCachedSongsFileInfosGroupedByAlbum(for: accountAsync)
+    }
+    return await Task.detached(priority: .utility) {
+      createUsage(
+        accountInfo: accountInfo,
+        databaseStoreURL: databaseStoreURL,
+        albumFilesInfos: albumFilesInfos
+      )
+    }.value
+  }
+
+  private static func createUsage(
+    accountInfo: AccountInfo,
+    databaseStoreURL: URL?,
+    albumFilesInfos: [LibraryStorage.CachedAlbumFilesInfo]
+  )
+    -> StorageUsage {
+    let fileManager = CacheFileManager.shared
+    let albums = albumFilesInfos.map { info in
+      let sizeInByte = info.relFilePaths.reduce(Int64(0)) { size, relFilePath in
+        guard let absFilePath = fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath)
+        else { return size }
+        return size + (fileManager.getFileSize(url: absFilePath) ?? 0)
+      }
+      return StorageUsage.AlbumUsage(
+        id: info.albumId,
+        albumName: info.albumName,
+        artistName: info.artistName,
+        songCount: info.songCount,
+        sizeInByte: sizeInByte
+      )
+    }.sorted { $0.sizeInByte > $1.sizeInByte }
+
+    let databaseSize = databaseStoreURL
+      .map { PersistentStorage.getDatabaseSizeInByte(storeURL: $0) } ?? 0
+
+    return StorageUsage(
+      songsSize: fileManager.getSongsCacheSize(for: accountInfo),
+      episodesSize: fileManager.getEpisodesCacheSize(for: accountInfo),
+      artworkSize: fileManager.getArtworkCacheSize(for: accountInfo),
+      embeddedArtworkSize: fileManager.getEmbeddedArtworkCacheSize(for: accountInfo),
+      lyricsSize: fileManager.getLyricsCacheSize(for: accountInfo),
+      databaseSize: databaseSize,
+      albums: albums
+    )
+  }
+}

--- a/AmperfyKitTests/Cases/Storage/StorageUsageTest.swift
+++ b/AmperfyKitTests/Cases/Storage/StorageUsageTest.swift
@@ -1,0 +1,120 @@
+//
+//  StorageUsageTest.swift
+//  AmperfyKitTests
+//
+//  Created by David Masek on 22.08.26.
+//  Copyright (c) 2026 Maximilian Bauer. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import AmperfyKit
+import XCTest
+
+@MainActor
+class StorageUsageTest: XCTestCase {
+  var cdHelper: CoreDataHelper!
+  var library: LibraryStorage!
+  var account: Account!
+
+  override func setUp() async throws {
+    cdHelper = CoreDataHelper()
+    library = cdHelper.createSeededStorage()
+    account = library.getAccount(info: TestAccountInfo.create1())
+  }
+
+  override func tearDown() {}
+
+  func testCachedSongsFileInfosGroupedByAlbum() {
+    let album1 = library.createAlbum(account: account)
+    album1.name = "Album 1"
+    let album2 = library.createAlbum(account: account)
+    album2.name = "Album 2"
+
+    let song1 = library.createSong(account: account)
+    song1.id = "storageUsageSong1"
+    song1.album = album1
+    song1.relFilePath = URL(string: "songs/storageUsageSong1.mp3")
+
+    let song2 = library.createSong(account: account)
+    song2.id = "storageUsageSong2"
+    song2.album = album1
+    song2.relFilePath = URL(string: "songs/storageUsageSong2.mp3")
+
+    let song3 = library.createSong(account: account)
+    song3.id = "storageUsageSong3"
+    song3.album = album2
+    song3.relFilePath = URL(string: "songs/storageUsageSong3.mp3")
+
+    // not cached -> must not be counted
+    let song4 = library.createSong(account: account)
+    song4.id = "storageUsageSong4"
+    song4.album = album1
+
+    // cached, but without album -> unknown album bucket
+    let song5 = library.createSong(account: account)
+    song5.id = "storageUsageSong5"
+    song5.relFilePath = URL(string: "songs/storageUsageSong5.mp3")
+
+    library.saveContext()
+
+    let infos = library.getCachedSongsFileInfosGroupedByAlbum(for: account)
+
+    guard let album1Info = infos.first(where: { $0.albumName == "Album 1" })
+    else { XCTFail(); return }
+    XCTAssertEqual(album1Info.songCount, 2)
+    XCTAssertEqual(album1Info.relFilePaths.count, 2)
+
+    guard let album2Info = infos.first(where: { $0.albumName == "Album 2" })
+    else { XCTFail(); return }
+    XCTAssertEqual(album2Info.songCount, 1)
+    XCTAssertEqual(
+      album2Info.relFilePaths.first?.path,
+      "songs/storageUsageSong3.mp3"
+    )
+
+    guard let unknownAlbumInfo = infos.first(where: { $0.albumName == "Unknown Album" })
+    else { XCTFail(); return }
+    XCTAssertEqual(unknownAlbumInfo.songCount, 1)
+  }
+
+  func testGetDatabaseSizeInByte() throws {
+    let fileManager = FileManager.default
+    let tempDir = fileManager.temporaryDirectory
+      .appendingPathComponent("StorageUsageTest-" + UUID().uuidString)
+    try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: tempDir) }
+
+    let storeURL = tempDir.appendingPathComponent("Amperfy.sqlite")
+    try Data(count: 100).write(to: storeURL)
+    try Data(count: 10).write(to: tempDir.appendingPathComponent("Amperfy.sqlite-wal"))
+    try Data(count: 20).write(to: tempDir.appendingPathComponent("Amperfy.sqlite-shm"))
+    let externalDataDir = tempDir
+      .appendingPathComponent(".Amperfy_SUPPORT")
+      .appendingPathComponent("_EXTERNAL_DATA")
+    try fileManager.createDirectory(at: externalDataDir, withIntermediateDirectories: true)
+    try Data(count: 1_000).write(to: externalDataDir.appendingPathComponent("blob"))
+    // unrelated file next to the store -> must not be counted
+    try Data(count: 9_999).write(to: tempDir.appendingPathComponent("unrelated.txt"))
+
+    XCTAssertEqual(PersistentStorage.getDatabaseSizeInByte(storeURL: storeURL), 1_130)
+  }
+
+  func testGetDatabaseSizeInByteOfMissingStore() {
+    let missingStoreURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("StorageUsageTest-" + UUID().uuidString)
+      .appendingPathComponent("Amperfy.sqlite")
+    XCTAssertEqual(PersistentStorage.getDatabaseSizeInByte(storeURL: missingStoreURL), 0)
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Amperfy (personal fork)
+
+This is `davidmasek/amperfy`, a fork of [BLeeEZ/amperfy](https://github.com/BLeeEZ/amperfy)
+(iOS/iPadOS/macOS Swift client for Ampache/Subsonic servers, GPLv3). Used both for
+learning iOS dev and for preparing PRs back upstream.
+
+## Remotes
+
+- `origin` → your fork, push here.
+- `upstream` → `BLeeEZ/amperfy`, pull-only, PRs target this.
+
+## Branching rule — keeps local-only files out of upstream PRs
+
+This file, `.env.local`, and anything else that's useful locally but not part of the
+project only live on your fork's `master`. **Any branch meant to become an upstream PR
+must be based on `upstream/master`, not on your local `master`:**
+
+```
+git fetch upstream
+git checkout -b my-feature upstream/master
+```
+
+That way the feature branch's file tree never contains this file or any other local-only
+addition, so a PR diff against `upstream/master` is always exactly the intended change —
+regardless of what accumulates on your own `master`.
+
+Keep your fork's `master` in sync periodically: `git fetch upstream && git merge upstream/master`.
+
+## Secrets
+
+Never put credentials or private URLs directly in this file or any other tracked file.
+Local test-server details live in `.env.local` (gitignored) — see `.env.local.example`
+for the format. Currently points at a personal Navidrome instance reachable over Tailscale.
+
+## Build
+
+- Xcode 26, Swift 6 required.
+- Open `Amperfy.xcodeproj`, scheme `Amperfy` for the app, `DebugCoreData` for inspecting
+  the local Core Data store, `AmperfyIntents` for the Siri extension.
+- Dependencies resolve via Swift Package Manager automatically on first open.
+- Real-device signing: free/personal Apple ID team works, but `Amperfy/Amperfy.entitlements`
+  requests CarPlay + Siri entitlements that a free account can't get approved — clear those
+  entries to sideload locally. Also change the bundle identifier (upstream's isn't yours to sign).
+
+## Before opening a PR
+
+- Run `AmperfyKitTests` (also applies SwiftFormat/Google style automatically).
+- Or format manually: `./BuildTools/applyFormat.sh`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,20 +9,15 @@ learning iOS dev and for preparing PRs back upstream.
 - `origin` → your fork, push here.
 - `upstream` → `BLeeEZ/amperfy`, pull-only, PRs target this.
 
-## Branching rule — keeps local-only files out of upstream PRs
+## Branching
 
-This file, `.env.local`, and anything else that's useful locally but not part of the
-project only live on your fork's `master`. **Any branch meant to become an upstream PR
-must be based on `upstream/master`, not on your local `master`:**
-
-```
-git fetch upstream
-git checkout -b my-feature upstream/master
-```
-
-That way the feature branch's file tree never contains this file or any other local-only
-addition, so a PR diff against `upstream/master` is always exactly the intended change —
-regardless of what accumulates on your own `master`.
+Branch off your fork's `master` for everything: `git checkout -b my-feature master`. No
+need to juggle two bases — `master`'s local-only additions (this file, `.env.local`,
+whatever signing tweaks Xcode leaves behind) never block a PR, because when a branch is
+ready to go upstream, diff or cherry-pick just the relevant commits against
+`upstream/master` at that point (`git diff upstream/master...my-feature`, or
+`git rebase --onto upstream/master <fork-point> my-feature` for a clean PR branch) instead
+of requiring the branch to have been based there from the start.
 
 Keep your fork's `master` in sync periodically: `git fetch upstream && git merge upstream/master`.
 
@@ -41,6 +36,16 @@ for the format. Currently points at a personal Navidrome instance reachable over
 - Real-device signing: free/personal Apple ID team works, but `Amperfy/Amperfy.entitlements`
   requests CarPlay + Siri entitlements that a free account can't get approved — clear those
   entries to sideload locally. Also change the bundle identifier (upstream's isn't yours to sign).
+
+## Simulator automation (not set up yet)
+
+Claude can build, run `AmperfyKitTests`, and launch the app in the iOS Simulator to check
+it doesn't crash on boot — but there's no way to script taps/navigation yet: no
+`idb`/Appium is installed, and `osascript`/System Events UI scripting is blocked because
+Terminal doesn't have macOS Accessibility permission in this environment. So Claude can
+confirm "it builds and launches," not "this specific screen renders correctly" — that
+still needs a manual check in the Simulator for now. Worth revisiting properly later
+(install `idb`, or grant Accessibility access) if this comes up often.
 
 ## Before opening a PR
 


### PR DESCRIPTION
## Summary
- New Settings screen (Settings ▸ Storage, also linked from Library ▸ Cache) breaking down on-disk usage: songs, podcast episodes, remote artwork, embedded artwork, lyrics, internal database, and available device space, plus a total.
- Per-album breakdown of cached song sizes, computed from the actual files on disk (not the server-reported `size` attribute), so it stays correct when the server transcodes downloads.
- New AmperfyKit surface used by the screen: `CacheFileManager` per-category size accessors, `PersistentStorage.getDatabaseSizeInByte`, `LibraryStorage.getCachedSongsFileInfosGroupedByAlbum`, and `StorageUsageCalculator` (computes off the main thread, Core Data access via the existing async wrapper).
