### PR TITLE
Remember main window size and position on Mac Catalyst

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -536,6 +536,9 @@
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		C90700000000000000000001 /* MainWindowFrameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90700000000000000000004; };
+		C90700000000000000000002 /* MainWindowFrameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90700000000000000000004; };
+		C90700000000000000000003 /* MainWindowFrameStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90700000000000000000005; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1158,6 +1161,8 @@
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		C90700000000000000000004 /* MainWindowFrameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amperfy/MainWindowFrameStore.swift; sourceTree = SOURCE_ROOT; };
+		C90700000000000000000005 /* MainWindowFrameStoreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmperfyKitTests/Cases/Storage/MainWindowFrameStoreTest.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1470,6 +1475,7 @@
 			children = (
 				508385E721C5965B00C4BB32 /* AppDelegate.swift */,
 				5059A31B28A9ED680068E4D2 /* SceneDelegate.swift */,
+				C90700000000000000000004 /* MainWindowFrameStore.swift */,
 				63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */,
 				637A28B42C79409B0082FACC /* MiniPlayerSceneDelegate.swift */,
 				C0A1B0022EEE000000000002 /* MacWindowHelper.swift */,
@@ -1592,6 +1598,7 @@
 			isa = PBXGroup;
 			children = (
 				5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */,
+				C90700000000000000000005 /* MainWindowFrameStoreTest.swift */,
 				5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */,
 			);
 			path = Player;
@@ -2529,6 +2536,7 @@
 				50DE29EF2B90642E00ABA78E /* SelectionAccessory.swift in Sources */,
 				501A7D4F26820B3F0055A51B /* PodcastDetailVC.swift in Sources */,
 				5059A31C28A9ED680068E4D2 /* SceneDelegate.swift in Sources */,
+				C90700000000000000000001 /* MainWindowFrameStore.swift in Sources */,
 				50DE29F12B90855100ABA78E /* KeyCommandCollectionViewController.swift in Sources */,
 				50E1D39C2B8BED4C0001A572 /* SideBarVC.swift in Sources */,
 				505CA20E2B88EB9A00AA81CD /* BasicFetchedResultsTableViewController.swift in Sources */,
@@ -2881,6 +2889,8 @@
 				50BE5D6E2850F4FB00156FC6 /* SsPlaylistsParserTest.swift in Sources */,
 				50BE5D862850F50F00156FC6 /* PlaylistSongsParserTest.swift in Sources */,
 				50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */,
+				C90700000000000000000002 /* MainWindowFrameStore.swift in Sources */,
+				C90700000000000000000003 /* MainWindowFrameStoreTest.swift in Sources */,
 				50BE5D732850F4FB00156FC6 /* SsPodcastParserTest.swift in Sources */,
 				50BE5D722850F4FB00156FC6 /* SsSongExample1ParserTest.swift in Sources */,
 				50BE5D912850F50F00156FC6 /* GenreParserTest.swift in Sources */,

