### PR TITLE
Show Artwork Cache Size

### DIFF
--- a/Amperfy/SwiftUI/Settings/Artwork/ArtworkSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Artwork/ArtworkSettingsView.swift
@@ -39,6 +39,8 @@ struct ArtworkSettingsView: View {
   var artworkNotCheckedCountText = ""
   @State
   var cachedArtworksCountText = ""
+  @State
+  var artworkCacheSizeText = ""
 
   @State
   var isShowDownloadArtworksAlert = false
@@ -77,6 +79,20 @@ struct ArtworkSettingsView: View {
     }}
   }
 
+  private func updateArtworkCacheSize() {
+    guard let activeAccountInfo = settings.activeAccountInfo else { return }
+    // Walks the artwork directory on disk, so keep it off the main thread and only
+    // trigger it on-demand rather than on the view's 1-second refresh timer.
+    Task.detached(priority: .utility) {
+      let artworkByteSize = fileManager.getArtworkCacheSize(for: activeAccountInfo)
+      let text = (artworkByteSize > 1_000_000) ? artworkByteSize.asByteString : Int64(0)
+        .asByteString
+      await MainActor.run {
+        artworkCacheSizeText = text
+      }
+    }
+  }
+
   var body: some View {
     ZStack {
       SettingsList {
@@ -89,6 +105,9 @@ struct ArtworkSettingsView: View {
           }
           SettingsRow(title: "Cached Artworks") {
             SecondaryText(cachedArtworksCountText)
+          }
+          SettingsRow(title: "Artwork Cache Size") {
+            SecondaryText(artworkCacheSizeText)
           }
 
           if let activeAccountInfo = settings.activeAccountInfo {
@@ -134,6 +153,7 @@ struct ArtworkSettingsView: View {
                   appDelegate.storage.main.library.saveContext()
                   fileManager.deleteRemoteArtworkCache(accountInfo: activeAccountInfo)
                   appDelegate.getMeta(activeAccountInfo).artworkDownloadManager.start()
+                  updateArtworkCacheSize()
                 },
                 secondaryButton: .cancel()
               )
@@ -154,6 +174,7 @@ struct ArtworkSettingsView: View {
     .navigationBarTitleDisplayMode(.inline)
     .onAppear {
       updateValues()
+      updateArtworkCacheSize()
     }
     .onReceive(timer) { _ in
       updateValues()

--- a/AmperfyKit/Storage/CacheFileManager.swift
+++ b/AmperfyKit/Storage/CacheFileManager.swift
@@ -307,6 +307,15 @@ final public class CacheFileManager: Sendable {
     return bytes
   }
 
+  /// Size of this account's downloaded artwork on disk. Unlike `getPlayableCacheSize`, this is
+  /// not backed by a maintained running total -- it walks the artwork directory on every call --
+  /// so callers should compute it on demand rather than on a high-frequency timer.
+  public func getArtworkCacheSize(for accountInfo: AccountInfo) -> Int64 {
+    guard let absArtworksDir = getOrCreateAbsoluteArtworksDirectory(for: accountInfo)
+    else { return 0 }
+    return directorySize(url: absArtworksDir)
+  }
+
   private static let artworkFileExtension = "png"
   private static let lyricsFileExtension = "xml"
   private static let accountsDir = URL(string: "accounts")!


### PR DESCRIPTION
x`I would like more visibility into storage used by Amperfy. This PR makes storage used by Artwork caching visible.

## Summary

Adds an "Artwork Cache Size" row to Settings->Artwork. Mirrors the existing "Complete Cache Size" on Settings->Library for song/episode cache.

## Alternatives considered

Unlike the playable cache size (which maintains running total using `CacheFileManager`) , `getArtworkCacheSize` does a real directory walk. To avoid repeated computations it's done on-demand instead of using the view's 1-second refresh timer.

I think it's a reasonable tradeoff to keep this feature simple. 

## UI Screenshot 

<img width="319" height="297" alt="image" src="https://github.com/user-attachments/assets/b4b5f825-eebc-4f4c-8e1a-45a39c2e892e" />
