### PR TITLE
Player: resume from the error position instead of restarting the track

### DIFF
--- a/AmperfyKit/Player/AudioPlayer.swift
+++ b/AmperfyKit/Player/AudioPlayer.swift
@@ -273,14 +273,25 @@ public class AudioPlayer: NSObject, BackendAudioPlayerNotifiable {
   }
 
   private func seekToLastStoppedPlayTime() {
+    // An error tears the player down and re-inserts the current playable, which
+    // makes it start from the beginning. Resume from the position captured when
+    // the error occurred instead. The persisted `playProgress` cannot be used
+    // for this: `savePlayInformation` deliberately resets it to zero within
+    // `progressTimeEndThreshold` of the end of the track, which is exactly where
+    // a stream error is most likely to happen.
+    if backendAudioPlayer.isErrorOccurred {
+      let resumeTime = backendAudioPlayer.elapsedTimeBeforeErrorOccurred
+      if resumeTime > 0 {
+        backendAudioPlayer.seek(toSecond: resumeTime)
+      }
+      return
+    }
+
     if let playable = currentlyPlaying,
        playable.playProgress > 0,
        playable
        .isPodcastEpisode ||
-       (
-         (playable.isSong || backendAudioPlayer.isErrorOccurred) && settings.user
-           .isPlayerSongPlaybackResumeEnabled
-       ) {
+       (playable.isSong && settings.user.isPlayerSongPlaybackResumeEnabled) {
       backendAudioPlayer.seek(toSecond: Double(playable.playProgress))
     }
   }

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -124,6 +124,10 @@ class BackendAudioPlayer: NSObject {
   public var triggerReinsertPlayableCB: TriggerReinsertPlayableCallback?
   public private(set) var isPlaying: Bool = false
   public private(set) var isErrorOccurred: Bool = false
+  /// Playback position in seconds at the moment the last error occurred.
+  /// Captured before `restartPlayer()` tears the engine down, so that error
+  /// recovery can resume where playback stopped instead of starting over.
+  public private(set) var elapsedTimeBeforeErrorOccurred: Double = 0.0
   public private(set) var playType: PlayType?
   private var perloadedPlayType: PlayType?
   public private(set) var activeStreamingBitrate: StreamingMaxBitratePreference?
@@ -294,6 +298,7 @@ class BackendAudioPlayer: NSObject {
   private func handleError(error: Error) {
     isErrorOccurred = true
     wasPlayingBeforeErrorOccurred = isPlaying
+    elapsedTimeBeforeErrorOccurred = elapsedTime
     pause()
     nextPreloadedPlayable = nil
     nextPreloadedUrl = ""
@@ -379,6 +384,16 @@ class BackendAudioPlayer: NSObject {
 
   var shouldPlaybackStart: Bool {
     (!isErrorOccurred && isAutoStartPlayback) || (isErrorOccurred && wasPlayingBeforeErrorOccurred)
+  }
+
+  /// Leaves the error state once playback has actually resumed.
+  /// `isErrorOccurred` is otherwise never reset, so after the first error of a
+  /// session `shouldPlaybackStart` would keep ignoring `isAutoStartPlayback`.
+  /// Only call this after every reader of `shouldPlaybackStart` has run.
+  private func clearErrorState() {
+    isErrorOccurred = false
+    wasPlayingBeforeErrorOccurred = false
+    elapsedTimeBeforeErrorOccurred = 0.0
   }
 
   func requestToPlay(
@@ -803,6 +818,10 @@ extension BackendAudioPlayer: AudioStreaming.AudioPlayerDelegate {
         player?.seek(to: seekTimeWhenStarted)
         self.seekTimeWhenStarted = nil
       }
+
+      // Playback is running again and every reader of `shouldPlaybackStart` has
+      // had its turn, so it is safe to leave the error state here.
+      clearErrorState()
     }
   }
 

--- a/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
+++ b/AmperfyKitTests/Cases/Player/MusicPlayerTest.swift
@@ -2824,4 +2824,31 @@ class MusicPlayerTest: XCTestCase {
     XCTAssertTrue(testPlayer.isPlaying)
     XCTAssertEqual(testPlayer.currentlyPlaying?.id, playlistAllCached.playables[0].id)
   }
+
+  @MainActor
+  private func startPlaybackAndSettle() async throws {
+    prepareWithAllSongsCached()
+    testPlayer.play()
+    // playback start hops through the main actor several times, so let it settle
+    // before injecting an error, otherwise the two interleave.
+    try await Task.sleep(nanoseconds: 500_000_000)
+  }
+
+  @MainActor
+  func testStreamError_capturesPlaybackPositionForRecovery() async throws {
+    try await startPlaybackAndSettle()
+    mockAudioStreamingPlayer.mockElapsedTime = 200.0
+
+    XCTAssertFalse(backendPlayer.isErrorOccurred)
+    XCTAssertEqual(backendPlayer.elapsedTimeBeforeErrorOccurred, 0.0)
+
+    backendPlayer.audioPlayerUnexpectedError(
+      player: AudioStreaming.AudioPlayer(),
+      error: .codecError
+    )
+    try await Task.sleep(nanoseconds: 300_000_000)
+
+    XCTAssertTrue(backendPlayer.isErrorOccurred)
+    XCTAssertEqual(backendPlayer.elapsedTimeBeforeErrorOccurred, 200.0)
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #305, and the same symptom reported in #315. A song plays fine, a red
`AudioStreaming.NetworkError error 0.` appears near the end of the track, and the
same song starts again from the beginning.

The restart is client-side. It happens on macOS as well as iOS, and it happens with
`format=raw`, a plain `download.view` response that carries a correct `Content-Length`
and answers `Range` with `206`. You do not need the missing-`Content-Length`,
`Accept-Ranges: none` shape of an uncached transcode to reproduce it. That header
problem is real and worth fixing on its own, but it is not what makes the track restart.

After an error the player already re-inserts the current playable. What it does not do is
seek back to where playback stopped, so the re-insert plays from `0`.

## Root cause

Two conditions both have to hold for
[`seekToLastStoppedPlayTime()`](AmperfyKit/Player/AudioPlayer.swift) to restore the
position. Near the end of a track both are false.

**The saved position is zeroed exactly where the error lands.**
`AudioPlayer.savePlayInformation` clears `playProgress` once playback is within
`progressTimeEndThreshold` (15 s) of the end:

```swift
if playProgress > Self.progressTimeStartThreshold,
   playProgress < (playDuration - Self.progressTimeEndThreshold) {
  playable.playProgress = Int(playProgress)
} else {
  playable.playProgress = 0
}
```

That is right on its own. A track that reached the end should not resume mid-way next
time. But `seekToLastStoppedPlayTime()` is gated on `playable.playProgress > 0`, so error
recovery inherits the reset and has nothing to seek to.

**Error recovery became opt-in.** bcd9c8e added the error-recovery seek as its own
condition. 84e740d ("new setting to optionally save and use song playback progress") then
folded it into the new setting:

```swift
playable.isPodcastEpisode ||
  ((playable.isSong || backendAudioPlayer.isErrorOccurred) && settings.user
    .isPlayerSongPlaybackResumeEnabled)
```

`isErrorOccurred` went from its own `||` branch to being `&&`-ed with a setting that
defaults to `false`. For a song the expression reduces to
`isPlayerSongPlaybackResumeEnabled`, so with default settings the seek never runs. That
commit was adding resume for normal playback, so entangling the error flag with it looks
unintended.

With both gates shut, `handleError` calls `restartPlayer()` and then
`triggerReinsertPlayableCB()`, which puts the track back at position `0`.

**Why it clusters near the end of the track.** `checkForPreloadNextPlayerItem` in
[`BackendAudioPlayer.swift`](AmperfyKit/Player/BackendAudioPlayer.swift) opens the next
track's stream when `remainingTime < 10`:

```swift
let remainingTime = duration - elapsedTime
if remainingTime > 0, remainingTime < 10 {
  nextPreloadedPlayable = nextPlayablePreloadCB?()
  ...
  try await insertStreamPlayable(playable: nextPreloadedPlayable, queueType: .queue)
```

The restarts I measured land inside that window. 225 s into a 233 s track leaves 8 s, and
313 s into a 323 s track leaves 10 s. `audioPlayerUnexpectedError(player:error:)` carries
no entry id, so `handleError` cannot tell which queued entry failed and tears down
whatever is playing at the time. I have not tried to fix that attribution here, since it
is a much larger change. This PR makes the recovery itself non-destructive.

## The change

Capture the position when the error happens, before `restartPlayer()` discards it, and use
it for recovery independently of the persisted `playProgress`.

- `BackendAudioPlayer.elapsedTimeBeforeErrorOccurred` is set in `handleError` ahead of the
  teardown.
- `seekToLastStoppedPlayTime()` handles the error case first and returns. The opt-in
  setting keeps governing normal playback exactly as 84e740d intended.
- `clearErrorState()` runs at the end of `didStartPlaying`, the first point where every
  reader of `shouldPlaybackStart` has had its turn. `isErrorOccurred` had no reset at all
  before, so after the first error of a session `shouldPlaybackStart` ignored
  `isAutoStartPlayback` for good.

With default settings the track now continues from where it stopped instead of restarting
from `0`. The error itself is unchanged and still reported.

## Test plan

`AmperfyKitTests` passes. 366 tests, 0 failures, on
`platform=macOS,variant=Mac Catalyst,arch=arm64`.

Added `MusicPlayerTest.testStreamError_capturesPlaybackPositionForRecovery`, which checks
that the position survives the teardown.

I could not write an honest end-to-end test of the restart, and I would rather say so than
pad the diff. In the current harness
[`MusicPlayerTest`](AmperfyKitTests/Cases/Player/MusicPlayerTest.swift) `setUp` never wires
`triggerReinsertPlayableCB` (production wires it in
[`AmperfyKit.swift`](AmperfyKit/AmperfyKit.swift)), so `handleError`'s recovery does
nothing in tests and this path has never had coverage. Wiring the callback is not enough
either. `AudioPlayer.play()` on an already-playing item resumes rather than re-preparing,
so the mock's `play(url:)` never re-runs and the elapsed time never returns to zero. An
assertion on "the track did not restart" then passes with and without this fix. I
confirmed that by disabling the recovery seek and watching the test stay green, then
deleted it. Making that path testable is worth doing separately.

Manual, against Navidrome over a direct LAN link:

- [ ] FLAC library, `Format (Transcoding) = raw`, stream a track to the end
- [ ] Same with `Format = mp3`, an uncached transcode with no `Content-Length` and `Accept-Ranges: none`
- [ ] `Song Playback Resume` off (default) and on, recovery works either way
- [ ] Locally cached track, unchanged, no error path taken
- [ ] Podcast episode, resume behaviour unchanged
- [ ] Second error in the same session still auto-starts playback