--- a/Amperfy/MainWindowFrameStore.swift
+++ b/Amperfy/MainWindowFrameStore.swift
@@ -1,0 +1,95 @@
+//
+//  MainWindowFrameStore.swift
+//  Amperfy
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+// Window geometry is stored in macOS screen points, not UIKit content coordinates.
+import Foundation
+#if targetEnvironment(macCatalyst)
+  import CoreGraphics
+#endif
+
+// MARK: - MainWindowFrameStore
+
+struct MainWindowFrameStore {
+  let defaults: UserDefaults
+  static let frameKey = "window.main.frame.v1"
+  static let sizeKey = "window.main.size.v1"
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  func restoredFrame(defaultFrame: CGRect, displays: [CGRect]) -> CGRect? {
+    var frame: CGRect
+    if let values = defaults.array(forKey: Self.frameKey) as? [Double],
+       values.count == 4,
+       Self.isValid(CGRect(x: values[0], y: values[1], width: values[2], height: values[3])) {
+      frame = CGRect(x: values[0], y: values[1], width: values[2], height: values[3])
+    } else if let values = defaults.array(forKey: Self.sizeKey) as? [Double],
+              values.count == 2,
+              Self.isValid(CGRect(x: 0, y: 0, width: values[0], height: values[1])) {
+      frame = CGRect(origin: defaultFrame.origin, size: CGSize(width: values[0], height: values[1]))
+    } else {
+      return nil
+    }
+    let screens = displays.filter(Self.isValid)
+    guard let primary = screens.first else { return frame }
+    // Keep the original display when possible. If it was removed, use the display
+    // selected by the system for the new window, then the primary display.
+    let screen = screens.max(by: { intersectionArea(frame, $0) < intersectionArea(frame, $1) })
+    let destination: CGRect
+    if let screen, intersectionArea(frame, screen) > 0 {
+      destination = screen
+    } else {
+      destination = screens.first(where: { $0.contains(defaultFrame.origin) }) ?? primary
+      frame.origin = CGPoint(
+        x: destination.midX - frame.width / 2,
+        y: destination.midY - frame.height / 2
+      )
+    }
+    frame.size.width = min(frame.width, destination.width)
+    frame.size.height = min(frame.height, destination.height)
+    frame.origin.x = max(destination.minX, min(frame.minX, destination.maxX - frame.width))
+    frame.origin.y = max(destination.minY, min(frame.minY, destination.maxY - frame.height))
+    // UIKit applies the final menu bar, Dock, and minimum-size constraints.
+    return frame
+  }
+
+  func save(_ frame: CGRect, isFullScreen: Bool, isResizing: Bool) {
+    guard !isFullScreen, !isResizing, Self.isValid(frame) else { return }
+    defaults.set(
+      [Double(frame.minX), Double(frame.minY), Double(frame.width), Double(frame.height)],
+      forKey: Self.frameKey
+    )
+    defaults.set([Double(frame.width), Double(frame.height)], forKey: Self.sizeKey)
+  }
+
+  private static func isValid(_ frame: CGRect) -> Bool {
+    [frame.origin.x, frame.origin.y, frame.size.width, frame.size.height]
+      .allSatisfy { $0.isFinite && abs($0) < 100_000 } && frame.size.width > 0 && frame.size
+      .height > 0
+  }
+
+  private func intersectionArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+    let intersection = lhs.intersection(rhs)
+    return intersection.isNull ? 0 : intersection.width * intersection.height
+  }
+
+  #if targetEnvironment(macCatalyst)
+    static func connectedDisplayFrames() -> [CGRect] {
+      var count: UInt32 = 0
+      guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
+      var displays = [CGDirectDisplayID](repeating: 0, count: Int(count))
+      guard CGGetActiveDisplayList(count, &displays, &count) == .success else { return [] }
+      return displays.prefix(Int(count)).map { CGDisplayBounds($0) }
+    }
+  #endif
+}

--- a/Amperfy/SceneDelegate.swift
+++ b/Amperfy/SceneDelegate.swift
@@ -83,6 +83,40 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   var window: UIWindow?
 
+  #if targetEnvironment(macCatalyst)
+    private let mainWindowFrameStore = MainWindowFrameStore()
+    private var hasRestoredMainWindowFrame = false
+
+    private func restoreMainWindowFrame(in scene: UIWindowScene) {
+      guard !hasRestoredMainWindowFrame, !scene.isFullScreen else { return }
+      hasRestoredMainWindowFrame = true
+      guard let frame = mainWindowFrameStore.restoredFrame(
+        defaultFrame: scene.effectiveGeometry.systemFrame,
+        displays: MainWindowFrameStore.connectedDisplayFrames()
+      ) else { return }
+      scene.requestGeometryUpdate(UIWindowScene.GeometryPreferences.Mac(systemFrame: frame)) {
+        error in
+        os_log("Could not restore main window frame: %@", type: .error, error.localizedDescription)
+      }
+    }
+
+    private func saveMainWindowFrame(in scene: UIWindowScene) {
+      guard hasRestoredMainWindowFrame else { return }
+      mainWindowFrameStore.save(
+        scene.effectiveGeometry.systemFrame,
+        isFullScreen: scene.isFullScreen,
+        isResizing: scene.effectiveGeometry.isInteractivelyResizing
+      )
+    }
+
+    func windowScene(
+      _ windowScene: UIWindowScene,
+      didUpdateEffectiveGeometry previousEffectiveGeometry: UIWindowScene.Geometry
+    ) {
+      saveMainWindowFrame(in: windowScene)
+    }
+  #endif
+
   func scene(
     _ scene: UIScene,
     willConnectTo session: UISceneSession,
@@ -161,6 +195,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Called when the scene has moved from an inactive state to an active state.
     // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     os_log("sceneDidBecomeActive", log: self.log, type: .info)
+    #if targetEnvironment(macCatalyst)
+      if let windowScene = scene as? UIWindowScene {
+        restoreMainWindowFrame(in: windowScene)
+      }
+    #endif
     guard appDelegate.isNormalInteraction else {
       return
     }
@@ -172,6 +211,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Called when the scene will move from an active state to an inactive state.
     // This may occur due to temporary interruptions (ex. an incoming phone call).
     os_log("sceneWillResignActive", log: self.log, type: .info)
+    #if targetEnvironment(macCatalyst)
+      if let windowScene = scene as? UIWindowScene {
+        saveMainWindowFrame(in: windowScene)
+      }
+    #endif
     guard appDelegate.isNormalInteraction else {
       return
     }

--- a/AmperfyKitTests/Cases/Storage/MainWindowFrameStoreTest.swift
+++ b/AmperfyKitTests/Cases/Storage/MainWindowFrameStoreTest.swift
@@ -1,0 +1,57 @@
+//
+//  MainWindowFrameStoreTest.swift
+//  AmperfyKit
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+import XCTest
+
+final class MainWindowFrameStoreTest: XCTestCase {
+  func testRestoresNormalFrameAndIgnoresFullscreenAndIntermediateResizes() {
+    let name = "MainWindowFrameStoreTest-\(UUID())"
+    let defaults = UserDefaults(suiteName: name)!
+    defer { defaults.removePersistentDomain(forName: name) }
+    let store = MainWindowFrameStore(defaults: defaults)
+    let frame = CGRect(x: 200, y: 120, width: 1200, height: 800)
+    let display = CGRect(x: 0, y: 0, width: 3840, height: 2160)
+    store.save(frame, isFullScreen: false, isResizing: false)
+    store.save(display, isFullScreen: true, isResizing: false)
+    store.save(.zero, isFullScreen: false, isResizing: true)
+    XCTAssertEqual(store.restoredFrame(defaultFrame: .zero, displays: [display]), frame)
+  }
+
+  func testNegativeDisplayOriginsAndRemovedDisplay() {
+    let name = "MainWindowFrameStoreTest-\(UUID())"
+    let defaults = UserDefaults(suiteName: name)!
+    defer { defaults.removePersistentDomain(forName: name) }
+    let store = MainWindowFrameStore(defaults: defaults)
+    let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+    let secondary = CGRect(x: -2560, y: -400, width: 2560, height: 1440)
+    let saved = CGRect(x: -2200, y: -100, width: 1500, height: 900)
+    store.save(saved, isFullScreen: false, isResizing: false)
+    XCTAssertEqual(store.restoredFrame(defaultFrame: .zero, displays: [primary, secondary]), saved)
+    let restored = store.restoredFrame(defaultFrame: .zero, displays: [primary])!
+    XCTAssertTrue(primary.contains(restored))
+    XCTAssertEqual(restored.size, saved.size)
+  }
+
+  func testSmallerDisplayAndLegacyPreference() {
+    let name = "MainWindowFrameStoreTest-\(UUID())"
+    let defaults = UserDefaults(suiteName: name)!
+    defer { defaults.removePersistentDomain(forName: name) }
+    let store = MainWindowFrameStore(defaults: defaults)
+    let display = CGRect(x: 0, y: 0, width: 1440, height: 900)
+    defaults.set([2363.0, 1488.0], forKey: MainWindowFrameStore.sizeKey)
+    XCTAssertEqual(store.restoredFrame(defaultFrame: .zero, displays: [display]), display)
+    defaults.set([0.0, 0.0, -1.0, 200.0], forKey: MainWindowFrameStore.frameKey)
+    XCTAssertEqual(store.restoredFrame(defaultFrame: .zero, displays: [display]), display)
+    defaults.removeObject(forKey: MainWindowFrameStore.sizeKey)
+    XCTAssertNil(store.restoredFrame(defaultFrame: .zero, displays: [display]))
+  }
+}


### PR DESCRIPTION
A resized and repositioned Mac Catalyst window currently opens at the system default frame on the next launch. This remembers the main window's normal size and position and restores them with the public `UIWindowScene` geometry API.

- Ignore full screen geometry and intermediate drag resize updates so they do not replace the normal frame.
- Keep the window on its previous display when available; clamp or reposition it onto a connected display when the saved display is missing or smaller.
- Leave Settings and mini player window behavior unchanged.

Validation: all 368 `AmperfyKitTests` passed on arm64 Mac Catalyst with Xcode 26.6, including three new geometry tests. In a sandboxed local build, a 1344 × 968 window at (1408, 348) restored exactly after quit/relaunch; entering and leaving full screen preserved that frame. Removed displays and negative display origins are covered by unit tests; physical monitor removal has not been exercised.