### PR TITLE
Choose where downloaded music is stored on Mac

### DIFF
--- a/Amperfy.xcodeproj/project.pbxproj
+++ b/Amperfy.xcodeproj/project.pbxproj
@@ -536,6 +536,12 @@
 		638920F02C8C8E9000932EE8 /* SettingsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638920EF2C8C8E9000932EE8 /* SettingsList.swift */; };
 		63DCDB7A2C674B5D00522F68 /* SettingsSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCDB792C674B5D00522F68 /* SettingsSceneDelegate.swift */; };
 		641708592C13BF5100BA2619 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641708582C13BF5100BA2619 /* Haptics.swift */; };
+		A11E00000000000000000001 /* ExternalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E00000000000000000003 /* ExternalCache.swift */; };
+		A11E00000000000000000002 /* ExternalCacheTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E00000000000000000004 /* ExternalCacheTest.swift */; };
+		A11E00000000000000000005 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A11E00000000000000000006 /* PrivacyInfo.xcprivacy */; };
+		A11E00000000000000000008 /* CacheLocationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E00000000000000000009 /* CacheLocationSettingsView.swift */; };
+		C90700000000000000000006 /* CacheRelocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90700000000000000000007 /* CacheRelocation.swift */; };
+		C90700000000000000000008 /* CacheRelocationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90700000000000000000009 /* CacheRelocationTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1158,6 +1164,12 @@
 		641708582C13BF5100BA2619 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		643A04712CD29AB20012DEA3 /* Amperfy v39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v39.xcdatamodel"; sourceTree = "<group>"; };
 		64C433822E1391FA0082A165 /* Amperfy v46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Amperfy v46.xcdatamodel"; sourceTree = "<group>"; };
+		A11E00000000000000000003 /* ExternalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmperfyKit/Storage/ExternalCache.swift; sourceTree = SOURCE_ROOT; };
+		A11E00000000000000000004 /* ExternalCacheTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmperfyKitTests/Cases/Storage/ExternalCacheTest.swift; sourceTree = SOURCE_ROOT; };
+		A11E00000000000000000006 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Amperfy/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
+		A11E00000000000000000009 /* CacheLocationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amperfy/SwiftUI/Settings/CacheLocationSettingsView.swift; sourceTree = SOURCE_ROOT; };
+		C90700000000000000000007 /* CacheRelocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmperfyKit/Storage/CacheRelocation.swift; sourceTree = SOURCE_ROOT; };
+		C90700000000000000000009 /* CacheRelocationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmperfyKitTests/Cases/Storage/CacheRelocationTest.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1420,6 +1432,7 @@
 				5078AFB12B40CA5E0038FD17 /* DisplaySettingsView.swift */,
 				50AE79AB2C1CCBEC0085CBB3 /* DeveloperView.swift */,
 				50791E8428D36F1F006CE6E5 /* LibrarySettingsView.swift */,
+				A11E00000000000000000009 /* CacheLocationSettingsView.swift */,
 				504B441828D6F0920033982C /* LicenseSettingsView.swift */,
 				504B441C28D7A6330033982C /* XCallbackURLsSetttingsView.swift */,
 				502041962E2A37D6003CE29A /* Player */,
@@ -1592,6 +1605,8 @@
 			isa = PBXGroup;
 			children = (
 				5095F98B23C8389E008B0805 /* MusicPlayerTest.swift */,
+				C90700000000000000000009 /* CacheRelocationTest.swift */,
+				A11E00000000000000000004 /* ExternalCacheTest.swift */,
 				5011712D27453D1300B7C08D /* PlayQueueHandlerTest.swift */,
 			);
 			path = Player;
@@ -1739,6 +1754,8 @@
 				50E59A4C2ED7541900F2B65C /* HomeSection.swift */,
 				50C9D6EC284FADB8007F18D0 /* PlayerDisplayStyleType.swift */,
 				5023D9AF2BD9A55E00310144 /* CacheFileManager.swift */,
+				C90700000000000000000007 /* CacheRelocation.swift */,
+				A11E00000000000000000003 /* ExternalCache.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -1774,6 +1791,7 @@
 			children = (
 				43FBE27E250D4DFD00D5F9B3 /* LaunchScreen.storyboard */,
 				508385EB21C5965B00C4BB32 /* Main.storyboard */,
+				A11E00000000000000000006 /* PrivacyInfo.xcprivacy */,
 				508FDE4B21F58AFC005A0724 /* AppStoryboard.swift */,
 				5009863A2208CB170057A1A6 /* Basics */,
 				504627EB2B73C1E600F481F8 /* Player */,
@@ -2360,6 +2378,7 @@
 				50CCD0572B6C38670073793B /* PlainDetailsVC.xib in Resources */,
 				508EBB282850C8D90053D9F0 /* Assets.xcassets in Resources */,
 				508385ED21C5965B00C4BB32 /* Main.storyboard in Resources */,
+				A11E00000000000000000005 /* PrivacyInfo.xcprivacy in Resources */,
 				500B97D02B7C9555005554BF /* EntityPreviewVC.xib in Resources */,
 				50A30E642B756CF100722894 /* CurrentlyPlayingTableCell.xib in Resources */,
 			);
@@ -2529,6 +2548,7 @@
 				50DE29EF2B90642E00ABA78E /* SelectionAccessory.swift in Sources */,
 				501A7D4F26820B3F0055A51B /* PodcastDetailVC.swift in Sources */,
 				5059A31C28A9ED680068E4D2 /* SceneDelegate.swift in Sources */,
+				A11E00000000000000000008 /* CacheLocationSettingsView.swift in Sources */,
 				50DE29F12B90855100ABA78E /* KeyCommandCollectionViewController.swift in Sources */,
 				50E1D39C2B8BED4C0001A572 /* SideBarVC.swift in Sources */,
 				505CA20E2B88EB9A00AA81CD /* BasicFetchedResultsTableViewController.swift in Sources */,
@@ -2761,6 +2781,8 @@
 				50C9D690284FAA6C007F18D0 /* ArtworkMO+CoreDataProperties.swift in Sources */,
 				50C9D657284FAA02007F18D0 /* SsSongParserDelegate.swift in Sources */,
 				5023D9B02BD9A55E00310144 /* CacheFileManager.swift in Sources */,
+				C90700000000000000000006 /* CacheRelocation.swift in Sources */,
+				A11E00000000000000000001 /* ExternalCache.swift in Sources */,
 				50C9D6C1284FAACE007F18D0 /* PlayableDownloadDelegate.swift in Sources */,
 				50AE79AE2C1E23930085CBB3 /* SsOpenSubsonicExtensionsParserDelegate.swift in Sources */,
 				50C9D671284FAA4D007F18D0 /* Identifyable.swift in Sources */,
@@ -2881,6 +2903,8 @@
 				50BE5D6E2850F4FB00156FC6 /* SsPlaylistsParserTest.swift in Sources */,
 				50BE5D862850F50F00156FC6 /* PlaylistSongsParserTest.swift in Sources */,
 				50BE5D532850F4E700156FC6 /* MusicPlayerTest.swift in Sources */,
+				C90700000000000000000008 /* CacheRelocationTest.swift in Sources */,
+				A11E00000000000000000002 /* ExternalCacheTest.swift in Sources */,
 				50BE5D732850F4FB00156FC6 /* SsPodcastParserTest.swift in Sources */,
 				50BE5D722850F4FB00156FC6 /* SsSongExample1ParserTest.swift in Sources */,
 				50BE5D912850F50F00156FC6 /* GenreParserTest.swift in Sources */,

--- a/Amperfy/Amperfy.entitlements
+++ b/Amperfy/Amperfy.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/Amperfy/AppDelegate.swift
+++ b/Amperfy/AppDelegate.swift
@@ -37,6 +37,9 @@ let defaultWindowActivityType = "amperfy.main"
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+  #if targetEnvironment(macCatalyst)
+    private var cacheAvailabilityTimer: Timer?
+  #endif
   static let name = "Amperfy"
   static var version: String {
     (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? ""
@@ -185,6 +188,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   @MainActor
   private func performBackgroundFetchTask(bgTask: BGTask) async {
+    guard let rootLease = try? CacheFileManager.shared.currentRootLease() else {
+      bgTask.setTaskCompleted(success: false)
+      return
+    }
     os_log("Perform task: %s", log: self.log, type: .info, Self.refreshTaskId)
     var success = true
     for accountInfo in storage.settings.accounts.allAccounts {
@@ -199,6 +206,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
           displayPopup: false
         )
       }
+    }
+    do {
+      try rootLease.validateCurrent()
+    } catch {
+      success = false
     }
     bgTask.setTaskCompleted(success: success)
     userStatistics.backgroundFetchPerformed(result: UIBackgroundFetchResult.newData)
@@ -255,6 +267,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   )
     -> Bool {
+    do {
+      try CacheRootRuntime.shared.bootstrap()
+    } catch {
+      // Metadata and streaming remain available. Cache consumers still reject access
+      // until the configured drive is verified; no internal fallback is created.
+    }
+
     if let options = launchOptions {
       os_log("application launch with options:", log: self.log, type: .info)
       options
@@ -263,8 +282,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       os_log("application launch", log: self.log, type: .info)
     }
 
+    #if targetEnvironment(macCatalyst)
+      cacheAvailabilityTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { _ in
+        Task.detached { CacheRootRuntime.shared.refreshAvailability() }
+      }
+    #endif
     storage.applyMultiAccountSettingsUpdateIfNeeded()
-    libraryUpdater.performAccountCleanUpIfNeccessaryInBackground()
+    if CacheRootRuntime.shared.isCacheAvailable {
+      libraryUpdater.performAccountCleanUpIfNeccessaryInBackground()
+    }
 
     configureDefaultNavigationBarStyle()
     configureBatteryMonitoring()
@@ -291,7 +317,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       type: .info,
       CacheFileManager.shared.getAmperfyPath() ?? "-"
     )
-    libraryUpdater.performSmallBlockingLibraryUpdatesIfNeeded()
+    if CacheRootRuntime.shared.isCacheAvailable {
+      libraryUpdater.performSmallBlockingLibraryUpdatesIfNeeded()
+    }
     // start manager only if no visual indicated updates are needed
     if !libraryUpdater.isVisualUpadateNeeded {
       startManagerForNormalOperation()

--- a/Amperfy/PrivacyInfo.xcprivacy
+++ b/Amperfy/PrivacyInfo.xcprivacy
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Amperfy/SceneDelegate.swift
+++ b/Amperfy/SceneDelegate.swift
@@ -21,6 +21,7 @@
 
 import AmperfyKit
 import OSLog
+import SwiftUI
 import UIKit
 
 // MARK: - MainSceneHostingViewController
@@ -82,6 +83,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }()
 
   var window: UIWindow?
+  #if targetEnvironment(macCatalyst)
+    private var cacheBanner: UIView?
+    private var cacheBannerTimer: Timer?
+    private var contentTopInset: CGFloat = 0
+  #endif
 
   func scene(
     _ scene: UIScene,
@@ -128,8 +134,76 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func replaceMainRootViewController(vc: UIViewController) {
+    #if targetEnvironment(macCatalyst)
+      cacheBanner?.removeFromSuperview()
+      cacheBanner = nil
+      cacheBannerTimer?.invalidate()
+      contentTopInset = vc.additionalSafeAreaInsets.top
+    #endif
     window?.rootViewController = vc
+    #if targetEnvironment(macCatalyst)
+      updateCacheBanner()
+      cacheBannerTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] _ in
+        Task { @MainActor in self?.updateCacheBanner() }
+      }
+    #endif
   }
+
+  #if targetEnvironment(macCatalyst)
+    private func updateCacheBanner() {
+      guard let window, let vc = window.rootViewController,
+            vc.viewIfLoaded?.window === window else { return }
+      guard case .blocked = CacheRootRuntime.shared.state else {
+        cacheBanner?.removeFromSuperview()
+        cacheBanner = nil
+        vc.additionalSafeAreaInsets.top = contentTopInset
+        return
+      }
+      if let cacheBanner {
+        window.bringSubviewToFront(cacheBanner)
+        return
+      }
+      let label = UILabel()
+      label.text = "Cache drive unavailable. Downloads are waiting."
+      label.font = .preferredFont(forTextStyle: .footnote)
+      label.textColor = .label
+      label.isAccessibilityElement = true
+      label.setContentCompressionResistancePriority(.required, for: .horizontal)
+      let button = UIButton(type: .system)
+      button.setTitle("Storage…", for: .normal)
+      button.addTarget(self, action: #selector(showCacheLocation), for: .touchUpInside)
+      let banner = UIView()
+      banner.backgroundColor = .secondarySystemBackground
+      banner.translatesAutoresizingMaskIntoConstraints = false
+      label.translatesAutoresizingMaskIntoConstraints = false
+      button.translatesAutoresizingMaskIntoConstraints = false
+      banner.addSubview(label)
+      banner.addSubview(button)
+      vc.additionalSafeAreaInsets.top = contentTopInset + 44
+      // UISplitViewController owns and lays out its direct subviews. Keep this
+      // scene-wide notice in the window, outside that managed hierarchy.
+      window.addSubview(banner)
+      NSLayoutConstraint.activate([
+        banner.topAnchor.constraint(equalTo: vc.view.safeAreaLayoutGuide.topAnchor, constant: -44),
+        banner.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+        banner.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+        banner.heightAnchor.constraint(equalToConstant: 44),
+        label.leadingAnchor.constraint(equalTo: banner.leadingAnchor, constant: 16),
+        label.centerYAnchor.constraint(equalTo: banner.centerYAnchor),
+        label.trailingAnchor.constraint(lessThanOrEqualTo: button.leadingAnchor, constant: -16),
+        button.trailingAnchor.constraint(equalTo: banner.trailingAnchor, constant: -16),
+        button.centerYAnchor.constraint(equalTo: banner.centerYAnchor),
+      ])
+      cacheBanner = banner
+    }
+
+    @objc
+    private func showCacheLocation() {
+      let sheet = UIHostingController(rootView: CacheLocationSheet())
+      sheet.modalPresentationStyle = .formSheet
+      window?.rootViewController?.present(sheet, animated: true)
+    }
+  #endif
 
   /** Called when the user activates your application by selecting a shortcut on the Home Screen,
        and the window scene is already connected.
@@ -161,6 +235,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Called when the scene has moved from an inactive state to an active state.
     // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     os_log("sceneDidBecomeActive", log: self.log, type: .info)
+    #if targetEnvironment(macCatalyst)
+      updateCacheBanner()
+    #endif
     guard appDelegate.isNormalInteraction else {
       return
     }

--- a/Amperfy/Screens/ViewController/LoginVC.swift
+++ b/Amperfy/Screens/ViewController/LoginVC.swift
@@ -180,6 +180,34 @@ class LoginVC: UIViewController {
     return button
   }()
 
+  #if targetEnvironment(macCatalyst)
+    fileprivate lazy var cacheLocationButton: UIButton = {
+      var config = UIButton.Configuration.glass()
+      config.image = .folder
+      config.imagePadding = 8.0
+      let button = UIButton(configuration: config)
+      button.setTitle("Cache Location…", for: .normal)
+      button.accessibilityIdentifier = CacheLocationAccessibility.preLoginEntry
+      button.accessibilityLabel = "Cache Location"
+      button.accessibilityHint = "Opens the application-wide cache location settings"
+      button.addTarget(
+        self,
+        action: #selector(Self.cacheLocationPressed),
+        for: .touchUpInside
+      )
+      button.preferredBehavioralStyle = .pad
+      return button
+    }()
+
+    @IBAction
+    func cacheLocationPressed() {
+      let hostingController = UIHostingController(rootView: CacheLocationSheet())
+      hostingController.modalPresentationStyle = .formSheet
+      hostingController.preferredContentSize = CGSize(width: 620, height: 480)
+      present(hostingController, animated: true)
+    }
+  #endif
+
   fileprivate lazy var httpHeadersButton: UIButton = {
     var config = UIButton.Configuration.glass()
     let button = UIButton(configuration: config)
@@ -517,11 +545,17 @@ class LoginVC: UIViewController {
     formGlassContainer.translatesAutoresizingMaskIntoConstraints = false
     loginGlassContainer.translatesAutoresizingMaskIntoConstraints = false
     closeButton.translatesAutoresizingMaskIntoConstraints = false
+    #if targetEnvironment(macCatalyst)
+      cacheLocationButton.translatesAutoresizingMaskIntoConstraints = false
+    #endif
     view.addSubview(amperfyLabel)
     view.addSubview(iconView)
     view.addSubview(formGlassContainer)
     view.addSubview(loginGlassContainer)
     view.addSubview(closeButton)
+    #if targetEnvironment(macCatalyst)
+      view.addSubview(cacheLocationButton)
+    #endif
 
     formLeadingConstraing = formGlassContainer.leadingAnchor.constraint(
       equalTo: view.leadingAnchor,
@@ -575,6 +609,18 @@ class LoginVC: UIViewController {
         constant: -16
       ),
     ])
+
+    #if targetEnvironment(macCatalyst)
+      NSLayoutConstraint.activate([
+        cacheLocationButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        cacheLocationButton.topAnchor.constraint(
+          equalTo: loginGlassContainer.bottomAnchor,
+          constant: 12
+        ),
+        cacheLocationButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 180),
+        cacheLocationButton.heightAnchor.constraint(equalToConstant: 40),
+      ])
+    #endif
 
     // Show close button only when presented as a sheet/modal
     let isModal = presentingViewController != nil || navigationController?

--- a/Amperfy/SwiftUI/Settings/Artwork/ArtworkSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/Artwork/ArtworkSettingsView.swift
@@ -122,6 +122,7 @@ struct ArtworkSettingsView: View {
                   "This action will delete downloaded artworks. Artworks embedded in song/podcast episode files will be kept. Continue?"
                 ),
                 primaryButton: .destructive(Text("Delete")) {
+                  guard CacheRootRuntime.shared.isCacheAvailable else { return }
                   let account = appDelegate.storage.main.library
                     .getAccount(info: activeAccountInfo)
                   appDelegate.getMeta(activeAccountInfo).artworkDownloadManager.stop()

--- a/Amperfy/SwiftUI/Settings/CacheLocationSettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/CacheLocationSettingsView.swift
@@ -1,0 +1,353 @@
+//
+//  CacheLocationSettingsView.swift
+//  Amperfy
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+#if targetEnvironment(macCatalyst)
+  import AmperfyKit
+  import SwiftUI
+  import UIKit
+  import UniformTypeIdentifiers
+
+  enum CacheLocationAccessibility {
+    static let preLoginEntry = "amperfy.login.cache-location"
+    static let sheet = "amperfy.cache-location.sheet"
+    static let chooseFolder = "amperfy.cache-location.choose-folder"
+    static let pendingSelection = "amperfy.cache-location.pending-selection"
+    static let confirmSelection = "amperfy.cache-location.confirm-selection"
+    static let status = "amperfy.cache-location.status"
+    static let close = "amperfy.cache-location.close"
+    static let picker = "amperfy.cache-location.folder-picker"
+  }
+
+  // MARK: - CacheFolderPicker
+
+  /// UIKit is the only v1 folder-picker implementation. An AppKit bridge is intentionally absent.
+  struct CacheFolderPicker: UIViewControllerRepresentable {
+    let didSelect: (URL) -> ()
+    let didCancel: () -> ()
+
+    func makeCoordinator() -> Coordinator {
+      Coordinator(didSelect: didSelect, didCancel: didCancel)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+      let picker = UIDocumentPickerViewController(
+        forOpeningContentTypes: [.folder],
+        asCopy: false
+      )
+      picker.allowsMultipleSelection = false
+      picker.delegate = context.coordinator
+      picker.view.accessibilityIdentifier = CacheLocationAccessibility.picker
+      picker.view.accessibilityLabel = "Choose a folder for downloaded files"
+      return picker
+    }
+
+    func updateUIViewController(
+      _ uiViewController: UIDocumentPickerViewController,
+      context: Context
+    ) {}
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+      private let didSelect: (URL) -> ()
+      private let didCancel: () -> ()
+
+      init(didSelect: @escaping (URL) -> (), didCancel: @escaping () -> ()) {
+        self.didSelect = didSelect
+        self.didCancel = didCancel
+      }
+
+      func documentPicker(
+        _ controller: UIDocumentPickerViewController,
+        didPickDocumentsAt urls: [URL]
+      ) {
+        guard let url = urls.first else { return didCancel() }
+        didSelect(url)
+      }
+
+      func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        didCancel()
+      }
+    }
+  }
+
+  // MARK: - CacheLocationSettingsView
+
+  struct CacheLocationSettingsView: View {
+    var onWorkingChanged: (Bool) -> () = { _ in }
+    @State
+    private var prepared: PreparedExternalCacheSelection?
+    @State
+    private var choosingFolder = false
+    @State
+    private var reconnecting = false
+    @State
+    private var confirmingMove = false
+    @State
+    private var bytesToMove: Int64 = 0
+    @State
+    private var isWorking = false
+    @State
+    private var moveTask: Task<(), Never>?
+    @State
+    private var progress = CacheMoveProgress(message: "")
+    @State
+    private var errorMessage: String?
+    @State
+    private var location = "On This Mac"
+    @State
+    private var locationPath = ""
+    @State
+    private var availableSpace = ""
+    @State
+    private var usedSpace = ""
+    @State
+    private var isExternal = false
+    @State
+    private var isAvailable = false
+    @State
+    private var unfinishedMove = false
+    private let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+      SettingsList {
+        SettingsSection(
+          content: {
+            SettingsRow(title: "Location") { SecondaryText(location) }
+              .accessibilityIdentifier(CacheLocationAccessibility.status)
+            if !locationPath.isEmpty {
+              SettingsRow(title: "Folder") { SecondaryText(locationPath) }
+            }
+            SettingsRow(title: "Status") {
+              SecondaryText(
+                isWorking ? "Moving files" :
+                  (isAvailable ? "Available" : "Drive unavailable")
+              )
+            }
+            if isAvailable {
+              SettingsRow(title: "Downloaded Audio") { SecondaryText(usedSpace) }
+              SettingsRow(title: "Available Space") { SecondaryText(availableSpace) }
+            }
+          },
+          footer: "Songs, podcasts, artwork, and lyrics use this location for all accounts. Your account settings and library database stay on this Mac."
+        )
+
+        if isWorking {
+          SettingsSection {
+            Text(progress.message)
+            if progress.totalBytes > 0 {
+              ProgressView(
+                value: Double(progress.completedBytes),
+                total: Double(progress.totalBytes)
+              )
+              SecondaryText(
+                "\(progress.completedBytes.asByteString) of \(progress.totalBytes.asByteString)"
+              )
+            } else {
+              ProgressView()
+            }
+            Button("Cancel Move", role: .cancel) { moveTask?.cancel() }
+              .disabled(
+                progress.message == "Switching cache location…" || progress
+                  .message == "Removing the previous copy…"
+              )
+          }
+        } else if unfinishedMove {
+          SettingsSection(
+            content: {
+              Button("Finish Previous Move") { finishPreviousMove() }
+            },
+            footer: "A previous move was interrupted. Reconnect both drives to finish cleanup. The location shown above remains active."
+          )
+        } else if isAvailable {
+          SettingsSection {
+            Button("Change…") {
+              reconnecting = false
+              choosingFolder = true
+            }
+            .accessibilityIdentifier(CacheLocationAccessibility.chooseFolder)
+            if isExternal {
+              Button("Use Built-in Storage…") {
+                prepared?.cancel()
+                prepared = nil
+                Task {
+                  do {
+                    bytesToMove = try await Task
+                      .detached { try CacheRootRuntime.shared.cacheInventorySize() }.value
+                    confirmingMove = true
+                  } catch { errorMessage = cacheErrorMessage(error) }
+                }
+              }
+            }
+          }
+        } else {
+          SettingsSection(
+            content: {
+              Button("Retry") {
+                Task {
+                  await Task.detached { CacheRootRuntime.shared.refreshAvailability() }.value
+                  await refresh()
+                }
+              }
+              Button("Locate Cache Folder…") {
+                reconnecting = true
+                choosingFolder = true
+              }
+            },
+            footer: "Reconnect the drive to use downloaded music, or select the folder you originally chose. You can continue browsing and stream music in online mode. Downloads will wait; they will not use built-in storage instead."
+          )
+        }
+      }
+      .navigationTitle("Cache Location")
+      .navigationBarTitleDisplayMode(.inline)
+      .accessibilityIdentifier(CacheLocationAccessibility.sheet)
+      .interactiveDismissDisabled(isWorking)
+      .navigationBarBackButtonHidden(isWorking)
+      .onChange(of: isWorking) { _, working in onWorkingChanged(working) }
+      .task { await refresh() }
+      .onReceive(timer) { _ in Task { await refresh() } }
+      .sheet(isPresented: $choosingFolder) {
+        CacheFolderPicker(didSelect: { url in
+          choosingFolder = false
+          Task {
+            do {
+              if reconnecting {
+                try await Task.detached {
+                  try CacheRootRuntime.shared.reselectConfiguredExternal(selectedParentURL: url)
+                }.value
+                await refresh()
+              } else {
+                let selection = try await Task.detached {
+                  try CacheRootRuntime.shared.prepareExternal(selectedParentURL: url)
+                }.value
+                prepared?.cancel()
+                prepared = selection
+                bytesToMove = try await Task
+                  .detached { try CacheRootRuntime.shared.cacheInventorySize() }.value
+                try CacheCapacityPolicy().validate(
+                  available: selection.availableCapacity,
+                  inventoryBytes: bytesToMove
+                )
+                confirmingMove = true
+              }
+            } catch { errorMessage = cacheErrorMessage(error) }
+          }
+        }, didCancel: { choosingFolder = false })
+      }
+      .alert("Move Downloaded Files?", isPresented: $confirmingMove) {
+        Button("Cancel", role: .cancel) { prepared?.cancel(); prepared = nil }
+        Button("Move") { startMove() }
+          .accessibilityIdentifier(CacheLocationAccessibility.confirmSelection)
+      } message: {
+        Text(
+          "Move \(bytesToMove.asByteString) of downloaded files for all accounts to \(prepared?.parentURL.lastPathComponent ?? "built-in storage")? Playback and downloads pause during the move. Amperfy verifies the new copy before removing the old one."
+        )
+      }
+      .alert("Cache Location", isPresented: Binding(
+        get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }
+      )) {
+        Button("OK", role: .cancel) { errorMessage = nil }
+      } message: { Text(errorMessage ?? "") }
+    }
+
+    private func refresh() async {
+      let runtime = CacheRootRuntime.shared
+      let preference = try? runtime.configuredPreference()
+      isExternal = preference?.mode == .external
+      isAvailable = runtime.isCacheAvailable
+      location = isExternal ? (preference?.displayName ?? "External Drive") : "On This Mac"
+      if case let .ready(_, root) = runtime.state { locationPath = root.path }
+      else { locationPath = "" }
+      unfinishedMove = runtime.hasUnfinishedMove
+      usedSpace = runtime.fileManager.completePlayableCacheSize.asByteString
+      let capacity = await Task.detached { try? runtime.availableCapacity() }.value
+      availableSpace = capacity?.asByteString ?? "Unavailable"
+    }
+
+    private func startMove() {
+      let selection = prepared
+      prepared = nil
+      isWorking = true
+      progress = CacheMoveProgress(message: "Preparing to move…")
+      moveTask = Task {
+        if AmperKit.shared.settings.accounts.active != nil { AmperKit.shared.player.pause() }
+        await AmperKit.shared.pauseDownloadsForCacheMove()
+        let worker = Task.detached {
+          try CacheRootRuntime.shared.relocateCache(to: selection, progress: { update in
+            Task { @MainActor in progress = update }
+          }, checkCancellation: { try Task.checkCancellation() })
+        }
+        do {
+          try await withTaskCancellationHandler(
+            operation: { try await worker.value },
+            onCancel: { worker.cancel() }
+          )
+        } catch is CancellationError {
+          errorMessage = "The move was canceled. Your previous cache location remains active."
+        } catch { errorMessage = cacheErrorMessage(error) }
+        await AmperKit.shared.resumeDownloadsAfterCacheMove()
+        isWorking = false
+        moveTask = nil
+        await refresh()
+      }
+    }
+
+    private func finishPreviousMove() {
+      isWorking = true
+      progress = CacheMoveProgress(message: "Finishing the previous move…")
+      Task {
+        do { try await Task.detached { try CacheRootRuntime.shared.finishInterruptedMove() }.value }
+        catch { errorMessage = cacheErrorMessage(error) }
+        isWorking = false
+        await refresh()
+      }
+    }
+
+    private func cacheErrorMessage(_ error: Error) -> String {
+      switch error {
+      case let CacheRootError.insufficientCapacity(required, available):
+        return "This location needs \(required.asByteString) free, including working space. It has \(available.asByteString) available. Choose a drive with more space."
+      case CacheRootError.markerMismatch:
+        return "This folder does not contain the expected cache, or already contains another cache. Select the original cache folder to reconnect, or an empty folder for a new location."
+      case CacheRootError.invalidPreparedSelection:
+        return "Choose a different folder outside the current cache."
+      case CacheRootError.migrationRequired:
+        return "The destination already contains downloaded files. Choose an empty folder."
+      default:
+        return "Amperfy could not finish this operation. Check that the drive is connected and the folder is writable, then retry. The active location is shown in settings."
+      }
+    }
+  }
+
+  // MARK: - CacheLocationSheet
+
+  struct CacheLocationSheet: View {
+    @Environment(\.dismiss)
+    private var dismiss
+    @State
+    private var isWorking = false
+
+    var body: some View {
+      NavigationStack {
+        CacheLocationSettingsView(onWorkingChanged: { isWorking = $0 })
+          .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+              Button("Done") { dismiss() }
+                .disabled(isWorking)
+                .accessibilityIdentifier(CacheLocationAccessibility.close)
+                .accessibilityLabel("Close Cache Location")
+            }
+          }
+      }
+      .accessibilityIdentifier(CacheLocationAccessibility.sheet)
+    }
+  }
+
+#endif

--- a/Amperfy/SwiftUI/Settings/LibrarySettingsView.swift
+++ b/Amperfy/SwiftUI/Settings/LibrarySettingsView.swift
@@ -124,8 +124,7 @@ struct LibrarySettingsView: View {
       completeCacheSize = try await appDelegate.storage.async.performAndGet { asyncCompanion in
         let accountAsync = asyncCompanion.library.getAccount(managedObjectId: accountObjectId)
         let playableByteSize = fileManager.getPlayableCacheSize(for: accountAsync.info)
-        return (playableByteSize > 1_000_000) ? playableByteSize.asByteString : Int64(0)
-          .asByteString
+        return playableByteSize.asByteString
       }
 
       let curCacheSizeLimit = Int64(settings.cacheSizeLimit)
@@ -188,6 +187,16 @@ struct LibrarySettingsView: View {
             }
           }
 
+          #if targetEnvironment(macCatalyst)
+            NavigationLink(destination: CacheLocationSettingsView()) {
+              SettingsRow(title: "Cache Location") {
+                SecondaryText(
+                  CacheRootRuntime.shared
+                    .isCacheAvailable ? "Manage Storage" : "Drive Unavailable"
+                )
+              }
+            }
+          #endif
           SettingsRow(title: "Cached Songs") { SecondaryText(cachedSongCount.description) }
           SettingsRow(title: "Cached Podcast Episodes") {
             SecondaryText(cachedPodcastEpisodesCount.description)
@@ -253,6 +262,7 @@ struct LibrarySettingsView: View {
                   "Are you sure you want to delete this account’s downloaded songs and podcast episodes?"
                 ),
                 primaryButton: .destructive(Text("Delete")) {
+                  guard CacheRootRuntime.shared.isCacheAvailable else { return }
                   appDelegate.player.stop()
                   let account = appDelegate.storage.main.library
                     .getAccount(info: activeAccountInfo)

--- a/AmperfyKit/AmperfyKit.swift
+++ b/AmperfyKit/AmperfyKit.swift
@@ -72,6 +72,20 @@ public class AmperKit {
     metaManager
   }
 
+  public func pauseDownloadsForCacheMove() async {
+    for meta in Array(metaManager.values) {
+      await meta.playableDownloadManager.pauseForCacheMove()
+      await meta.artworkDownloadManager.pauseForCacheMove()
+    }
+  }
+
+  public func resumeDownloadsAfterCacheMove() async {
+    for meta in Array(metaManager.values) {
+      await meta.playableDownloadManager.resumeAfterCacheMove()
+      await meta.artworkDownloadManager.resumeAfterCacheMove()
+    }
+  }
+
   public func resetMeta(_ accountInfo: AccountInfo) {
     metaManager[accountInfo] = nil
   }

--- a/AmperfyKit/Api/Ampache/AmpacheArtworkDownloadDelegate.swift
+++ b/AmperfyKit/Api/Ampache/AmpacheArtworkDownloadDelegate.swift
@@ -100,29 +100,38 @@ final class AmpacheArtworkDownloadDelegate: DownloadManagerDelegate {
       return artwork.remoteInfo
     }
     guard let artworkRemoteInfo else { return }
-
-    let relFilePath = handleCustomImage(fileURL: fileURL, artworkRemoteInfo: artworkRemoteInfo)
-    try? await storage.perform { asyncCompanion in
-      let artwork = Artwork(
-        managedObject: asyncCompanion.context
-          .object(with: downloadInfo.objectId) as! ArtworkMO
-      )
-      artwork.status = .CustomImage
-      artwork.relFilePath = relFilePath
-      asyncCompanion.saveContext()
-    }
-  }
-
-  func handleCustomImage(fileURL: URL, artworkRemoteInfo: ArtworkRemoteInfo) -> URL? {
     guard let account = ampacheXmlServerApi.account,
-          let relFilePath = fileManager.createRelPath(for: artworkRemoteInfo, account: account),
-          let absFilePath = fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath)
-    else { return nil }
+          let rootLease = try? fileManager.currentRootLease()
+    else { return }
     do {
-      try fileManager.moveExcludedFromBackupItem(at: fileURL, to: absFilePath, accountInfo: account)
-      return relFilePath
+      let preparedCommit = try await storage.performWithCommitValidation { asyncCompanion in
+        let artwork = Artwork(
+          managedObject: asyncCompanion.context
+            .object(with: downloadInfo.objectId) as! ArtworkMO
+        )
+        guard let relFilePath = self.fileManager.createRelPath(
+          for: artworkRemoteInfo,
+          account: account
+        ) else { throw CacheRootError.unavailable }
+        let absolutePath = try self.fileManager.getAbsoluteAmperfyPath(
+          relFilePath: relFilePath,
+          using: rootLease
+        )
+        let transaction = try self.fileManager.prepareRecoverableFileCommit(
+          sourceURL: fileURL,
+          destinationURL: absolutePath,
+          accountInfo: account,
+          using: rootLease
+        )
+        artwork.status = .CustomImage
+        artwork.relFilePath = relFilePath
+        return transaction
+      } validateBeforeSave: {
+        try rootLease.validateCurrent()
+      }
+      try preparedCommit.finishAfterCoreDataCommit()
     } catch {
-      return nil
+      return
     }
   }
 

--- a/AmperfyKit/Api/CommonLibrarySyncer.swift
+++ b/AmperfyKit/Api/CommonLibrarySyncer.swift
@@ -57,19 +57,21 @@ class CommonLibrarySyncer {
 
   func createCachedItemRepresentationsInCoreData(statusNotifyier: SyncCallbacks?) async throws {
     let accountInfo = account.info
-    try await storage.async.perform { asyncCompanion in
-      let cachedArtworks = self.fileManager.getCachedArtworks(for: accountInfo)
-      let cachedEmbeddedArtworks = self.fileManager.getCachedEmbeddedArtworks(for: accountInfo)
-      let cachedLyrics = self.fileManager.getCachedLyrics(for: accountInfo)
-      let cachedSongs = self.fileManager.getCachedSongs(for: accountInfo)
-      let cachedEpisodes = self.fileManager.getCachedEpisodes(for: accountInfo)
+    let rootLease = try fileManager.currentRootLease()
+    let snapshot = try fileManager.accountCacheSnapshot(for: accountInfo, using: rootLease)
+    try await storage.async.performWithCommitValidation { asyncCompanion in
+      let cachedArtworks = snapshot.artworks
+      let cachedEmbeddedArtworks = snapshot.embeddedArtworks
+      let cachedLyrics = snapshot.lyrics
+      let cachedSongs = snapshot.songs
+      let cachedEpisodes = snapshot.episodes
 
       let accountAsync = asyncCompanion.library.getAccount(managedObjectId: self.accountObjectId)
       let totalCount = cachedArtworks.count + cachedEmbeddedArtworks.count + cachedLyrics
         .count + cachedSongs.count + cachedEpisodes.count
       guard totalCount > 0 else {
         // nothing to do
-        return
+        return ()
       }
       statusNotifyier?.notifySyncStarted(ofType: .cache, totalCount: totalCount)
       for cachedArtwork in cachedArtworks {
@@ -137,6 +139,9 @@ class CommonLibrarySyncer {
         }
         statusNotifyier?.notifyParsedObject(ofType: .cache)
       }
+      return ()
+    } validateBeforeSave: {
+      try rootLease.validateCurrent()
     }
   }
 }

--- a/AmperfyKit/Api/Subsonic/SubsonicArtworkDownloadDelegate.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicArtworkDownloadDelegate.swift
@@ -101,27 +101,38 @@ final class SubsonicArtworkDownloadDelegate: DownloadManagerDelegate {
       return artwork.remoteInfo
     }
     guard let artworkRemoteInfo else { return }
-    let relFilePath = handleCustomImage(fileURL: fileURL, artworkRemoteInfo: artworkRemoteInfo)
-    try? await storage.perform { asyncCompanion in
-      let artwork = Artwork(
-        managedObject: asyncCompanion.context
-          .object(with: downloadInfo.objectId) as! ArtworkMO
-      )
-      artwork.status = .CustomImage
-      artwork.relFilePath = relFilePath
-    }
-  }
-
-  func handleCustomImage(fileURL: URL, artworkRemoteInfo: ArtworkRemoteInfo) -> URL? {
     guard let account = subsonicServerApi.account,
-          let relFilePath = fileManager.createRelPath(for: artworkRemoteInfo, account: account),
-          let absFilePath = fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath)
-    else { return nil }
+          let rootLease = try? fileManager.currentRootLease()
+    else { return }
     do {
-      try fileManager.moveExcludedFromBackupItem(at: fileURL, to: absFilePath, accountInfo: account)
-      return relFilePath
+      let preparedCommit = try await storage.performWithCommitValidation { asyncCompanion in
+        let artwork = Artwork(
+          managedObject: asyncCompanion.context
+            .object(with: downloadInfo.objectId) as! ArtworkMO
+        )
+        guard let relFilePath = self.fileManager.createRelPath(
+          for: artworkRemoteInfo,
+          account: account
+        ) else { throw CacheRootError.unavailable }
+        let absolutePath = try self.fileManager.getAbsoluteAmperfyPath(
+          relFilePath: relFilePath,
+          using: rootLease
+        )
+        let transaction = try self.fileManager.prepareRecoverableFileCommit(
+          sourceURL: fileURL,
+          destinationURL: absolutePath,
+          accountInfo: account,
+          using: rootLease
+        )
+        artwork.status = .CustomImage
+        artwork.relFilePath = relFilePath
+        return transaction
+      } validateBeforeSave: {
+        try rootLease.validateCurrent()
+      }
+      try preparedCommit.finishAfterCoreDataCommit()
     } catch {
-      return nil
+      return
     }
   }
 

--- a/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
+++ b/AmperfyKit/Api/Subsonic/SubsonicLibrarySyncer.swift
@@ -1297,11 +1297,14 @@ class SubsonicLibrarySyncer: CommonLibrarySyncer, LibrarySyncer {
   @MainActor
   func parseLyrics(relFilePath: URL) async throws -> LyricsList {
     let parserDelegate = SsLyricsParserDelegate(performanceMonitor: performanceMonitor)
-    guard let absFilePath = fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath) else {
-      throw ResponseError(type: .xml)
-    }
     do {
-      try parse(absFilePath: absFilePath, delegate: parserDelegate, isThrowingErrorsAllowed: false)
+      try fileManager.withCacheFile(relativePath: relFilePath) { absFilePath in
+        try parse(
+          absFilePath: absFilePath,
+          delegate: parserDelegate,
+          isThrowingErrorsAllowed: false
+        )
+      }
     } catch {
       throw ResponseError(type: .xml)
     }

--- a/AmperfyKit/Common/ShareSongAction.swift
+++ b/AmperfyKit/Common/ShareSongAction.swift
@@ -95,8 +95,8 @@ public enum ShareSongAction {
 
   private static func cachedFileURL(for playable: AbstractPlayable) -> URL? {
     guard let relPath = playable.relFilePath,
-          let absoluteURL = CacheFileManager.shared.getAbsoluteAmperfyPath(relFilePath: relPath),
-          FileManager.default.fileExists(atPath: absoluteURL.path)
+          CacheFileManager.shared.fileExits(relFilePath: relPath),
+          let absoluteURL = CacheFileManager.shared.getAbsoluteAmperfyPath(relFilePath: relPath)
     else { return nil }
     return absoluteURL
   }
@@ -119,8 +119,12 @@ public enum ShareSongAction {
       .appendingPathComponent(safeFileName)
       .appendingPathExtension(fileURL.pathExtension)
     try? FileManager.default.removeItem(at: tempURL)
-    try? FileManager.default.copyItem(at: fileURL, to: tempURL)
-    let shareURL = FileManager.default.fileExists(atPath: tempURL.path) ? tempURL : fileURL
+    do {
+      try CacheFileManager.shared.copyCacheItem(at: fileURL, to: tempURL)
+    } catch {
+      return
+    }
+    let shareURL = tempURL
 
     let artwork = artworkImage(for: playable)
     let fileItemSource = SongShareItemSource(

--- a/AmperfyKit/Download/DownloadManager.swift
+++ b/AmperfyKit/Download/DownloadManager.swift
@@ -94,6 +94,7 @@ actor DownloadManager: NSObject, DownloadManageable {
   private let urlCleanser: URLCleanser
 
   private var isRunning = false
+  private var isPausedForCacheMove = false
   private var taskOperations = [DownloadRequest: DownloadOperation]()
   private var backgroundFetchCompletionHandler: CompleteHandlerBlock?
   private var isFailWithPopupError: Bool = true
@@ -152,6 +153,12 @@ actor DownloadManager: NSObject, DownloadManageable {
       self,
       selector: #selector(networkStatusChanged(notification:)),
       name: .networkStatusChanged,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(networkStatusChanged(notification:)),
+      name: CacheRootRuntime.didChangeNotification,
       object: nil
     )
     Task {
@@ -297,6 +304,26 @@ actor DownloadManager: NSObject, DownloadManageable {
     for task in urlSessionTasks {
       task.cancel()
     }
+  }
+
+  @MainActor
+  func pauseForCacheMove() async {
+    await setCacheMovePaused(true)
+  }
+
+  @MainActor
+  func resumeAfterCacheMove() async {
+    await setCacheMovePaused(false)
+  }
+
+  private func setCacheMovePaused(_ paused: Bool) async {
+    if !paused {
+      isPausedForCacheMove = false
+      await setupDownloadQueue()
+      return
+    }
+    isPausedForCacheMove = true
+    await _suspendDownloads()
   }
 
   nonisolated func suspendDownloads() {
@@ -533,7 +560,8 @@ actor DownloadManager: NSObject, DownloadManageable {
   }
 
   private var isAllowedToTriggerDownload: Bool {
-    isRunning &&
+    isRunning && !isPausedForCacheMove &&
+      CacheRootRuntime.shared.isCacheAvailable &&
       settings.user.isOnlineMode &&
       networkMonitor.isConnectedToNetwork &&
       (!isCacheSizeLimited || !storageExceedsCacheLimit())

--- a/AmperfyKit/Download/DownloadManagerSessionExtension.swift
+++ b/AmperfyKit/Download/DownloadManagerSessionExtension.swift
@@ -115,9 +115,11 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
   nonisolated func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
     os_log("URLSession urlSessionDidFinishEvents", log: self.log, type: .info)
     Task { @MainActor in
-      guard let completionHandler = await getBackgroundFetchCompletionHandler() else { return }
+      guard let completionHandler = await getBackgroundFetchCompletionHandler(),
+            let rootLease = try? fileManager.currentRootLease()
+      else { return }
       os_log("Calling application backgroundFetchCompletionHandler", log: self.log, type: .info)
-      completionHandler()
+      try? rootLease.performAtCommitBoundary { completionHandler() }
       setBackgroundFetchCompletionHandler(nil)
     }
   }

--- a/AmperfyKit/Download/DownloadProtocols.swift
+++ b/AmperfyKit/Download/DownloadProtocols.swift
@@ -53,6 +53,15 @@ public protocol DownloadManageable {
   func cancelDownloads()
   func start()
   func stop()
+  @MainActor
+  func pauseForCacheMove() async
+  @MainActor
+  func resumeAfterCacheMove() async
+}
+
+extension DownloadManageable {
+  public func pauseForCacheMove() async { stop() }
+  public func resumeAfterCacheMove() async { start() }
 }
 
 // MARK: - DownloadManagerDelegate

--- a/AmperfyKit/Download/PlayableDownloadDelegate.swift
+++ b/AmperfyKit/Download/PlayableDownloadDelegate.swift
@@ -29,16 +29,21 @@ final class PlayableDownloadDelegate: DownloadManagerDelegate {
   private let backendApi: BackendApi
   private let artworkExtractor: EmbeddedArtworkExtractor
   private let networkMonitor: NetworkMonitorFacade
-  private let fileManager = CacheFileManager.shared
+  private let fileManager: CacheFileManager
+  private let afterFilesystemCommitBeforeCoreDataSave: @Sendable () throws -> ()
 
   init(
     backendApi: BackendApi,
     artworkExtractor: EmbeddedArtworkExtractor,
-    networkMonitor: NetworkMonitorFacade
+    networkMonitor: NetworkMonitorFacade,
+    fileManager: CacheFileManager = .shared,
+    afterFilesystemCommitBeforeCoreDataSave: @escaping @Sendable () throws -> () = {}
   ) {
     self.backendApi = backendApi
     self.artworkExtractor = artworkExtractor
     self.networkMonitor = networkMonitor
+    self.fileManager = fileManager
+    self.afterFilesystemCommitBeforeCoreDataSave = afterFilesystemCommitBeforeCoreDataSave
   }
 
   var requestPredicate: NSPredicate {
@@ -132,29 +137,35 @@ final class PlayableDownloadDelegate: DownloadManagerDelegate {
     fileMimeType: String?,
     storage: AsyncCoreDataAccessWrapper
   ) async throws {
-    try await storage.perform { asyncCompanion in
+    let rootLease = try fileManager.currentRootLease()
+    let preparedCommit = try await storage.performWithCommitValidation { asyncCompanion in
       let playableAsync = AbstractPlayable(
         managedObject: asyncCompanion.context
           .object(with: playableInfo.objectID) as! AbstractPlayableMO
       )
       playableAsync.contentTypeTranscoded = fileMimeType
       // transcoding info needs to available to generate a correct file extension
-      guard let relFilePath = CacheFileManager.shared.createRelPath(for: playableAsync),
-            let absFilePath = CacheFileManager.shared
-            .getAbsoluteAmperfyPath(relFilePath: relFilePath),
+      guard let relFilePath = self.fileManager.createRelPath(for: playableAsync),
             let accountInfo = playableAsync.account?.info
-      else { return }
-      do {
-        try CacheFileManager.shared.moveExcludedFromBackupItem(
-          at: fileURL,
-          to: absFilePath,
-          accountInfo: accountInfo
-        )
-        playableAsync.relFilePath = relFilePath
-      } catch {
-        playableAsync.relFilePath = nil
-      }
+      else { throw CacheRootError.unavailable }
+      let absFilePath = try self.fileManager.getAbsoluteAmperfyPath(
+        relFilePath: relFilePath,
+        using: rootLease
+      )
+      let transaction = try self.fileManager.prepareRecoverableFileCommit(
+        sourceURL: fileURL,
+        destinationURL: absFilePath,
+        accountInfo: accountInfo,
+        using: rootLease
+      )
+      try self.afterFilesystemCommitBeforeCoreDataSave()
+      try rootLease.validateCurrent()
+      playableAsync.relFilePath = relFilePath
+      return transaction
+    } validateBeforeSave: {
+      try rootLease.validateCurrent()
     }
+    try preparedCommit.finishAfterCoreDataCommit()
   }
 
   func failedDownload(downloadInfo: DownloadElementInfo, storage: AsyncCoreDataAccessWrapper) {}

--- a/AmperfyKit/Player/BackendAudioPlayer.swift
+++ b/AmperfyKit/Player/BackendAudioPlayer.swift
@@ -75,7 +75,6 @@ enum BackendAudioQueueType {
 @MainActor
 class BackendAudioPlayer: NSObject {
   private let getPlayableDownloaderCB: GetPlayableDownloadManagerCallback
-  private let cacheProxy: PlayableFileCachable
   private let getBackendApiCB: GetBackendApiCallback
   private let userStatistics: UserStatistics
   private let createAudioStreamingPlayerCB: CreateAudioStreamingPlayerCallback
@@ -210,7 +209,7 @@ class BackendAudioPlayer: NSObject {
     self.networkMonitor = networkMonitor
     self.eventLogger = eventLogger
     self.getPlayableDownloaderCB = getPlayableDownloaderCB
-    self.cacheProxy = cacheProxy
+    _ = cacheProxy // retained only for source-compatible player tests
     self.userStatistics = userStatistics
     self.audioAnalyzer = AudioAnalyzer()
 
@@ -257,7 +256,7 @@ class BackendAudioPlayer: NSObject {
         nextPreloadedPlayable = nextPlayablePreloadCB?()
         guard let nextPreloadedPlayable = nextPreloadedPlayable else { return }
         os_log(.default, "Preloading: %s", nextPreloadedPlayable.displayString)
-        if nextPreloadedPlayable.isCached {
+        if let path = nextPreloadedPlayable.relFilePath, fileManager.fileExits(relFilePath: path) {
           insertCachedPlayable(playable: nextPreloadedPlayable, queueType: .queue)
         } else if !isOfflineMode {
           Task { @MainActor in
@@ -528,19 +527,19 @@ class BackendAudioPlayer: NSObject {
     playable: AbstractPlayable,
     queueType: BackendAudioQueueType = .play
   ) {
-    guard let fileURL = cacheProxy.getFileURL(forPlayable: playable) else {
-      return
+    guard let relativePath = playable.relFilePath else { return }
+    try? fileManager.withCacheFile(relativePath: relativePath) { fileURL in
+      if queueType == .play {
+        playType = .cache
+        perloadedPlayType = nil
+        os_log(.default, "Play Cache: %s (%s)", playable.displayString, fileURL.absoluteString)
+      } else {
+        perloadedPlayType = .cache
+        os_log(.default, "Insert Cache: %s (%s)", playable.displayString, fileURL.absoluteString)
+      }
+      if playable.isSong { userStatistics.playedSong(isPlayedFromCache: true) }
+      insert(playable: playable, withUrl: fileURL, queueType: queueType)
     }
-    if queueType == .play {
-      playType = .cache
-      perloadedPlayType = nil
-      os_log(.default, "Play Cache: %s (%s)", playable.displayString, fileURL.absoluteString)
-    } else {
-      perloadedPlayType = .cache
-      os_log(.default, "Insert Cache: %s (%s)", playable.displayString, fileURL.absoluteString)
-    }
-    if playable.isSong { userStatistics.playedSong(isPlayedFromCache: true) }
-    insert(playable: playable, withUrl: fileURL, queueType: queueType)
   }
 
   @MainActor

--- a/AmperfyKit/Player/EmbeddedArtworkExtractor.swift
+++ b/AmperfyKit/Player/EmbeddedArtworkExtractor.swift
@@ -30,69 +30,61 @@ final class EmbeddedArtworkExtractor: Sendable {
     playableInfo: AbstractPlayableInfo,
     storage: AsyncCoreDataAccessWrapper
   ) async throws {
-    let absFilePath: URL? = try await storage.performAndGet { asyncCompanion in
+    let relativeFilePath: URL? = try await storage.performAndGet { asyncCompanion in
       let playable = AbstractPlayable(
         managedObject: asyncCompanion.context
           .object(with: playableInfo.objectID) as! AbstractPlayableMO
       )
-      guard let relFilePath = playable.relFilePath else { return nil }
-      return self.fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath)
+      return playable.relFilePath
     }
-    guard let absFilePath else { return }
+    guard let relativeFilePath else { return }
 
-    guard let id3Tag = try? id3TagEditor.read(from: absFilePath.path) else { return }
-    let tagContentReader = ID3TagContentReader(id3Tag: id3Tag)
-    let artworks = tagContentReader.attachedPictures()
+    let artworks: [AttachedPicture] = try fileManager.withCacheFile(
+      relativePath: relativeFilePath
+    ) { fileURL in
+      guard let id3Tag = try? id3TagEditor.read(from: fileURL.path) else { return [] }
+      return ID3TagContentReader(id3Tag: id3Tag).attachedPictures()
+    }
 
-    try await storage.perform { asyncCompanion in
+    let embeddedImage: UIImage?
+    if let frontCoverArtwork = artworks.lazy.first(where: { $0.type == .frontCover }) {
+      embeddedImage = UIImage(data: frontCoverArtwork.picture)
+    } else {
+      embeddedImage = artworks.lazy.compactMap { UIImage(data: $0.picture) }.first
+    }
+    guard let pngData = embeddedImage?.pngData() else { return }
+
+    let sourceURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("embedded-artwork-\(UUID().uuidString).png")
+    try pngData.write(to: sourceURL, options: [.atomic])
+    let rootLease = try fileManager.currentRootLease()
+
+    let preparedCommit = try await storage.performWithCommitValidation { asyncCompanion in
       let playable = AbstractPlayable(
         managedObject: asyncCompanion.context
           .object(with: playableInfo.objectID) as! AbstractPlayableMO
       )
-
-      // if there is a frontCover artwork take this as embedded artwork
-      if let frontCoverArtwork = artworks.lazy.filter({ $0.type == .frontCover }).first,
-         let artworkImage = UIImage(data: frontCoverArtwork.picture) {
-        self.saveEmbeddedImageInLibrary(
-          library: asyncCompanion.library,
-          playable: playable,
-          embeddedImage: artworkImage
-        )
-        // take the first other available artwork
-      } else if let artworkImage = artworks.lazy.compactMap({ UIImage(data: $0.picture) }).first {
-        self.saveEmbeddedImageInLibrary(
-          library: asyncCompanion.library,
-          playable: playable,
-          embeddedImage: artworkImage
-        )
+      guard let account = playable.account else { throw CacheRootError.unavailable }
+      let embeddedArtwork = asyncCompanion.library.createEmbeddedArtwork(account: account)
+      embeddedArtwork.owner = playable
+      guard let relFilePath = self.fileManager.createRelPath(for: embeddedArtwork) else {
+        throw CacheRootError.unavailable
       }
-    }
-  }
-
-  private func saveEmbeddedImageInLibrary(
-    library: LibraryStorage,
-    playable: AbstractPlayable,
-    embeddedImage: UIImage
-  ) {
-    guard let account = playable.account else { return }
-    let embeddedArtwork = library.createEmbeddedArtwork(account: account)
-    embeddedArtwork.owner = playable
-
-    guard let relFilePath = fileManager.createRelPath(for: embeddedArtwork),
-          let absFilePath = fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath),
-          let pngData = embeddedImage.pngData()
-    else { return }
-
-    do {
-      try fileManager.writeDataExcludedFromBackup(
-        data: pngData,
-        to: absFilePath,
-        accountInfo: account.info
+      let absFilePath = try self.fileManager.getAbsoluteAmperfyPath(
+        relFilePath: relFilePath,
+        using: rootLease
+      )
+      let transaction = try self.fileManager.prepareRecoverableFileCommit(
+        sourceURL: sourceURL,
+        destinationURL: absFilePath,
+        accountInfo: account.info,
+        using: rootLease
       )
       embeddedArtwork.relFilePath = relFilePath
-    } catch {
-      embeddedArtwork.relFilePath = nil
+      return transaction
+    } validateBeforeSave: {
+      try rootLease.validateCurrent()
     }
-    library.saveContext()
+    try preparedCommit.finishAfterCoreDataCommit()
   }
 }

--- a/AmperfyKit/Screens/LibraryEntityImage.swift
+++ b/AmperfyKit/Screens/LibraryEntityImage.swift
@@ -178,7 +178,9 @@ public class LibraryEntityImage: RoundedImage {
     imagePath: String
   ) async {
     guard !Task.isCancelled else { return }
-    let loadedImage = UIImage(contentsOfFile: imagePath)
+    let loadedImage = try? UIImage(
+      data: CacheFileManager.shared.readCacheData(at: URL(fileURLWithPath: imagePath))
+    )
     let readyImage = await loadedImage?.byPreparingForDisplay()
     guard !Task.isCancelled else { return }
     Task { @MainActor [weak self] in

--- a/AmperfyKit/Storage/CacheFileManager.swift
+++ b/AmperfyKit/Storage/CacheFileManager.swift
@@ -19,6 +19,8 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CryptoKit
+import Darwin
 import Foundation
 import UniformTypeIdentifiers
 
@@ -75,55 +77,114 @@ public class MimeFileConverter {
   }
 }
 
+// MARK: - PreparedCacheFileCommit
+
+public final class PreparedCacheFileCommit: @unchecked Sendable {
+  public let receipt: CacheFileCommitReceipt
+  public let recoverableFileURL: URL
+  public let destinationURL: URL
+
+  private let finishOperation: @Sendable () throws -> ()
+  private let cancelOperation: @Sendable () throws -> ()
+
+  init(
+    receipt: CacheFileCommitReceipt,
+    recoverableFileURL: URL,
+    destinationURL: URL,
+    finishOperation: @escaping @Sendable () throws -> (),
+    cancelOperation: @escaping @Sendable () throws -> ()
+  ) {
+    self.receipt = receipt
+    self.recoverableFileURL = recoverableFileURL
+    self.destinationURL = destinationURL
+    self.finishOperation = finishOperation
+    self.cancelOperation = cancelOperation
+  }
+
+  /// Removes recovery evidence only after the caller has committed Core Data successfully.
+  public func finishAfterCoreDataCommit() throws {
+    try finishOperation()
+  }
+
+  /// Explicitly cancels retry state. It succeeds only while the original root lease is current.
+  public func cancel() throws {
+    try cancelOperation()
+  }
+}
+
 // MARK: - CacheFileManager
 
 final public class CacheFileManager: Sendable {
-  public static let shared = CacheFileManager()
+  public static var shared: CacheFileManager { CacheRootRuntime.shared.fileManager }
 
-  // Get the URL to the app container's 'Library' directory.
-  private let amperfyLibraryDirectory: URL?
+  private let rootRegistry: CacheRootRegistry
+  private let backgroundStagingRoot: URL?
+  private let backgroundStagingPolicy: BackgroundStagingPolicy
+  private let atomicStore: DurableAtomicFileStore
+  // Get the currently active cache root. External roots can only become visible through the
+  // registry, which invalidates all leases from the previous generation.
+  private var amperfyLibraryDirectory: URL? {
+    try? rootRegistry.currentLease().rootURL
+  }
+
   // Complete playable directory size
   nonisolated(unsafe) private var _completePlayableCacheSize: Int64 = 0
   private let _completePlayableCacheSizeLock = NSLock()
   nonisolated public var completePlayableCacheSize: Int64 {
-    _completePlayableCacheSizeLock.withLock { _completePlayableCacheSize }
+    guard let lease = try? rootRegistry.currentLease() else { return 0 }
+    return (try? lease.performAtCommitBoundary {
+      _completePlayableCacheSizeLock.withLock { _completePlayableCacheSize }
+    }) ?? 0
   }
 
   // Account playable directory size
   nonisolated(unsafe) private var _accountPlayableCacheSize = [AccountInfo: Int64]()
   private let _accountPlayableCacheSizeLock = NSLock()
   nonisolated public func getPlayableCacheSize(for accountInfo: AccountInfo) -> Int64 {
-    var size = Int64(0)
-    _accountPlayableCacheSizeLock.withLock { size = _accountPlayableCacheSize[accountInfo] ?? 0 }
-    return size
+    guard let lease = try? rootRegistry.currentLease() else { return 0 }
+    return (try? lease.performAtCommitBoundary {
+      _accountPlayableCacheSizeLock.withLock { _accountPlayableCacheSize[accountInfo] ?? 0 }
+    }) ?? 0
   }
 
-  init() {
-    // the action to get Amperfy's library directory takes long -> save it in cache
-    if let bundleIdentifier = Bundle.main.bundleIdentifier,
-       // Get the URL to the app container's 'Library' directory.
-       var url = try? FileManager.default.url(
-         for: .libraryDirectory,
-         in: .userDomainMask,
-         appropriateFor: nil,
-         create: true
-       ) {
-      // Append the bundle identifier to the retrieved URL.
-      url.appendPathComponent(bundleIdentifier, isDirectory: true)
-      self.amperfyLibraryDirectory = url
-    } else {
-      self.amperfyLibraryDirectory = nil
-    }
+  init(
+    rootRegistry: CacheRootRegistry,
+    backgroundStagingRoot: URL? = nil,
+    backgroundStagingPolicy: BackgroundStagingPolicy = BackgroundStagingPolicy(),
+    atomicStore: DurableAtomicFileStore = DurableAtomicFileStore()
+  ) {
+    self.rootRegistry = rootRegistry
+    self.backgroundStagingRoot = backgroundStagingRoot
+    self.backgroundStagingPolicy = backgroundStagingPolicy
+    self.atomicStore = atomicStore
+  }
 
-    checkAmperfyDirectory()
+  public func currentRootLease() throws -> CacheRootLease {
+    try rootRegistry.currentLease()
+  }
+
+  /// Called only by the bootstrap authority after preference resolution and health checks.
+  func rootDidActivate(using lease: CacheRootLease) throws {
+    try lease.performAtCommitBoundary {
+      let root = try lease.secureContainedURL(CacheRelativePath(".bootstrap-root"))
+        .deletingLastPathComponent()
+      try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+      try markItemAsExcludedFromBackup(at: root)
+    }
     recalculatePlayableCacheSizes()
   }
 
+  func rootDidBlock() {
+    _accountPlayableCacheSizeLock.withLock { _accountPlayableCacheSize.removeAll() }
+    _completePlayableCacheSizeLock.withLock { _completePlayableCacheSize = 0 }
+  }
+
   public func recalculatePlayableCacheSizes() {
+    guard let lease = try? currentRootLease() else { return }
     var completeCacheSize = Int64(0)
-    let accounts = getAccounts()
+    let accounts = getAccounts(using: lease)
     for account in accounts {
-      let accountCache = calculatePlayableCacheSize(for: account)
+      let accountCache = calculatePlayableCacheSize(for: account, using: lease)
       _accountPlayableCacheSizeLock.withLock {
         _accountPlayableCacheSize[account] = accountCache
       }
@@ -131,13 +192,6 @@ final public class CacheFileManager: Sendable {
     }
     _completePlayableCacheSizeLock.withLock {
       _completePlayableCacheSize = completeCacheSize
-    }
-  }
-
-  func checkAmperfyDirectory() {
-    guard let amperfyLibraryDirectory else { return }
-    if createDirectoryIfNeeded(at: amperfyLibraryDirectory) {
-      try? markItemAsExcludedFromBackup(at: amperfyLibraryDirectory)
     }
   }
 
@@ -149,42 +203,237 @@ final public class CacheFileManager: Sendable {
     return tmpFileURL
   }
 
-  public func moveExcludedFromBackupItem(at: URL, to: URL, accountInfo: AccountInfo) throws {
-    let subDir = to.deletingLastPathComponent()
-    if createDirectoryIfNeeded(at: subDir) {
-      try? markItemAsExcludedFromBackup(at: subDir)
-    }
-    if FileManager.default.fileExists(atPath: to.path) {
-      try? removeItem(at: to, accountInfo: accountInfo)
-    }
-    try FileManager.default.moveItem(at: at, to: to)
-    try markItemAsExcludedFromBackup(at: to)
+  /// Stages a completed background download in the app container, writes a durable receipt, then
+  /// copies it into the leased cache root using a verified temporary file and atomic rename. The
+  /// recoverable app-container copy is retained until `finishAfterCoreDataCommit()` is called.
+  public func prepareRecoverableFileCommit(
+    sourceURL: URL,
+    destinationURL: URL,
+    accountInfo: AccountInfo,
+    using lease: CacheRootLease
+  ) throws
+    -> PreparedCacheFileCommit {
+    let stagingRoot = try resolvedBackgroundStagingRoot()
+    try FileManager.default.createDirectory(at: stagingRoot, withIntermediateDirectories: true)
+    try validateStagingCapacity(adding: getFileSize(url: sourceURL) ?? 0, at: stagingRoot)
 
-    updateCachedDirectorySize(itemUrl: to, isAdded: true, accountInfo: accountInfo)
+    let transactionID = UUID()
+    let transactionRoot = stagingRoot.appendingPathComponent(
+      transactionID.uuidString,
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: transactionRoot, withIntermediateDirectories: true)
+    let recoverableURL = transactionRoot.appendingPathComponent("payload", isDirectory: false)
+    let incomingURL = transactionRoot.appendingPathComponent("payload.incoming", isDirectory: false)
+    let receiptURL = transactionRoot.appendingPathComponent("receipt.json", isDirectory: false)
+
+    do {
+      try FileManager.default.copyItem(at: sourceURL, to: incomingURL)
+      try synchronizeFile(at: incomingURL)
+      let sourceDigest = try sha256AndSize(of: sourceURL)
+      let incomingDigest = try sha256AndSize(of: incomingURL)
+      guard incomingDigest == sourceDigest else { throw CacheRootError.inconsistentActivation }
+      guard Darwin.rename(incomingURL.path, recoverableURL.path) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+      }
+
+      let safeDestination = try ensureInsideRoot(destinationURL, lease: lease)
+      let rootPrefix = lease.rootURL.path.hasSuffix("/")
+        ? lease.rootURL.path
+        : lease.rootURL.path + "/"
+      let relativeDestination = try CacheRelativePath(
+        String(safeDestination.path.dropFirst(rootPrefix.count))
+      )
+      var receipt = CacheFileCommitReceipt(
+        transactionID: transactionID,
+        relativeDestinationPath: relativeDestination.string,
+        stagedFileName: recoverableURL.lastPathComponent,
+        byteCount: sourceDigest.size,
+        sha256: sourceDigest.sha256,
+        phase: .staged
+      )
+      try atomicStore.write(receipt, to: receiptURL)
+      try? FileManager.default.removeItem(at: sourceURL)
+
+      try lease.performAtCommitBoundary {
+        let finalDestination = try lease.secureContainedURL(relativeDestination)
+        let parent = finalDestination.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        _ = try ensureInsideRoot(parent, lease: lease)
+        let partialURL = parent.appendingPathComponent(
+          ".\(finalDestination.lastPathComponent).\(transactionID.uuidString).partial"
+        )
+        try? FileManager.default.removeItem(at: partialURL)
+        try FileManager.default.copyItem(at: recoverableURL, to: partialURL)
+        try synchronizeFile(at: partialURL)
+        guard try sha256AndSize(of: partialURL) == sourceDigest else {
+          throw CacheRootError.inconsistentActivation
+        }
+        _ = try ensureInsideRoot(partialURL, lease: lease)
+        guard Darwin.rename(partialURL.path, finalDestination.path) == 0 else {
+          throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        try markItemAsExcludedFromBackup(at: finalDestination)
+        updateCachedDirectorySize(
+          itemUrl: finalDestination,
+          isAdded: true,
+          accountInfo: accountInfo,
+          using: lease
+        )
+      }
+
+      receipt.phase = .filesystemCommitted
+      try atomicStore.write(receipt, to: receiptURL)
+      return PreparedCacheFileCommit(
+        receipt: receipt,
+        recoverableFileURL: recoverableURL,
+        destinationURL: safeDestination,
+        finishOperation: {
+          try FileManager.default.removeItem(at: transactionRoot)
+        },
+        cancelOperation: { [weak self] in
+          guard let self else { throw CacheRootError.unavailable }
+          try lease.performAtCommitBoundary {
+            let destination = try lease.secureContainedURL(relativeDestination)
+            if FileManager.default.fileExists(atPath: destination.path) {
+              try self.removeItem(at: destination, accountInfo: accountInfo, using: lease)
+            }
+            try FileManager.default.removeItem(at: transactionRoot)
+          }
+        }
+      )
+    } catch {
+      try? FileManager.default.removeItem(at: incomingURL)
+      throw error
+    }
+  }
+
+  private func resolvedBackgroundStagingRoot() throws -> URL {
+    if let backgroundStagingRoot { return backgroundStagingRoot }
+    let applicationSupport = try FileManager.default.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
+    let bundle = Bundle.main.bundleIdentifier ?? "Amperfy"
+    return applicationSupport.appendingPathComponent(bundle, isDirectory: true)
+      .appendingPathComponent("Cache Commit Staging", isDirectory: true)
+  }
+
+  private func validateStagingCapacity(adding bytes: Int64, at stagingRoot: URL) throws {
+    var stagedBytes: Int64 = 0
+    var oldestDate = Date()
+    if let enumerator = FileManager.default.enumerator(
+      at: stagingRoot,
+      includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey, .isRegularFileKey]
+    ) {
+      while let url = enumerator.nextObject() as? URL {
+        let values = try url.resourceValues(forKeys: [
+          .fileSizeKey,
+          .contentModificationDateKey,
+          .isRegularFileKey,
+        ])
+        guard values.isRegularFile == true else { continue }
+        stagedBytes += Int64(values.fileSize ?? 0)
+        oldestDate = min(oldestDate, values.contentModificationDate ?? oldestDate)
+      }
+    }
+    let available = try stagingRoot.resourceValues(forKeys: [
+      .volumeAvailableCapacityForImportantUsageKey,
+    ]).volumeAvailableCapacityForImportantUsage ?? 0
+    guard backgroundStagingPolicy.permits(
+      stagedBytes: stagedBytes + bytes,
+      oldestItemAge: Date().timeIntervalSince(oldestDate),
+      containerAvailableCapacity: available
+    ) else { throw CacheRootError.stagingLimitExceeded }
+  }
+
+  private func sha256AndSize(of url: URL) throws -> (sha256: String, size: Int64) {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+    var hasher = SHA256()
+    var size: Int64 = 0
+    while true {
+      let data = try handle.read(upToCount: 1024 * 1024) ?? Data()
+      guard !data.isEmpty else { break }
+      hasher.update(data: data)
+      size += Int64(data.count)
+    }
+    return (hasher.finalize().map { String(format: "%02x", $0) }.joined(), size)
+  }
+
+  private func synchronizeFile(at url: URL) throws {
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.synchronize()
+  }
+
+  public func moveExcludedFromBackupItem(at: URL, to: URL, accountInfo: AccountInfo) throws {
+    let lease = try currentRootLease()
+    try moveExcludedFromBackupItem(at: at, to: to, accountInfo: accountInfo, using: lease)
+  }
+
+  /// Moves a completed download only while `lease` is still the active root generation.
+  public func moveExcludedFromBackupItem(
+    at sourceURL: URL,
+    to destinationURL: URL,
+    accountInfo: AccountInfo,
+    using lease: CacheRootLease
+  ) throws {
+    try lease.performAtCommitBoundary {
+      let expectedDestination = try ensureInsideRoot(destinationURL, lease: lease)
+      let subdirectory = expectedDestination.deletingLastPathComponent()
+      try FileManager.default.createDirectory(
+        at: subdirectory,
+        withIntermediateDirectories: true
+      )
+      try markItemAsExcludedFromBackup(at: subdirectory)
+      if FileManager.default.fileExists(atPath: expectedDestination.path) {
+        try removeItem(at: expectedDestination, accountInfo: accountInfo, using: lease)
+      }
+      try FileManager.default.moveItem(at: sourceURL, to: expectedDestination)
+      try markItemAsExcludedFromBackup(at: expectedDestination)
+      updateCachedDirectorySize(
+        itemUrl: expectedDestination,
+        isAdded: true,
+        accountInfo: accountInfo,
+        using: lease
+      )
+    }
   }
 
   public func move(from: URL?, to: URL?) throws {
     guard let from, let to else { return }
-    if createDirectoryIfNeeded(at: to) {
-      try? markItemAsExcludedFromBackup(at: to)
+    let lease = try currentRootLease()
+    try lease.performAtCommitBoundary {
+      let safeFrom = try ensureInsideRoot(from, lease: lease)
+      let safeTo = try ensureInsideRoot(to, lease: lease)
+      try FileManager.default.createDirectory(at: safeTo, withIntermediateDirectories: true)
+      try markItemAsExcludedFromBackup(at: safeTo)
+      let items = try contentsOfDirectory(url: safeFrom, using: lease)
+      for file in items {
+        let destinationFileURL = safeTo.appendingPathComponent(file.lastPathComponent)
+        _ = try ensureInsideRoot(destinationFileURL, lease: lease)
+        try FileManager.default.moveItem(at: file, to: destinationFileURL)
+      }
+      try markItemAsExcludedFromBackup(at: safeTo)
     }
-    let items = contentsOfDirectory(url: from)
-    for file in items {
-      let destinationFileURL = to.appendingPathComponent(file.lastPathComponent)
-      try FileManager.default.moveItem(at: file, to: destinationFileURL)
-    }
-    try markItemAsExcludedFromBackup(at: to)
   }
 
   @discardableResult
   public func createDirectoryIfNeeded(at url: URL) -> Bool {
-    guard !FileManager.default.fileExists(atPath: url.path) else { return false }
-    try? FileManager.default.createDirectory(
-      at: url,
-      withIntermediateDirectories: true,
-      attributes: [:]
-    )
-    return true
+    guard let lease = try? currentRootLease() else { return false }
+    return (try? lease.performAtCommitBoundary {
+      let safeURL = try ensureInsideRoot(url, lease: lease)
+      guard !FileManager.default.fileExists(atPath: safeURL.path) else { return false }
+      try FileManager.default.createDirectory(
+        at: safeURL,
+        withIntermediateDirectories: true,
+        attributes: [:]
+      )
+      return true
+    }) ?? false
   }
 
   nonisolated private func resetPlayableCacheSize(for accountInfo: AccountInfo) {
@@ -237,13 +486,38 @@ final public class CacheFileManager: Sendable {
   }
 
   public func removeItem(at itemUrl: URL, accountInfo: AccountInfo) throws {
-    updateCachedDirectorySize(itemUrl: itemUrl, isAdded: false, accountInfo: accountInfo)
-    try FileManager.default.removeItem(at: itemUrl)
+    let lease = try currentRootLease()
+    try removeItem(at: itemUrl, accountInfo: accountInfo, using: lease)
   }
 
-  private func updateCachedDirectorySize(itemUrl: URL, isAdded: Bool, accountInfo: AccountInfo) {
-    guard let absSongsDir = getOrCreateAbsoluteSongsDirectory(for: accountInfo),
-          let absEpisodesDir = getOrCreateAbsolutePodcastEpisodesDirectory(for: accountInfo),
+  private func removeItem(
+    at itemURL: URL,
+    accountInfo: AccountInfo,
+    using lease: CacheRootLease
+  ) throws {
+    try lease.performAtCommitBoundary {
+      let safeURL = try ensureInsideRoot(itemURL, lease: lease)
+      updateCachedDirectorySize(
+        itemUrl: safeURL,
+        isAdded: false,
+        accountInfo: accountInfo,
+        using: lease
+      )
+      try FileManager.default.removeItem(at: safeURL)
+    }
+  }
+
+  private func updateCachedDirectorySize(
+    itemUrl: URL,
+    isAdded: Bool,
+    accountInfo: AccountInfo,
+    using lease: CacheRootLease
+  ) {
+    guard let absSongsDir = getOrCreateAbsoluteSongsDirectory(for: accountInfo, using: lease),
+          let absEpisodesDir = getOrCreateAbsolutePodcastEpisodesDirectory(
+            for: accountInfo,
+            using: lease
+          ),
           let itemSize = getFileSize(url: itemUrl),
           isFileURLInsideDirectory(fileURL: itemUrl, directoryURL: absSongsDir) ||
           isFileURLInsideDirectory(fileURL: itemUrl, directoryURL: absEpisodesDir)
@@ -257,54 +531,78 @@ final public class CacheFileManager: Sendable {
   }
 
   private func getOrCreateSubDirectory(subDirectoryNames: [String]) -> URL? {
-    var url: URL? = amperfyLibraryDirectory
-    for subDirName in subDirectoryNames {
-      url = url?.appendingPathComponent(
-        subDirName,
-        isDirectory: true
-      )
-      guard let url else { continue }
-      if createDirectoryIfNeeded(at: url) {
-        try? markItemAsExcludedFromBackup(at: url)
+    guard let lease = try? currentRootLease() else { return nil }
+    return getOrCreateSubDirectory(subDirectoryNames: subDirectoryNames, using: lease)
+  }
+
+  private func getOrCreateSubDirectory(
+    subDirectoryNames: [String],
+    using lease: CacheRootLease
+  )
+    -> URL? {
+    guard let relativePath = try? CacheRelativePath(subDirectoryNames.joined(separator: "/"))
+    else { return nil }
+    return try? lease.performAtCommitBoundary {
+      let url = try lease.secureContainedURL(relativePath)
+      if !FileManager.default.fileExists(atPath: url.path) {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try markItemAsExcludedFromBackup(at: url)
       }
+      return try lease.secureContainedURL(relativePath)
     }
-    return url
   }
 
   public func deleteAccountCache(accountInfo: AccountInfo) {
-    if let absAccountDir = getOrCreateAbsoluteAccountDirectory(for: accountInfo) {
-      try? FileManager.default.removeItem(at: absAccountDir)
+    guard let lease = try? currentRootLease(),
+          let absAccountDir = getOrCreateAbsoluteAccountDirectory(for: accountInfo, using: lease)
+    else { return }
+    try? lease.performAtCommitBoundary {
+      try FileManager.default.removeItem(at: try ensureInsideRoot(absAccountDir, lease: lease))
     }
   }
 
   public func deletePlayableCache(accountInfo: AccountInfo) {
-    if let absSongsDir = getOrCreateAbsoluteSongsDirectory(for: accountInfo) {
-      try? FileManager.default.removeItem(at: absSongsDir)
+    guard let lease = try? currentRootLease() else { return }
+    try? lease.performAtCommitBoundary {
+      let directories = [
+        getOrCreateAbsoluteSongsDirectory(for: accountInfo, using: lease),
+        getOrCreateAbsolutePodcastEpisodesDirectory(for: accountInfo, using: lease),
+        getOrCreateAbsoluteEmbeddedArtworksDirectory(for: accountInfo, using: lease),
+      ].compactMap { $0 }
+      for directory in directories {
+        try? FileManager.default.removeItem(at: try ensureInsideRoot(directory, lease: lease))
+      }
+      resetPlayableCacheSize(for: accountInfo)
     }
-    if let absEpisodesDir = getOrCreateAbsolutePodcastEpisodesDirectory(for: accountInfo) {
-      try? FileManager.default.removeItem(at: absEpisodesDir)
-    }
-    if let absEmbeddedArtworksDir = getOrCreateAbsoluteEmbeddedArtworksDirectory(for: accountInfo) {
-      try? FileManager.default.removeItem(at: absEmbeddedArtworksDir)
-    }
-    resetPlayableCacheSize(for: accountInfo)
   }
 
   public func deleteRemoteArtworkCache(accountInfo: AccountInfo) {
-    if let absArtworksDir = getOrCreateAbsoluteArtworksDirectory(for: accountInfo) {
-      try? FileManager.default.removeItem(at: absArtworksDir)
+    guard let lease = try? currentRootLease(),
+          let absArtworksDir = getOrCreateAbsoluteArtworksDirectory(for: accountInfo, using: lease)
+    else { return }
+    try? lease.performAtCommitBoundary {
+      try FileManager.default.removeItem(at: try ensureInsideRoot(absArtworksDir, lease: lease))
     }
   }
 
-  private func calculatePlayableCacheSize(for accountInfo: AccountInfo) -> Int64 {
-    var bytes = Int64(0)
-    if let absSongsDir = getOrCreateAbsoluteSongsDirectory(for: accountInfo) {
-      bytes += directorySize(url: absSongsDir)
-    }
-    if let absEpisodesDir = getOrCreateAbsolutePodcastEpisodesDirectory(for: accountInfo) {
-      bytes += directorySize(url: absEpisodesDir)
-    }
-    return bytes
+  private func calculatePlayableCacheSize(
+    for accountInfo: AccountInfo,
+    using lease: CacheRootLease
+  )
+    -> Int64 {
+    (try? lease.performAtCommitBoundary {
+      var bytes = Int64(0)
+      if let absSongsDir = getOrCreateAbsoluteSongsDirectory(for: accountInfo, using: lease) {
+        bytes += try directorySize(url: absSongsDir, using: lease)
+      }
+      if let absEpisodesDir = getOrCreateAbsolutePodcastEpisodesDirectory(
+        for: accountInfo,
+        using: lease
+      ) {
+        bytes += try directorySize(url: absEpisodesDir, using: lease)
+      }
+      return bytes
+    }) ?? 0
   }
 
   private static let artworkFileExtension = "png"
@@ -339,6 +637,17 @@ final public class CacheFileManager: Sendable {
     ))
   }
 
+  private func getOrCreateAbsoluteAccountDirectory(
+    for account: AccountInfo,
+    using lease: CacheRootLease
+  )
+    -> URL? {
+    getOrCreateSubDirectory(
+      subDirectoryNames: getRelAccountPaths(for: account, dirName: nil),
+      using: lease
+    )
+  }
+
   public func getRelPath(for account: AccountInfo) -> URL? {
     Self.accountsDir.appendingPathComponent(account.serverHash)
       .appendingPathComponent(account.userHash)
@@ -349,6 +658,17 @@ final public class CacheFileManager: Sendable {
       for: account,
       dirName: Self.songsDir.path
     ))
+  }
+
+  private func getOrCreateAbsoluteSongsDirectory(
+    for account: AccountInfo,
+    using lease: CacheRootLease
+  )
+    -> URL? {
+    getOrCreateSubDirectory(
+      subDirectoryNames: getRelAccountPaths(for: account, dirName: Self.songsDir.path),
+      using: lease
+    )
   }
 
   public func getRelSongsDirectory(for account: AccountInfo) -> URL? {
@@ -362,6 +682,17 @@ final public class CacheFileManager: Sendable {
     ))
   }
 
+  private func getOrCreateAbsolutePodcastEpisodesDirectory(
+    for account: AccountInfo,
+    using lease: CacheRootLease
+  )
+    -> URL? {
+    getOrCreateSubDirectory(
+      subDirectoryNames: getRelAccountPaths(for: account, dirName: Self.episodesDir.path),
+      using: lease
+    )
+  }
+
   public func getRelPodcastEpisodesDirectory(for account: AccountInfo) -> URL? {
     getRelPath(for: account)?.appendingPathComponent(Self.episodesDir.path)
   }
@@ -373,6 +704,17 @@ final public class CacheFileManager: Sendable {
     ))
   }
 
+  private func getOrCreateAbsoluteArtworksDirectory(
+    for account: AccountInfo,
+    using lease: CacheRootLease
+  )
+    -> URL? {
+    getOrCreateSubDirectory(
+      subDirectoryNames: getRelAccountPaths(for: account, dirName: Self.artworksDir.path),
+      using: lease
+    )
+  }
+
   public func getRelArtworkDirectory(for account: AccountInfo) -> URL? {
     getRelPath(for: account)?.appendingPathComponent(Self.artworksDir.path)
   }
@@ -382,6 +724,17 @@ final public class CacheFileManager: Sendable {
       for: account,
       dirName: Self.embeddedArtworksDir.path
     ))
+  }
+
+  private func getOrCreateAbsoluteEmbeddedArtworksDirectory(
+    for account: AccountInfo,
+    using lease: CacheRootLease
+  )
+    -> URL? {
+    getOrCreateSubDirectory(
+      subDirectoryNames: getRelAccountPaths(for: account, dirName: Self.embeddedArtworksDir.path),
+      using: lease
+    )
   }
 
   public func getRelEmbeddedArtworkDirectory(for account: AccountInfo) -> URL? {
@@ -400,11 +753,19 @@ final public class CacheFileManager: Sendable {
   }
 
   public func getAccounts() -> [AccountInfo] {
+    guard let lease = try? currentRootLease() else { return [] }
+    return getAccounts(using: lease)
+  }
+
+  private func getAccounts(using lease: CacheRootLease) -> [AccountInfo] {
     var URLs = [URL]()
     var accountInfo = [AccountInfo]()
     var serverHashes = [String]()
-    if let accountsDir = getOrCreateAbsoluteServerDirectory() {
-      URLs = contentsOfDirectory(url: accountsDir)
+    if let accountsDir = getOrCreateSubDirectory(
+      subDirectoryNames: [Self.accountsDir.path],
+      using: lease
+    ) {
+      URLs = (try? contentsOfDirectory(url: accountsDir, using: lease)) ?? []
     }
     // get all server hashes
     for url in URLs {
@@ -420,8 +781,11 @@ final public class CacheFileManager: Sendable {
       serverHashes.append(url.lastPathComponent)
     }
     for serverHash in serverHashes {
-      if let usersDir = getOrCreateAbsoluteUserDirectory(server: serverHash) {
-        URLs = contentsOfDirectory(url: usersDir)
+      if let usersDir = getOrCreateSubDirectory(
+        subDirectoryNames: [Self.accountsDir.path, serverHash],
+        using: lease
+      ) {
+        URLs = (try? contentsOfDirectory(url: usersDir, using: lease)) ?? []
       }
       // get all users hashes for the server hashes
       for url in URLs {
@@ -650,6 +1014,30 @@ final public class CacheFileManager: Sendable {
     let relFilePath: URL?
   }
 
+  public struct AccountCacheSnapshot: Sendable {
+    let artworks: [ArtworkCacheInfo]
+    let embeddedArtworks: [EmbeddedArtworkCacheInfo]
+    let lyrics: [LyricsCacheInfo]
+    let songs: [PlayableCacheInfo]
+    let episodes: [PlayableCacheInfo]
+  }
+
+  public func accountCacheSnapshot(
+    for account: AccountInfo,
+    using lease: CacheRootLease
+  ) throws
+    -> AccountCacheSnapshot {
+    try lease.performAtCommitBoundary {
+      AccountCacheSnapshot(
+        artworks: getCachedArtworks(for: account),
+        embeddedArtworks: getCachedEmbeddedArtworks(for: account),
+        lyrics: getCachedLyrics(for: account),
+        songs: getCachedSongs(for: account),
+        episodes: getCachedEpisodes(for: account)
+      )
+    }
+  }
+
   public func getCachedLyrics(for account: AccountInfo) -> [LyricsCacheInfo] {
     var cacheInfo = [LyricsCacheInfo]()
     if let lyricsDir = getOrCreateAbsoluteLyricsDirectory(for: account) {
@@ -788,27 +1176,112 @@ final public class CacheFileManager: Sendable {
   }
 
   public func getAbsoluteAmperfyPath(relFilePath: URL) -> URL? {
-    guard let amperfyDir = amperfyLibraryDirectory else { return nil }
-    return amperfyDir.appendingPathComponent(relFilePath.path)
+    guard let lease = try? currentRootLease() else { return nil }
+    return try? lease.resolve(relativePath: relFilePath)
+  }
+
+  public func getAbsoluteAmperfyPath(
+    relFilePath: URL,
+    using lease: CacheRootLease
+  ) throws
+    -> URL {
+    try lease.resolve(relativePath: relFilePath)
+  }
+
+  public func getAbsoluteAmperfyPath(
+    relativePath: CacheRelativePath,
+    using lease: CacheRootLease
+  ) throws
+    -> URL {
+    try lease.resolve(relativePath: relativePath)
+  }
+
+  public func withCacheFile<T>(
+    relativePath: URL,
+    operation: (URL) throws -> T
+  ) throws
+    -> T {
+    let lease = try currentRootLease()
+    return try lease.performAtCommitBoundary {
+      let absoluteURL = try lease.resolve(relativePath: relativePath)
+      guard FileManager.default.fileExists(atPath: absoluteURL.path) else {
+        throw CocoaError(.fileNoSuchFile)
+      }
+      return try operation(absoluteURL)
+    }
+  }
+
+  public func readCacheData(at absoluteURL: URL) throws -> Data {
+    let lease = try currentRootLease()
+    return try lease.performAtCommitBoundary {
+      let safeURL = try ensureInsideRoot(absoluteURL, lease: lease)
+      return try Data(contentsOf: safeURL)
+    }
+  }
+
+  public func copyCacheItem(at absoluteURL: URL, to destinationURL: URL) throws {
+    let lease = try currentRootLease()
+    try lease.performAtCommitBoundary {
+      let safeURL = try ensureInsideRoot(absoluteURL, lease: lease)
+      try FileManager.default.copyItem(at: safeURL, to: destinationURL)
+    }
   }
 
   public func fileExits(relFilePath: URL) -> Bool {
-    guard let absFilePath = amperfyLibraryDirectory?.appendingPathComponent(relFilePath.path)
-    else { return false }
-    return FileManager.default.fileExists(atPath: absFilePath.path)
+    guard let lease = try? currentRootLease() else { return false }
+    return (try? lease.performAtCommitBoundary {
+      let absolutePath = try lease.resolve(relativePath: relFilePath)
+      return FileManager.default.fileExists(atPath: absolutePath.path)
+    }) ?? false
   }
 
   public func writeDataExcludedFromBackup(data: Data, to: URL, accountInfo: AccountInfo?) throws {
-    let subDir = to.deletingLastPathComponent()
-    if createDirectoryIfNeeded(at: subDir) {
-      try? markItemAsExcludedFromBackup(at: subDir)
+    let lease = try currentRootLease()
+    try writeDataExcludedFromBackup(data: data, to: to, accountInfo: accountInfo, using: lease)
+  }
+
+  public func writeDataExcludedFromBackup(
+    data: Data,
+    to destinationURL: URL,
+    accountInfo: AccountInfo?,
+    using lease: CacheRootLease
+  ) throws {
+    try lease.performAtCommitBoundary {
+      let expectedDestination = try ensureInsideRoot(destinationURL, lease: lease)
+      let subdirectory = expectedDestination.deletingLastPathComponent()
+      try FileManager.default.createDirectory(
+        at: subdirectory,
+        withIntermediateDirectories: true
+      )
+      try markItemAsExcludedFromBackup(at: subdirectory)
+      try data.write(to: expectedDestination, options: [.atomic])
+      try markItemAsExcludedFromBackup(at: expectedDestination)
+      if let accountInfo {
+        updateCachedDirectorySize(
+          itemUrl: expectedDestination,
+          isAdded: true,
+          accountInfo: accountInfo,
+          using: lease
+        )
+      }
     }
-    try data.write(to: to, options: [.atomic])
-    try markItemAsExcludedFromBackup(at: to)
-    // account info is nil when written to Amperfy directory directly
-    if let accountInfo {
-      updateCachedDirectorySize(itemUrl: to, isAdded: true, accountInfo: accountInfo)
+  }
+
+  private func ensureInsideRoot(_ url: URL, lease: CacheRootLease) throws -> URL {
+    let standardizedURL = url.standardizedFileURL
+    let standardizedRoot = lease.rootURL.standardizedFileURL
+    if standardizedURL.path == standardizedRoot.path {
+      try lease.validateCurrent()
+      return standardizedRoot.resolvingSymlinksInPath()
     }
+    let rootPath = standardizedRoot.path.hasSuffix("/")
+      ? standardizedRoot.path
+      : standardizedRoot.path + "/"
+    guard standardizedURL.path.hasPrefix(rootPath) else {
+      throw CacheRootError.pathEscapesRoot
+    }
+    let relative = try CacheRelativePath(String(standardizedURL.path.dropFirst(rootPath.count)))
+    return try lease.secureContainedURL(relative)
   }
 
   private func markItemAsExcludedFromBackup(at: URL) throws {
@@ -820,42 +1293,58 @@ final public class CacheFileManager: Sendable {
   }
 
   private func contentsOfDirectory(url: URL) -> [URL] {
-    let contents = try? FileManager.default.contentsOfDirectory(
-      at: url,
-      includingPropertiesForKeys: [.isDirectoryKey]
-    )
-    return contents ?? [URL]()
+    guard let lease = try? currentRootLease() else { return [] }
+    return (try? contentsOfDirectory(url: url, using: lease)) ?? []
   }
 
-  private func directorySize(url: URL) -> Int64 {
-    let contents: [URL]
-    do {
-      contents = try FileManager.default.contentsOfDirectory(
-        at: url,
-        includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey]
+  private func contentsOfDirectory(url: URL, using lease: CacheRootLease) throws -> [URL] {
+    try lease.performAtCommitBoundary {
+      let safeURL = try ensureInsideRoot(url, lease: lease)
+      let contents = try FileManager.default.contentsOfDirectory(
+        at: safeURL,
+        includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey]
       )
-    } catch {
-      return 0
+      for item in contents {
+        _ = try ensureInsideRoot(item, lease: lease)
+      }
+      return contents
     }
+  }
+
+  private func directorySize(url: URL, using lease: CacheRootLease) throws -> Int64 {
+    let safeURL = try ensureInsideRoot(url, lease: lease)
+    let contents = try FileManager.default.contentsOfDirectory(
+      at: safeURL,
+      includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey, .isSymbolicLinkKey]
+    )
 
     var size: Int64 = 0
 
     for url in contents {
       let isDirectoryResourceValue: URLResourceValues
       do {
-        isDirectoryResourceValue = try url.resourceValues(forKeys: [.isDirectoryKey])
+        _ = try ensureInsideRoot(url, lease: lease)
+        isDirectoryResourceValue = try url.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .isSymbolicLinkKey,
+        ])
       } catch {
-        continue
+        throw error
+      }
+
+      guard isDirectoryResourceValue.isSymbolicLink != true else {
+        throw CacheRootError.pathEscapesRoot
       }
 
       if isDirectoryResourceValue.isDirectory == true {
-        size += directorySize(url: url)
+        size += try directorySize(url: url, using: lease)
       } else {
         if let fileSize = getFileSize(url: url) {
           size += fileSize
         }
       }
     }
+    try lease.validateCurrent()
     return size
   }
 

--- a/AmperfyKit/Storage/CacheRelocation.swift
+++ b/AmperfyKit/Storage/CacheRelocation.swift
@@ -1,0 +1,262 @@
+//
+//  CacheRelocation.swift
+//  AmperfyKit
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+import CryptoKit
+import Darwin
+import Foundation
+
+// MARK: - CacheMoveProgress
+
+public struct CacheMoveProgress: Sendable {
+  public let message: String
+  public let completedBytes: Int64
+  public let totalBytes: Int64
+
+  public init(message: String, completedBytes: Int64 = 0, totalBytes: Int64 = 0) {
+    self.message = message
+    self.completedBytes = completedBytes
+    self.totalBytes = totalBytes
+  }
+}
+
+// MARK: - CacheRelocationRecord
+
+struct CacheRelocationRecord: Codable, Sendable {
+  let id: UUID
+  let source: URL
+  let destination: URL
+  let oldPreference: CacheLocationPreference
+  let newPreference: CacheLocationPreference
+  let cacheID: UUID
+  let inventory: [CacheInventoryEntry]
+
+  init(
+    source: URL,
+    destination: URL,
+    oldPreference: CacheLocationPreference,
+    newPreference: CacheLocationPreference,
+    cacheID: UUID,
+    inventory: [CacheInventoryEntry]
+  ) {
+    self.id = UUID()
+    self.source = source
+    self.destination = destination
+    self.oldPreference = oldPreference
+    self.newPreference = newPreference
+    self.cacheID = cacheID
+    self.inventory = inventory
+  }
+
+  var staging: URL {
+    destination.deletingLastPathComponent().appendingPathComponent(".amperfy-move-\(id.uuidString)")
+  }
+}
+
+// MARK: - CacheRelocationCopy
+
+/// Filesystem half of a relocation. The caller owns security scopes and suspends cache
+/// consumers. No existing destination containing payload is overwritten or adopted.
+enum CacheRelocationCopy {
+  static func copy(
+    _ move: CacheRelocationRecord,
+    progress: @Sendable (CacheMoveProgress) -> (),
+    checkCancellation: @Sendable () throws -> ()
+  ) throws {
+    let fm = FileManager.default
+    let total = move.inventory.reduce(Int64(0)) { $0 + $1.byteCount }
+    let parent = move.destination.deletingLastPathComponent()
+    try CacheCapacityPolicy().validate(
+      available: VolumeImportantUsageCapacityProvider().availableCapacity(at: parent),
+      inventoryBytes: total
+    )
+    if fm.fileExists(atPath: move.destination.path) {
+      // An empty root previously created by Amperfy can be reused. Arbitrary
+      // pre-existing folders and populated caches are never overwritten.
+      if move.newPreference.mode == .external {
+        _ = try DurableAtomicFileStore().read(
+          CacheMarker.self,
+          from: move.destination
+            .appendingPathComponent(CacheMarker.fileName)
+        )
+      }
+      guard try CacheInventoryBuilder().build(rootURL: move.destination).isEmpty
+      else { throw CacheRootError.migrationRequired }
+    }
+    guard !fm.fileExists(atPath: move.staging.path)
+    else { throw CacheRootError.inconsistentActivation }
+    try fm.createDirectory(at: move.staging, withIntermediateDirectories: false)
+    try DurableAtomicFileStore().write(
+      CacheMarker(cacheID: move.cacheID),
+      to: move.staging
+        .appendingPathComponent(CacheMarker.fileName)
+    )
+    var copied: Int64 = 0
+    for entry in move.inventory {
+      try checkCancellation()
+      let source = try contained(entry.relativePath, in: move.source)
+      let destination = try contained(entry.relativePath, in: move.staging)
+      try fm.createDirectory(
+        at: destination.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      let input = try FileHandle(forReadingFrom: source)
+      defer { try? input.close() }
+      guard fm.createFile(atPath: destination.path, contents: nil)
+      else { throw CocoaError(.fileWriteUnknown) }
+      let output = try FileHandle(forWritingTo: destination)
+      defer { try? output.close() }
+      var hash = SHA256()
+      var size: Int64 = 0
+      while let data = try input.read(upToCount: 1024 * 1024), !data.isEmpty {
+        try checkCancellation()
+        try output.write(contentsOf: data)
+        hash.update(data: data)
+        size += Int64(data.count)
+        progress(CacheMoveProgress(
+          message: "Moving downloaded files…",
+          completedBytes: copied + size,
+          totalBytes: total
+        ))
+      }
+      try output.synchronize()
+      let digest = hash.finalize().map { String(format: "%02x", $0) }.joined()
+      guard size == entry.byteCount,
+            digest == entry.sha256 else { throw CacheRootError.inconsistentActivation }
+      copied += size
+    }
+    progress(CacheMoveProgress(
+      message: "Verifying the new copy…",
+      completedBytes: total,
+      totalBytes: total
+    ))
+    guard try CacheInventoryBuilder().build(
+      rootURL: move.staging,
+      checkCancellation: checkCancellation
+    ) == move.inventory else {
+      throw CacheRootError.inconsistentActivation
+    }
+    try checkCancellation()
+    if fm.fileExists(atPath: move.destination.path) {
+      guard try CacheInventoryBuilder().build(rootURL: move.destination).isEmpty
+      else { throw CacheRootError.migrationRequired }
+      try fm.removeItem(at: move.destination)
+    }
+    try syncDirectories(move.staging)
+    try fm.moveItem(at: move.staging, to: move.destination)
+    try syncDirectory(parent)
+  }
+
+  static func finish(_ move: CacheRelocationRecord, committed: Bool) throws {
+    let fm = FileManager.default
+    if committed {
+      // Cleanup removes only inventoried source files whose bytes still match. A
+      // partial cleanup can be repeated; new/unrecognized files are always retained.
+      guard fm.fileExists(atPath: move.destination.path) else { throw CacheRootError.unavailable }
+      let marker = try DurableAtomicFileStore().read(
+        CacheMarker.self,
+        from: move.destination
+          .appendingPathComponent(CacheMarker.fileName)
+      )
+      guard marker.cacheID == move.cacheID else { throw CacheRootError.markerMismatch }
+      for entry in move.inventory {
+        let source = try contained(entry.relativePath, in: move.source)
+        guard fm.fileExists(atPath: source.path) else { continue }
+        let destination = try contained(entry.relativePath, in: move.destination)
+        guard try matches(source, entry), try matches(destination, entry) else {
+          throw CacheRootError.inconsistentActivation
+        }
+        try fm.removeItem(at: source)
+      }
+      // Preserve the old root and its control files. Removing empty account directories
+      // makes it usable again without deleting a user-selected folder or its siblings.
+      try pruneEmptyDirectories(move.source)
+    } else {
+      for url in [move.staging, move.destination] where fm.fileExists(atPath: url.path) {
+        let marker = try? DurableAtomicFileStore().read(
+          CacheMarker.self,
+          from: url
+            .appendingPathComponent(
+              CacheMarker
+                .fileName
+            )
+        )
+        guard marker?.cacheID == move.cacheID else {
+          // An existing destination rejected before copying belongs to somebody else.
+          if url == move.destination { continue }
+          throw CacheRootError.markerMismatch
+        }
+        try fm.removeItem(at: url)
+      }
+    }
+  }
+
+  private static func syncDirectory(_ url: URL) throws {
+    let descriptor = Darwin.open(url.path, O_RDONLY)
+    guard descriptor >= 0 else { throw POSIXError(.EIO) }
+    defer { Darwin.close(descriptor) }
+    guard Darwin.fsync(descriptor) == 0 else { throw POSIXError(.EIO) }
+  }
+
+  private static func syncDirectories(_ root: URL) throws {
+    for url in try FileManager.default.contentsOfDirectory(
+      at: root,
+      includingPropertiesForKeys: [
+        .isDirectoryKey,
+        .isSymbolicLinkKey,
+      ]
+    ) {
+      let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+      if values.isDirectory == true, values.isSymbolicLink != true { try syncDirectories(url) }
+    }
+    try syncDirectory(root)
+  }
+
+  private static func pruneEmptyDirectories(_ root: URL) throws {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: root.path) else { return }
+    for url in try fm.contentsOfDirectory(
+      at: root,
+      includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+    ) {
+      let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+      guard values.isDirectory == true, values.isSymbolicLink != true else { continue }
+      try pruneEmptyDirectories(url)
+      if try fm.contentsOfDirectory(atPath: url.path).isEmpty { try fm.removeItem(at: url) }
+    }
+  }
+
+  private static func matches(_ url: URL, _ entry: CacheInventoryEntry) throws -> Bool {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+    var hash = SHA256()
+    var bytes: Int64 = 0
+    while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+      hash.update(data: data)
+      bytes += Int64(data.count)
+    }
+    return bytes == entry.byteCount && hash.finalize().map { String(format: "%02x", $0) }
+      .joined() == entry.sha256
+  }
+
+  private static func contained(_ path: String, in root: URL) throws -> URL {
+    let relative = try CacheRelativePath(path)
+    var url = root.standardizedFileURL
+    for component in relative.components {
+      url.appendPathComponent(component)
+      if let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey]),
+         values.isSymbolicLink == true {
+        throw CacheRootError.pathEscapesRoot
+      }
+    }
+    return url
+  }
+}

--- a/AmperfyKit/Storage/ExternalCache.swift
+++ b/AmperfyKit/Storage/ExternalCache.swift
@@ -1,0 +1,2130 @@
+//
+//  ExternalCache.swift
+//  AmperfyKit
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+import CryptoKit
+import Darwin
+import Foundation
+
+// MARK: - CacheRootError
+
+public enum CacheRootError: Error, Equatable, Sendable {
+  case unavailable
+  case staleGeneration
+  case pathEscapesRoot
+  case markerMismatch
+  case insufficientCapacity(required: Int64, available: Int64)
+  case inconsistentActivation
+  case unsupportedBookmarkPlatform
+  case stagingLimitExceeded
+  case migrationRequired
+  case invalidPreparedSelection
+  case rollbackFailed
+}
+
+// MARK: - CacheRootGeneration
+
+public struct CacheRootGeneration: Codable, Equatable, Hashable, Sendable {
+  public let id: UUID
+
+  public init(id: UUID = UUID()) {
+    self.id = id
+  }
+}
+
+// MARK: - CacheRootRegistry
+
+/// Thread-safe runtime authority for the active cache root.
+///
+/// A root transition invalidates every previously issued lease. Final filesystem and Core Data
+/// commit boundaries must validate their lease against this registry again.
+public final class CacheRootRegistry: @unchecked Sendable {
+  private struct ActiveRoot {
+    let rootURL: URL
+    let generation: CacheRootGeneration
+    let stopAccessing: (@Sendable () -> ())?
+    let validateRoot: (@Sendable () throws -> ())?
+  }
+
+  private let lock = NSRecursiveLock()
+  private var activeRoot: ActiveRoot?
+  private var isSuspended = false
+
+  public init() {}
+
+  deinit {
+    lock.withLock {
+      activeRoot?.stopAccessing?()
+      activeRoot = nil
+    }
+  }
+
+  @discardableResult
+  public func activate(
+    rootURL: URL,
+    generation: CacheRootGeneration = CacheRootGeneration(),
+    stopAccessing: (@Sendable () -> ())? = nil,
+    validateRoot: (@Sendable () throws -> ())? = nil
+  )
+    -> CacheRootLease {
+    let standardizedRoot = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+    lock.withLock {
+      activeRoot?.stopAccessing?()
+      isSuspended = false
+      activeRoot = ActiveRoot(
+        rootURL: standardizedRoot,
+        generation: generation,
+        stopAccessing: stopAccessing,
+        validateRoot: validateRoot
+      )
+    }
+    return CacheRootLease(
+      rootURL: standardizedRoot,
+      generation: generation,
+      registry: self
+    )
+  }
+
+  public func block() {
+    lock.withLock {
+      activeRoot?.stopAccessing?()
+      activeRoot = nil
+    }
+  }
+
+  /// Stop new cache operations while retaining the source security scope for a move.
+  public func suspend() {
+    lock.withLock { isSuspended = true }
+  }
+
+  public func currentLease() throws -> CacheRootLease {
+    try lock.withLock {
+      guard let activeRoot, !isSuspended else { throw CacheRootError.unavailable }
+      try activeRoot.validateRoot?()
+      return CacheRootLease(
+        rootURL: activeRoot.rootURL,
+        generation: activeRoot.generation,
+        registry: self
+      )
+    }
+  }
+
+  fileprivate func validate(_ generation: CacheRootGeneration) throws {
+    try lock.withLock {
+      guard let activeRoot, !isSuspended else { throw CacheRootError.unavailable }
+      guard activeRoot.generation == generation else { throw CacheRootError.staleGeneration }
+      try activeRoot.validateRoot?()
+    }
+  }
+
+  fileprivate func performIfCurrent<T>(
+    generation: CacheRootGeneration,
+    operation: () throws -> T
+  ) throws
+    -> T {
+    try lock.withLock {
+      guard let activeRoot, !isSuspended else { throw CacheRootError.unavailable }
+      guard activeRoot.generation == generation else { throw CacheRootError.staleGeneration }
+      try activeRoot.validateRoot?()
+      return try operation()
+    }
+  }
+}
+
+// MARK: - CacheRelativePath
+
+/// A filesystem-relative cache path. It deliberately does not use URL parsing, so legal filename
+/// characters such as spaces, `#`, `%`, `?`, `:`, and composed/decomposed Unicode are preserved.
+public struct CacheRelativePath: Codable, Equatable, Hashable, Sendable {
+  public let string: String
+  public let components: [String]
+
+  public init(_ string: String) throws {
+    guard !string.isEmpty,
+          !string.hasPrefix("/"),
+          !string.contains("\0")
+    else { throw CacheRootError.pathEscapesRoot }
+    let components = string.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+    guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+      throw CacheRootError.pathEscapesRoot
+    }
+    self.string = string
+    self.components = components
+  }
+
+  public init(url: URL) throws {
+    try self.init(url.path)
+  }
+
+  fileprivate func appending(to rootURL: URL) -> URL {
+    components.reduce(rootURL) { partial, component in
+      partial.appendingPathComponent(component, isDirectory: false)
+    }
+  }
+}
+
+// MARK: - CacheRootLease
+
+public final class CacheRootLease: @unchecked Sendable {
+  public let rootURL: URL
+  public let generation: CacheRootGeneration
+  private let registry: CacheRootRegistry
+
+  fileprivate init(
+    rootURL: URL,
+    generation: CacheRootGeneration,
+    registry: CacheRootRegistry
+  ) {
+    self.rootURL = rootURL
+    self.generation = generation
+    self.registry = registry
+  }
+
+  public func validateCurrent() throws {
+    try registry.validate(generation)
+  }
+
+  public func performAtCommitBoundary<T>(_ operation: () throws -> T) throws -> T {
+    try registry.performIfCurrent(generation: generation, operation: operation)
+  }
+
+  public func resolve(relativePath: URL) throws -> URL {
+    try resolve(relativePath: CacheRelativePath(url: relativePath))
+  }
+
+  public func resolve(relativePath: CacheRelativePath) throws -> URL {
+    try validateCurrent()
+    return try secureContainedURL(relativePath)
+  }
+
+  /// Rejects every existing symbolic-link component and proves each resolved component remains
+  /// below the real leased root. Call again inside the final commit boundary to close ordinary
+  /// time-of-check/time-of-use windows against root transitions.
+  public func secureContainedURL(_ relativePath: CacheRelativePath) throws -> URL {
+    let realRoot = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+    var candidate = realRoot
+    for component in relativePath.components {
+      candidate.appendPathComponent(component, isDirectory: false)
+      var statBuffer = stat()
+      if lstat(candidate.path, &statBuffer) == 0 {
+        guard statBuffer.st_mode & S_IFMT != S_IFLNK else {
+          throw CacheRootError.pathEscapesRoot
+        }
+        let resolvedExisting = candidate.resolvingSymlinksInPath().standardizedFileURL
+        guard Self.isContained(resolvedExisting, by: realRoot) else {
+          throw CacheRootError.pathEscapesRoot
+        }
+      } else if errno != ENOENT {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+      }
+    }
+    let standardized = candidate.standardizedFileURL
+    guard Self.isContained(standardized, by: realRoot) else {
+      throw CacheRootError.pathEscapesRoot
+    }
+    return standardized
+  }
+
+  private static func isContained(_ candidate: URL, by root: URL) -> Bool {
+    if candidate.path == root.path { return true }
+    let rootPrefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
+    return candidate.path.hasPrefix(rootPrefix)
+  }
+}
+
+// MARK: - CacheLocationPreference
+
+public struct CacheLocationPreference: Codable, Equatable, Sendable {
+  public enum Mode: String, Codable, Sendable {
+    case `default`
+    case external
+  }
+
+  public static let currentSchemaVersion = 1
+
+  public var schemaVersion: Int
+  public var mode: Mode
+  public var bookmarkData: Data?
+  public var displayName: String?
+  public var cacheID: UUID?
+
+  public init(
+    schemaVersion: Int = Self.currentSchemaVersion,
+    mode: Mode,
+    bookmarkData: Data? = nil,
+    displayName: String? = nil,
+    cacheID: UUID? = nil
+  ) {
+    self.schemaVersion = schemaVersion
+    self.mode = mode
+    self.bookmarkData = bookmarkData
+    self.displayName = displayName
+    self.cacheID = cacheID
+  }
+}
+
+// MARK: - CacheMarker
+
+public struct CacheMarker: Codable, Equatable, Sendable {
+  public static let childDirectoryName = "Amperfy Cache"
+  public static let fileName = ".amperfy-cache.json"
+  public static let currentSchemaVersion = 1
+
+  public let schemaVersion: Int
+  public let cacheID: UUID
+
+  public init(schemaVersion: Int = Self.currentSchemaVersion, cacheID: UUID) {
+    self.schemaVersion = schemaVersion
+    self.cacheID = cacheID
+  }
+}
+
+// MARK: - ResolvedCacheBookmark
+
+public struct ResolvedCacheBookmark: Sendable {
+  public let url: URL
+  public let isStale: Bool
+
+  public init(url: URL, isStale: Bool) {
+    self.url = url
+    self.isStale = isStale
+  }
+}
+
+// MARK: - PreparedExternalCacheSelection
+
+/// A security-scoped, in-memory folder candidate. It owns exactly one scope access until it is
+/// cancelled or atomically transferred to the active root registry.
+public final class PreparedExternalCacheSelection: @unchecked Sendable {
+  public let parentURL: URL
+  public let bookmarkData: Data
+  public let availableCapacity: Int64
+
+  private enum ScopeState: Equatable {
+    case active
+    case transferred
+    case stopped
+  }
+
+  private let bookmarkClient: any SecurityScopedBookmarkClient
+  private let lock = NSLock()
+  private var scopeState: ScopeState = .active
+
+  fileprivate init(
+    parentURL: URL,
+    bookmarkData: Data,
+    availableCapacity: Int64,
+    bookmarkClient: any SecurityScopedBookmarkClient
+  ) {
+    self.parentURL = parentURL
+    self.bookmarkData = bookmarkData
+    self.availableCapacity = availableCapacity
+    self.bookmarkClient = bookmarkClient
+  }
+
+  deinit {
+    cancel()
+  }
+
+  public func cancel() {
+    let shouldStop = lock.withLock {
+      guard scopeState == .active else { return false }
+      scopeState = .stopped
+      return true
+    }
+    if shouldStop {
+      bookmarkClient.stopAccessing(parentURL)
+    }
+  }
+
+  fileprivate func transferScope() throws -> @Sendable () -> () {
+    try lock.withLock {
+      guard scopeState == .active else { throw CacheRootError.invalidPreparedSelection }
+      scopeState = .transferred
+      return { [bookmarkClient, parentURL] in
+        bookmarkClient.stopAccessing(parentURL)
+      }
+    }
+  }
+}
+
+// MARK: - SecurityScopedBookmarkClient
+
+public protocol SecurityScopedBookmarkClient: Sendable {
+  func createBookmark(for url: URL) throws -> Data
+  func resolveBookmark(_ data: Data) throws -> ResolvedCacheBookmark
+  func startAccessing(_ url: URL) -> Bool
+  func stopAccessing(_ url: URL)
+}
+
+// MARK: - FoundationSecurityScopedBookmarkClient
+
+public struct FoundationSecurityScopedBookmarkClient: SecurityScopedBookmarkClient {
+  public init() {}
+
+  public func createBookmark(for url: URL) throws -> Data {
+    #if targetEnvironment(macCatalyst) || os(macOS)
+      try url.bookmarkData(
+        options: [.withSecurityScope],
+        includingResourceValuesForKeys: nil,
+        relativeTo: nil
+      )
+    #else
+      throw CacheRootError.unsupportedBookmarkPlatform
+    #endif
+  }
+
+  public func resolveBookmark(_ data: Data) throws -> ResolvedCacheBookmark {
+    #if targetEnvironment(macCatalyst) || os(macOS)
+      var isStale = false
+      let url = try URL(
+        resolvingBookmarkData: data,
+        options: [.withSecurityScope, .withoutUI, .withoutMounting],
+        relativeTo: nil,
+        bookmarkDataIsStale: &isStale
+      )
+      return ResolvedCacheBookmark(url: url, isStale: isStale)
+    #else
+      throw CacheRootError.unsupportedBookmarkPlatform
+    #endif
+  }
+
+  public func startAccessing(_ url: URL) -> Bool {
+    url.startAccessingSecurityScopedResource()
+  }
+
+  public func stopAccessing(_ url: URL) {
+    url.stopAccessingSecurityScopedResource()
+  }
+}
+
+// MARK: - CacheRootHealth
+
+public enum CacheRootHealth: Equatable, Sendable {
+  case notConfigured
+  case resolving
+  case ready(rootURL: URL, availableCapacity: Int64)
+  case unavailable(reason: String)
+}
+
+// MARK: - CacheRootCoordinator
+
+/// Fail-closed bookmark and root bootstrap coordinator.
+///
+/// UIKit owns folder presentation. This coordinator owns the returned URL from selection through marker,
+/// bookmark, scope, health, and root-generation activation.
+public final class CacheRootCoordinator: @unchecked Sendable {
+  nonisolated(unsafe) private var _health: CacheRootHealth = .notConfigured
+  private let healthLock = NSLock()
+  public var health: CacheRootHealth { healthLock.withLock { _health } }
+
+  private let registry: CacheRootRegistry
+  private let bookmarkClient: any SecurityScopedBookmarkClient
+  private let capacityProvider: any CacheCapacityProviding
+  private let atomicStore: DurableAtomicFileStore
+
+  public init(
+    registry: CacheRootRegistry,
+    bookmarkClient: any SecurityScopedBookmarkClient = FoundationSecurityScopedBookmarkClient(),
+    capacityProvider: any CacheCapacityProviding = VolumeImportantUsageCapacityProvider(),
+    atomicStore: DurableAtomicFileStore = DurableAtomicFileStore()
+  ) {
+    self.registry = registry
+    self.bookmarkClient = bookmarkClient
+    self.capacityProvider = capacityProvider
+    self.atomicStore = atomicStore
+  }
+
+  func accessParent(for preference: CacheLocationPreference) throws
+    -> PreparedExternalCacheSelection {
+    guard let bookmark = preference.bookmarkData else { throw CacheRootError.unavailable }
+    let resolved = try bookmarkClient.resolveBookmark(bookmark)
+    return try prepareExternal(selectedParentURL: resolved.url)
+  }
+
+  private func setHealth(_ health: CacheRootHealth) {
+    healthLock.withLock { _health = health }
+  }
+
+  @discardableResult
+  public func activateDefault(rootURL: URL) throws -> CacheRootLease {
+    setHealth(.resolving)
+    do {
+      try verifyWritableDirectory(rootURL)
+      let availableCapacity = try capacityProvider.availableCapacity(at: rootURL)
+      let lease = registry.activate(rootURL: rootURL)
+      setHealth(.ready(rootURL: rootURL.standardizedFileURL, availableCapacity: availableCapacity))
+      return lease
+    } catch {
+      registry.block()
+      setHealth(.unavailable(reason: String(describing: error)))
+      throw error
+    }
+  }
+
+  /// Acquires a scoped, complete bookmark candidate without changing root health, registry state,
+  /// filesystem ownership, or durable preferences.
+  public func prepareExternal(selectedParentURL: URL) throws
+    -> PreparedExternalCacheSelection {
+    guard bookmarkClient.startAccessing(selectedParentURL) else {
+      throw CacheRootError.unavailable
+    }
+
+    do {
+      try verifyExistingWritableDirectory(selectedParentURL)
+      let availableCapacity = try capacityProvider.availableCapacity(at: selectedParentURL)
+      let bookmarkData = try bookmarkClient.createBookmark(for: selectedParentURL)
+      return PreparedExternalCacheSelection(
+        parentURL: selectedParentURL,
+        bookmarkData: bookmarkData,
+        availableCapacity: availableCapacity,
+        bookmarkClient: bookmarkClient
+      )
+    } catch {
+      bookmarkClient.stopAccessing(selectedParentURL)
+      throw error
+    }
+  }
+
+  /// Materializes a newly owned empty cache root after explicit user confirmation. Existing roots
+  /// are never adopted implicitly.
+  public func materializeExternal(
+    prepared: PreparedExternalCacheSelection,
+    transaction: ExternalCacheActivationTransaction
+  ) throws
+    -> CacheLocationPreference {
+    let rootURL = prepared.parentURL.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    guard rootURL.standardizedFileURL.path == transaction.newRootURL.standardizedFileURL.path else {
+      throw CacheRootError.inconsistentActivation
+    }
+    guard !FileManager.default.fileExists(atPath: rootURL.path) else {
+      throw CacheRootError.markerMismatch
+    }
+
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: false)
+    do {
+      let marker = CacheMarker(cacheID: transaction.cacheID)
+      try atomicStore.write(marker, to: rootURL.appendingPathComponent(CacheMarker.fileName))
+      try atomicStore.write(
+        transaction,
+        to: rootURL.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+      )
+      try verifyWritableDirectory(rootURL)
+      return CacheLocationPreference(
+        mode: .external,
+        bookmarkData: prepared.bookmarkData,
+        displayName: prepared.parentURL.lastPathComponent,
+        cacheID: transaction.cacheID
+      )
+    } catch {
+      try? FileManager.default.removeItem(at: rootURL)
+      throw error
+    }
+  }
+
+  @discardableResult
+  public func activatePreparedExternal(
+    prepared: PreparedExternalCacheSelection,
+    preference: CacheLocationPreference
+  ) throws
+    -> CacheRootLease {
+    guard preference.mode == .external,
+          preference.bookmarkData == prepared.bookmarkData,
+          let expectedCacheID = preference.cacheID
+    else { throw CacheRootError.inconsistentActivation }
+    let rootURL = prepared.parentURL.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    let marker = try atomicStore.read(
+      CacheMarker.self,
+      from: rootURL.appendingPathComponent(CacheMarker.fileName)
+    )
+    guard marker.cacheID == expectedCacheID else { throw CacheRootError.markerMismatch }
+    try verifyWritableDirectory(rootURL)
+    let stopAccessing = try prepared.transferScope()
+    let lease = registry.activate(
+      rootURL: rootURL,
+      stopAccessing: stopAccessing,
+      validateRoot: Self.markerValidator(
+        rootURL: rootURL,
+        cacheID: expectedCacheID
+      )
+    )
+    setHealth(.ready(rootURL: lease.rootURL, availableCapacity: prepared.availableCapacity))
+    return lease
+  }
+
+  @discardableResult
+  public func activateExistingPreparedExternal(
+    prepared: PreparedExternalCacheSelection,
+    expectedCacheID: UUID
+  ) throws
+    -> (preference: CacheLocationPreference, lease: CacheRootLease) {
+    let rootURL = prepared.parentURL.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    let marker = try atomicStore.read(
+      CacheMarker.self,
+      from: rootURL.appendingPathComponent(CacheMarker.fileName)
+    )
+    guard marker.cacheID == expectedCacheID else { throw CacheRootError.markerMismatch }
+    let preference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: prepared.bookmarkData,
+      displayName: prepared.parentURL.lastPathComponent,
+      cacheID: marker.cacheID
+    )
+    let lease = try activatePreparedExternal(prepared: prepared, preference: preference)
+    return (preference, lease)
+  }
+
+  public func resolveExternal(
+    preference: CacheLocationPreference
+  ) throws
+    -> CacheLocationPreference {
+    setHealth(.resolving)
+    guard preference.mode == .external,
+          let bookmarkData = preference.bookmarkData,
+          let expectedCacheID = preference.cacheID
+    else {
+      registry.block()
+      setHealth(.unavailable(reason: "external cache preference is incomplete"))
+      throw CacheRootError.unavailable
+    }
+
+    do {
+      let resolved = try bookmarkClient.resolveBookmark(bookmarkData)
+      guard bookmarkClient.startAccessing(resolved.url) else {
+        throw CacheRootError.unavailable
+      }
+      do {
+        let rootURL = resolved.url.appendingPathComponent(
+          CacheMarker.childDirectoryName,
+          isDirectory: true
+        )
+        let marker = try atomicStore.read(
+          CacheMarker.self,
+          from: rootURL.appendingPathComponent(CacheMarker.fileName)
+        )
+        guard marker.cacheID == expectedCacheID else { throw CacheRootError.markerMismatch }
+        try verifyWritableDirectory(rootURL)
+        let availableCapacity = try capacityProvider.availableCapacity(at: rootURL)
+        let refreshedBookmark = resolved.isStale
+          ? try bookmarkClient.createBookmark(for: resolved.url)
+          : bookmarkData
+        registry.activate(rootURL: rootURL, stopAccessing: { [bookmarkClient] in
+          bookmarkClient.stopAccessing(resolved.url)
+        }, validateRoot: Self.markerValidator(rootURL: rootURL, cacheID: expectedCacheID))
+        setHealth(.ready(
+          rootURL: rootURL.standardizedFileURL,
+          availableCapacity: availableCapacity
+        ))
+        return CacheLocationPreference(
+          mode: .external,
+          bookmarkData: refreshedBookmark,
+          displayName: resolved.url.lastPathComponent,
+          cacheID: marker.cacheID
+        )
+      } catch {
+        bookmarkClient.stopAccessing(resolved.url)
+        throw error
+      }
+    } catch {
+      registry.block()
+      setHealth(.unavailable(reason: String(describing: error)))
+      throw error
+    }
+  }
+
+  private static func markerValidator(rootURL: URL, cacheID: UUID) -> @Sendable () throws -> () {
+    {
+      let marker = try DurableAtomicFileStore().read(
+        CacheMarker.self,
+        from: rootURL
+          .appendingPathComponent(CacheMarker.fileName)
+      )
+      guard marker.cacheID == cacheID else { throw CacheRootError.markerMismatch }
+    }
+  }
+
+  public func block(reason: String) {
+    registry.block()
+    setHealth(.unavailable(reason: reason))
+  }
+
+  private func verifyWritableDirectory(_ directoryURL: URL) throws {
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    let probeURL = directoryURL.appendingPathComponent(".amperfy-write-probe-\(UUID().uuidString)")
+    do {
+      try Data().write(to: probeURL, options: [.atomic])
+      try FileManager.default.removeItem(at: probeURL)
+    } catch {
+      try? FileManager.default.removeItem(at: probeURL)
+      throw error
+    }
+  }
+
+  private func verifyExistingWritableDirectory(_ directoryURL: URL) throws {
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory),
+          isDirectory.boolValue
+    else { throw CacheRootError.unavailable }
+    let probeURL = directoryURL.appendingPathComponent(
+      ".amperfy-selection-probe-\(UUID().uuidString)"
+    )
+    do {
+      try Data().write(to: probeURL, options: [.atomic])
+      try FileManager.default.removeItem(at: probeURL)
+    } catch {
+      try? FileManager.default.removeItem(at: probeURL)
+      throw error
+    }
+  }
+}
+
+// MARK: - CacheLocationPreferenceStoring
+
+public protocol CacheLocationPreferenceStoring: Sendable {
+  func load() throws -> CacheLocationPreference
+  func save(_ preference: CacheLocationPreference) throws
+}
+
+// MARK: - UserDefaultsCacheLocationPreferenceStore
+
+public final class UserDefaultsCacheLocationPreferenceStore: @unchecked Sendable,
+  CacheLocationPreferenceStoring {
+  public static let key = "cache.location.preference.v1"
+
+  private let defaults: UserDefaults
+  private let key: String
+
+  public init(
+    defaults: UserDefaults = .standard,
+    key: String = UserDefaultsCacheLocationPreferenceStore.key
+  ) {
+    self.defaults = defaults
+    self.key = key
+  }
+
+  public func load() throws -> CacheLocationPreference {
+    guard let data = defaults.data(forKey: key) else {
+      return CacheLocationPreference(mode: .default)
+    }
+    return try JSONDecoder().decode(CacheLocationPreference.self, from: data)
+  }
+
+  public func save(_ preference: CacheLocationPreference) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    defaults.set(try encoder.encode(preference), forKey: key)
+  }
+}
+
+// MARK: - CacheLocationConfigurationPaths
+
+public enum CacheLocationConfigurationPaths {
+  public static var directoryURL: URL {
+    let applicationSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? FileManager.default.temporaryDirectory
+    return applicationSupport
+      .appendingPathComponent("Amperfy", isDirectory: true)
+      .appendingPathComponent("CacheLocation", isDirectory: true)
+  }
+
+  public static var preferenceURL: URL {
+    directoryURL.appendingPathComponent("configuration.json")
+  }
+
+  public static var activationURL: URL {
+    directoryURL.appendingPathComponent("activation.json")
+  }
+}
+
+// MARK: - DurableCacheLocationPreferenceStore
+
+/// Authoritative app-container configuration. UserDefaults is written only as a UI projection and
+/// is never consulted when the durable file is absent or inconsistent.
+public final class DurableCacheLocationPreferenceStore: @unchecked Sendable,
+  CacheLocationPreferenceStoring {
+  public let configurationURL: URL
+
+  private let atomicStore: DurableAtomicFileStore
+  private let projection: (any CacheLocationPreferenceStoring)?
+
+  public init(
+    configurationURL: URL = CacheLocationConfigurationPaths.preferenceURL,
+    atomicStore: DurableAtomicFileStore = DurableAtomicFileStore(),
+    projection: (any CacheLocationPreferenceStoring)? = UserDefaultsCacheLocationPreferenceStore()
+  ) {
+    self.configurationURL = configurationURL
+    self.atomicStore = atomicStore
+    self.projection = projection
+  }
+
+  public func load() throws -> CacheLocationPreference {
+    guard FileManager.default.fileExists(atPath: configurationURL.path) else {
+      return CacheLocationPreference(mode: .default)
+    }
+    return try atomicStore.read(CacheLocationPreference.self, from: configurationURL)
+  }
+
+  public func save(_ preference: CacheLocationPreference) throws {
+    try atomicStore.write(preference, to: configurationURL)
+    try projection?.save(preference)
+  }
+}
+
+// MARK: - ExternalCacheActivationPhase
+
+public enum ExternalCacheActivationPhase: String, Codable, Sendable {
+  case prepared
+  case destinationMaterialized
+  case preferencePersisted
+  case registryActivated
+  case completed
+  case rolledBack
+  case blocked
+}
+
+// MARK: - ExternalCacheActivationTransaction
+
+public struct ExternalCacheActivationTransaction: Codable, Equatable, Sendable {
+  public let transactionID: UUID
+  public let cacheID: UUID
+  public let oldPreference: CacheLocationPreference
+  public let oldRootURL: URL
+  public let newPreference: CacheLocationPreference
+  public let newRootURL: URL
+  public var phase: ExternalCacheActivationPhase
+  public var failureDescription: String?
+
+  public init(
+    transactionID: UUID = UUID(),
+    cacheID: UUID,
+    oldPreference: CacheLocationPreference,
+    oldRootURL: URL,
+    newPreference: CacheLocationPreference,
+    newRootURL: URL,
+    phase: ExternalCacheActivationPhase,
+    failureDescription: String? = nil
+  ) {
+    self.transactionID = transactionID
+    self.cacheID = cacheID
+    self.oldPreference = oldPreference
+    self.oldRootURL = oldRootURL
+    self.newPreference = newPreference
+    self.newRootURL = newRootURL
+    self.phase = phase
+    self.failureDescription = failureDescription
+  }
+}
+
+// MARK: - ExternalCacheActivationStoring
+
+public protocol ExternalCacheActivationStoring: Sendable {
+  func load() throws -> ExternalCacheActivationTransaction?
+  func save(_ transaction: ExternalCacheActivationTransaction) throws
+}
+
+// MARK: - DurableExternalCacheActivationStore
+
+public final class DurableExternalCacheActivationStore: @unchecked Sendable,
+  ExternalCacheActivationStoring {
+  public let transactionURL: URL
+  private let atomicStore: DurableAtomicFileStore
+
+  public init(
+    transactionURL: URL = CacheLocationConfigurationPaths.activationURL,
+    atomicStore: DurableAtomicFileStore = DurableAtomicFileStore()
+  ) {
+    self.transactionURL = transactionURL
+    self.atomicStore = atomicStore
+  }
+
+  public func load() throws -> ExternalCacheActivationTransaction? {
+    guard FileManager.default.fileExists(atPath: transactionURL.path) else { return nil }
+    return try atomicStore.read(ExternalCacheActivationTransaction.self, from: transactionURL)
+  }
+
+  public func save(_ transaction: ExternalCacheActivationTransaction) throws {
+    try atomicStore.write(transaction, to: transactionURL)
+  }
+}
+
+// MARK: - CacheDirectActivationInventoryGate
+
+/// Direct activation is allowed only for a structurally empty root. An empty top-level `accounts`
+/// directory is an initialized layout, not an account subtree; anything below it requires migration.
+public struct CacheDirectActivationInventoryGate: Sendable {
+  private let atomicStore: DurableAtomicFileStore
+
+  public init(atomicStore: DurableAtomicFileStore = DurableAtomicFileStore()) {
+    self.atomicStore = atomicStore
+  }
+
+  public func validate(rootURL: URL) throws {
+    guard FileManager.default.fileExists(atPath: rootURL.path) else { return }
+    guard let enumerator = FileManager.default.enumerator(
+      at: rootURL,
+      includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+      options: []
+    ) else { return }
+
+    let rootPrefix = rootURL.standardizedFileURL.path + "/"
+    var markerURL: URL?
+    var receiptURL: URL?
+    while let itemURL = enumerator.nextObject() as? URL {
+      let itemPath = itemURL.standardizedFileURL.path
+      guard itemPath.hasPrefix(rootPrefix) else { throw CacheRootError.pathEscapesRoot }
+      let relative = try CacheRelativePath(String(itemPath.dropFirst(rootPrefix.count)))
+      let values = try itemURL.resourceValues(forKeys: [
+        .isDirectoryKey,
+        .isRegularFileKey,
+        .isSymbolicLinkKey,
+      ])
+      guard values.isSymbolicLink != true else { throw CacheRootError.migrationRequired }
+      if values.isDirectory == true,
+         relative.components == ["accounts"] {
+        continue
+      }
+      if values.isRegularFile == true,
+         relative.components == [CacheMarker.fileName] {
+        markerURL = itemURL
+        continue
+      }
+      if values.isRegularFile == true,
+         relative.components == [CacheMigrationEngine.receiptFileName] {
+        receiptURL = itemURL
+        continue
+      }
+      throw CacheRootError.migrationRequired
+    }
+
+    guard markerURL != nil || receiptURL != nil else { return }
+    guard let markerURL, let receiptURL else { throw CacheRootError.migrationRequired }
+    let marker = try atomicStore.read(CacheMarker.self, from: markerURL)
+    guard marker.schemaVersion == CacheMarker.currentSchemaVersion,
+          try isResolvedReceipt(receiptURL, marker: marker)
+    else { throw CacheRootError.migrationRequired }
+  }
+
+  private func isResolvedReceipt(_ receiptURL: URL, marker: CacheMarker) throws -> Bool {
+    if let transaction = try? atomicStore.read(
+      ExternalCacheActivationTransaction.self,
+      from: receiptURL
+    ) {
+      return transaction.phase == .completed &&
+        transaction.cacheID == marker.cacheID
+    }
+    if let receipt = try? atomicStore.read(CacheActivationReceipt.self, from: receiptURL) {
+      return receipt.phase == .activated && receipt.cacheID == marker.cacheID
+    }
+    return false
+  }
+}
+
+// MARK: - CacheBootstrapState
+
+public enum CacheBootstrapState: Equatable, Sendable {
+  case unresolved
+  case resolving
+  case ready(preference: CacheLocationPreference, rootURL: URL)
+  case blocked(reason: String)
+}
+
+// MARK: - CacheLocationPresentation
+
+/// Deterministic, dependency-free presentation state shared by Settings and the blocked shell.
+public struct CacheLocationPresentation: Equatable, Sendable {
+  public let statusText: String
+  public let blocksNormalOperation: Bool
+
+  public init(state: CacheBootstrapState) {
+    switch state {
+    case let .ready(preference, rootURL):
+      let label = preference.mode == .default ? "Default" : "External"
+      self.init(statusText: "\(label) — \(rootURL.path)", blocksNormalOperation: false)
+    case let .blocked(reason):
+      self.init(statusText: "Unavailable — \(reason)", blocksNormalOperation: true)
+    case .resolving:
+      self.init(statusText: "Checking cache location…", blocksNormalOperation: true)
+    case .unresolved:
+      self.init(statusText: "Not checked", blocksNormalOperation: true)
+    }
+  }
+
+  private init(statusText: String, blocksNormalOperation: Bool) {
+    self.statusText = statusText
+    self.blocksNormalOperation = blocksNormalOperation
+  }
+}
+
+// MARK: - PendingCacheLocationSelection
+
+/// Ephemeral folder-picker state. Choosing a folder records only an in-memory candidate; durable
+/// bookmark creation, root activation, and migration belong to a separately confirmed workflow.
+public struct PendingCacheLocationSelection: Equatable, Sendable {
+  public private(set) var isPickerPresented = false
+  public private(set) var parentURL: URL?
+
+  public init() {}
+
+  public mutating func beginChoosing() {
+    isPickerPresented = true
+  }
+
+  public mutating func select(_ url: URL) {
+    parentURL = url
+    isPickerPresented = false
+  }
+
+  public mutating func cancel() {
+    isPickerPresented = false
+  }
+
+  public mutating func clear() {
+    isPickerPresented = false
+    parentURL = nil
+  }
+}
+
+// MARK: - CacheRootRuntime
+
+/// The sole production bootstrap authority. Its registry begins blocked. Neither the default root
+/// nor an external root becomes visible to any cache consumer until `bootstrap()` resolves the
+/// persisted preference and the coordinator completes its health checks.
+public final class CacheRootRuntime: @unchecked Sendable {
+  public static let shared = CacheRootRuntime()
+
+  public let registry: CacheRootRegistry
+  public let coordinator: CacheRootCoordinator
+  public let fileManager: CacheFileManager
+
+  private let preferenceStore: any CacheLocationPreferenceStoring
+  private let activationStore: any ExternalCacheActivationStoring
+  private let inventoryGate: CacheDirectActivationInventoryGate
+  private let atomicStore: DurableAtomicFileStore
+  private let activationBoundary: @Sendable (ExternalCacheActivationPhase) throws -> ()
+  private let defaultRootProvider: @Sendable () throws -> URL
+  private let stateLock = NSLock()
+  private let operationLock = NSLock()
+  private let relocationURL: URL
+  nonisolated(unsafe) private var _state: CacheBootstrapState = .unresolved
+
+  public var state: CacheBootstrapState { stateLock.withLock { _state } }
+
+  public init(
+    registry: CacheRootRegistry = CacheRootRegistry(),
+    preferenceStore: any CacheLocationPreferenceStoring =
+      DurableCacheLocationPreferenceStore(),
+    activationStore: any ExternalCacheActivationStoring =
+      DurableExternalCacheActivationStore(),
+    inventoryGate: CacheDirectActivationInventoryGate = CacheDirectActivationInventoryGate(),
+    defaultRootProvider: @escaping @Sendable () throws -> URL = CacheRootRuntime
+      .defaultInternalRoot,
+    bookmarkClient: any SecurityScopedBookmarkClient = FoundationSecurityScopedBookmarkClient(),
+    capacityProvider: any CacheCapacityProviding = VolumeImportantUsageCapacityProvider(),
+    atomicStore: DurableAtomicFileStore = DurableAtomicFileStore(),
+    backgroundStagingRoot: URL? = nil,
+    relocationURL: URL = CacheLocationConfigurationPaths.preferenceURL.deletingLastPathComponent()
+      .appendingPathComponent("relocation.json"),
+    activationBoundary: @escaping @Sendable (ExternalCacheActivationPhase) throws -> () = { _ in }
+  ) {
+    self.registry = registry
+    self.relocationURL = relocationURL
+    self.preferenceStore = preferenceStore
+    self.activationStore = activationStore
+    self.inventoryGate = inventoryGate
+    self.atomicStore = atomicStore
+    self.activationBoundary = activationBoundary
+    self.defaultRootProvider = defaultRootProvider
+    self.coordinator = CacheRootCoordinator(
+      registry: registry,
+      bookmarkClient: bookmarkClient,
+      capacityProvider: capacityProvider,
+      atomicStore: atomicStore
+    )
+    self.fileManager = CacheFileManager(
+      rootRegistry: registry,
+      backgroundStagingRoot: backgroundStagingRoot
+    )
+  }
+
+  @discardableResult
+  public func bootstrap() throws -> CacheBootstrapState {
+    setState(.resolving)
+    registry.block()
+    do {
+      try reconcileInterruptedActivation()
+      let storedPreference = try preferenceStore.load()
+      let resolvedPreference: CacheLocationPreference
+      let lease: CacheRootLease
+      switch storedPreference.mode {
+      case .default:
+        lease = try coordinator.activateDefault(rootURL: defaultRootProvider())
+        resolvedPreference = CacheLocationPreference(mode: .default)
+      case .external:
+        resolvedPreference = try coordinator.resolveExternal(preference: storedPreference)
+        lease = try registry.currentLease()
+        if resolvedPreference != storedPreference {
+          try preferenceStore.save(resolvedPreference)
+        }
+      }
+      try fileManager.rootDidActivate(using: lease)
+      let ready = CacheBootstrapState.ready(
+        preference: resolvedPreference,
+        rootURL: lease.rootURL
+      )
+      setState(ready)
+      return ready
+    } catch {
+      registry.block()
+      fileManager.rootDidBlock()
+      let blocked = CacheBootstrapState.blocked(reason: String(describing: error))
+      setState(blocked)
+      throw error
+    }
+  }
+
+  /// Preflights a UIKit-selected folder while the current Ready root remains active.
+  @discardableResult
+  public func prepareExternal(selectedParentURL: URL) throws
+    -> PreparedExternalCacheSelection {
+    guard operationLock.try() else { throw CacheRootError.unavailable }
+    defer { operationLock.unlock() }
+    guard case .ready = state else { throw CacheRootError.unavailable }
+    return try coordinator.prepareExternal(selectedParentURL: selectedParentURL)
+  }
+
+  /// Confirms a prepared selection using a durable app-container transaction and mirrored
+  /// destination receipt. Every ordinary failure restores the prior complete Ready root.
+  @discardableResult
+  public func confirmPreparedExternal(
+    _ prepared: PreparedExternalCacheSelection
+  ) throws
+    -> CacheLocationPreference {
+    guard operationLock.try() else { throw CacheRootError.unavailable }
+    defer { operationLock.unlock() }
+    guard case let .ready(oldPreference, oldRootURL) = state else {
+      throw CacheRootError.unavailable
+    }
+    let oldLease = try registry.currentLease()
+    try oldLease.validateCurrent()
+    try inventoryGate.validate(rootURL: oldRootURL)
+
+    let cacheID = UUID()
+    let newRootURL = prepared.parentURL.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    let newPreference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: prepared.bookmarkData,
+      displayName: prepared.parentURL.lastPathComponent,
+      cacheID: cacheID
+    )
+    var transaction = ExternalCacheActivationTransaction(
+      cacheID: cacheID,
+      oldPreference: oldPreference,
+      oldRootURL: oldRootURL,
+      newPreference: newPreference,
+      newRootURL: newRootURL,
+      phase: .prepared
+    )
+    var destinationWasMaterialized = false
+
+    do {
+      try persist(transaction, mirrorToDestination: false)
+      try activationBoundary(.prepared)
+
+      let materializedPreference = try coordinator.materializeExternal(
+        prepared: prepared,
+        transaction: transaction
+      )
+      destinationWasMaterialized = true
+      guard materializedPreference == newPreference else {
+        throw CacheRootError.inconsistentActivation
+      }
+      transaction.phase = .destinationMaterialized
+      try persist(transaction, mirrorToDestination: true)
+      try activationBoundary(.destinationMaterialized)
+
+      try preferenceStore.save(newPreference)
+      transaction.phase = .preferencePersisted
+      try persist(transaction, mirrorToDestination: true)
+      try activationBoundary(.preferencePersisted)
+
+      let lease = try coordinator.activatePreparedExternal(
+        prepared: prepared,
+        preference: newPreference
+      )
+      transaction.phase = .registryActivated
+      try persist(transaction, mirrorToDestination: true)
+      try activationBoundary(.registryActivated)
+
+      try fileManager.rootDidActivate(using: lease)
+      transaction.phase = .completed
+      try persist(transaction, mirrorToDestination: true)
+      try activationBoundary(.completed)
+
+      setState(.ready(preference: newPreference, rootURL: lease.rootURL))
+      return newPreference
+    } catch {
+      do {
+        try rollbackActivation(
+          transaction: &transaction,
+          destinationWasMaterialized: destinationWasMaterialized,
+          originalError: error
+        )
+        prepared.cancel()
+      } catch {
+        prepared.cancel()
+        coordinator.block(reason: "external cache activation rollback failed")
+        fileManager.rootDidBlock()
+        transaction.phase = .blocked
+        transaction.failureDescription = String(describing: error)
+        try? persist(transaction, mirrorToDestination: destinationWasMaterialized)
+        setState(.blocked(reason: "external cache activation rollback failed"))
+        throw CacheRootError.rollbackFailed
+      }
+      throw error
+    }
+  }
+
+  /// Re-selects the already configured cache after a stale bookmark or reconnect. A different
+  /// cache ID is rejected; selecting a new destination belongs to the migration workflow.
+  @discardableResult
+  public func reselectConfiguredExternal(selectedParentURL: URL) throws
+    -> CacheLocationPreference {
+    guard operationLock.try() else { throw CacheRootError.unavailable }
+    defer { operationLock.unlock() }
+    let stored = try preferenceStore.load()
+    guard stored.mode == .external, let cacheID = stored.cacheID else {
+      throw CacheRootError.unavailable
+    }
+    let prepared = try coordinator.prepareExternal(selectedParentURL: selectedParentURL)
+    do {
+      let activated = try coordinator.activateExistingPreparedExternal(
+        prepared: prepared,
+        expectedCacheID: cacheID
+      )
+      try preferenceStore.save(activated.preference)
+      try fileManager.rootDidActivate(using: activated.lease)
+      setState(.ready(preference: activated.preference, rootURL: activated.lease.rootURL))
+      return activated.preference
+    } catch {
+      prepared.cancel()
+      coordinator.block(reason: String(describing: error))
+      fileManager.rootDidBlock()
+      setState(.blocked(reason: String(describing: error)))
+      throw error
+    }
+  }
+
+  public func block(reason: String) {
+    coordinator.block(reason: reason)
+    fileManager.rootDidBlock()
+    setState(.blocked(reason: reason))
+  }
+
+  private func setState(_ state: CacheBootstrapState) {
+    let changed = stateLock.withLock {
+      let changed = _state != state
+      _state = state
+      return changed
+    }
+    if changed { NotificationCenter.default.post(name: Self.didChangeNotification, object: nil) }
+  }
+
+  private func persist(
+    _ transaction: ExternalCacheActivationTransaction,
+    mirrorToDestination: Bool
+  ) throws {
+    try activationStore.save(transaction)
+    if mirrorToDestination {
+      try atomicStore.write(
+        transaction,
+        to: transaction.newRootURL.appendingPathComponent(
+          CacheMigrationEngine.receiptFileName
+        )
+      )
+    }
+  }
+
+  private func rollbackActivation(
+    transaction: inout ExternalCacheActivationTransaction,
+    destinationWasMaterialized: Bool,
+    originalError: Error
+  ) throws {
+    try preferenceStore.save(transaction.oldPreference)
+    try restoreRoot(
+      preference: transaction.oldPreference,
+      rootURL: transaction.oldRootURL
+    )
+    if destinationWasMaterialized {
+      try removeOwnedDestination(transaction)
+    }
+    transaction.phase = .rolledBack
+    transaction.failureDescription = String(describing: originalError)
+    try persist(transaction, mirrorToDestination: false)
+    setState(.ready(
+      preference: transaction.oldPreference,
+      rootURL: transaction.oldRootURL.standardizedFileURL.resolvingSymlinksInPath()
+    ))
+  }
+
+  private func restoreRoot(preference: CacheLocationPreference, rootURL: URL) throws {
+    let lease: CacheRootLease
+    switch preference.mode {
+    case .default:
+      lease = try coordinator.activateDefault(rootURL: rootURL)
+    case .external:
+      _ = try coordinator.resolveExternal(preference: preference)
+      lease = try registry.currentLease()
+    }
+    try fileManager.rootDidActivate(using: lease)
+  }
+
+  private func removeOwnedDestination(_ transaction: ExternalCacheActivationTransaction) throws {
+    guard FileManager.default.fileExists(atPath: transaction.newRootURL.path) else { return }
+    let marker = try atomicStore.read(
+      CacheMarker.self,
+      from: transaction.newRootURL.appendingPathComponent(CacheMarker.fileName)
+    )
+    guard marker.cacheID == transaction.cacheID else { throw CacheRootError.markerMismatch }
+    let allowed = Set([CacheMarker.fileName, CacheMigrationEngine.receiptFileName])
+    let contents = try FileManager.default.contentsOfDirectory(atPath: transaction.newRootURL.path)
+    guard Set(contents).isSubset(of: allowed) else { throw CacheRootError.rollbackFailed }
+    try FileManager.default.removeItem(at: transaction.newRootURL)
+  }
+
+  private func reconcileInterruptedActivation() throws {
+    guard var transaction = try activationStore.load() else { return }
+    switch transaction.phase {
+    case .completed:
+      return
+    case .rolledBack:
+      try preferenceStore.save(transaction.oldPreference)
+    case .blocked:
+      throw CacheRootError.inconsistentActivation
+    case .prepared:
+      try preferenceStore.save(transaction.oldPreference)
+      transaction.phase = .rolledBack
+      try persist(transaction, mirrorToDestination: false)
+    case .destinationMaterialized, .preferencePersisted:
+      let mirrored = try atomicStore.read(
+        ExternalCacheActivationTransaction.self,
+        from: transaction.newRootURL.appendingPathComponent(
+          CacheMigrationEngine.receiptFileName
+        )
+      )
+      guard mirrored == transaction else { throw CacheRootError.inconsistentActivation }
+      try preferenceStore.save(transaction.oldPreference)
+      try removeOwnedDestination(transaction)
+      transaction.phase = .rolledBack
+      try persist(transaction, mirrorToDestination: false)
+    case .registryActivated:
+      let mirrored = try atomicStore.read(
+        ExternalCacheActivationTransaction.self,
+        from: transaction.newRootURL.appendingPathComponent(
+          CacheMigrationEngine.receiptFileName
+        )
+      )
+      guard mirrored == transaction,
+            try preferenceStore.load() == transaction.newPreference
+      else { throw CacheRootError.inconsistentActivation }
+      transaction.phase = .completed
+      try persist(transaction, mirrorToDestination: true)
+    }
+  }
+
+  public static let didChangeNotification = Notification.Name("AmperfyCacheLocationDidChange")
+
+  public var isCacheAvailable: Bool {
+    if case .ready = state { return true }
+    return false
+  }
+
+  public func configuredPreference() throws -> CacheLocationPreference {
+    try preferenceStore.load()
+  }
+
+  public func availableCapacity() throws -> Int64 {
+    try VolumeImportantUsageCapacityProvider()
+      .availableCapacity(at: registry.currentLease().rootURL)
+  }
+
+  public func cacheInventorySize() throws -> Int64 {
+    let lease = try registry.currentLease()
+    return try lease.performAtCommitBoundary {
+      var scanError: Error?
+      guard let files = FileManager.default.enumerator(
+        at: lease.rootURL,
+        includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+        errorHandler: { _, error in scanError = error; return false }
+      ) else {
+        throw CacheRootError.unavailable
+      }
+      var size: Int64 = 0
+      for case let url as URL in files {
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        if values.isRegularFile == true { size += Int64(values.fileSize ?? 0) }
+      }
+      if let scanError { throw scanError }
+      return size
+    }
+  }
+
+  /// Polling checks the identity rather than trusting a mount path that may have been reused.
+  public func refreshAvailability() {
+    guard operationLock.try() else { return }
+    defer { operationLock.unlock() }
+    if case let .ready(preference, root) = state {
+      guard preference.mode == .external else { return }
+      do {
+        let marker = try atomicStore.read(
+          CacheMarker.self,
+          from: root.appendingPathComponent(CacheMarker.fileName)
+        )
+        guard marker.cacheID == preference.cacheID else { throw CacheRootError.markerMismatch }
+        return
+      } catch {
+        coordinator.block(reason: "Reconnect the drive containing your cache.")
+        setState(.blocked(reason: "Reconnect the drive containing your cache."))
+      }
+    } else if case .blocked = state {
+      _ = try? bootstrap()
+    }
+  }
+
+  public var hasUnfinishedMove: Bool {
+    FileManager.default.fileExists(atPath: relocationURL.path)
+  }
+
+  /// A failed or interrupted copy never changes the authoritative preference. A committed
+  /// copy is authoritative even if removing the old copy was interrupted.
+  public func finishInterruptedMove() throws {
+    guard operationLock.try() else { throw CacheRootError.unavailable }
+    defer { operationLock.unlock() }
+    try finishRelocation()
+  }
+
+  private func finishRelocation() throws {
+    guard hasUnfinishedMove else { return }
+    let move = try atomicStore.read(CacheRelocationRecord.self, from: relocationURL)
+    let current = try preferenceStore.load()
+    let committed = current.mode == move.newPreference.mode && current.cacheID == move.newPreference
+      .cacheID
+    guard committed || current == move.oldPreference
+    else { throw CacheRootError.inconsistentActivation }
+    let preference = committed ? move.oldPreference : move.newPreference
+    let access = preference.mode == .external ? try coordinator.accessParent(for: preference) : nil
+    defer { access?.cancel() }
+    let expectedRoot = committed ? move.source : move.destination
+    let resolvedRoot = try access?.parentURL.appendingPathComponent(CacheMarker.childDirectoryName)
+      ?? defaultRootProvider()
+    guard resolvedRoot.standardizedFileURL.resolvingSymlinksInPath().path == expectedRoot
+      .standardizedFileURL.resolvingSymlinksInPath().path else {
+      throw CacheRootError.markerMismatch
+    }
+    try CacheRelocationCopy.finish(move, committed: committed)
+    try FileManager.default.removeItem(at: relocationURL)
+  }
+
+  /// Run away from the main actor. The registry excludes all cache consumers during the
+  /// copy; the original security scope remains alive until activation has completed.
+  public func relocateCache(
+    to prepared: PreparedExternalCacheSelection?,
+    progress: @escaping @Sendable (CacheMoveProgress) -> (),
+    checkCancellation: @escaping @Sendable () throws -> () = {}
+  ) throws {
+    guard operationLock.try() else { throw CacheRootError.unavailable }
+    defer { operationLock.unlock(); prepared?.cancel() }
+    try finishRelocation()
+    guard case let .ready(oldPreference, source) = state else { throw CacheRootError.unavailable }
+    let destination = try prepared?.parentURL.appendingPathComponent(CacheMarker.childDirectoryName)
+      ?? defaultRootProvider()
+    guard source.standardizedFileURL != destination.standardizedFileURL,
+          !destination.path.hasPrefix(source.path + "/"),
+          !source.path.hasPrefix(destination.path + "/")
+    else { throw CacheRootError.invalidPreparedSelection }
+    let cacheID = UUID()
+    let preference = prepared.map {
+      CacheLocationPreference(
+        mode: .external,
+        bookmarkData: $0.bookmarkData,
+        displayName: $0.parentURL.lastPathComponent,
+        cacheID: cacheID
+      )
+    } ?? CacheLocationPreference(mode: .default)
+    // Keep independent access to the old drive until verified cleanup has finished.
+    let sourceAccess = oldPreference.mode == .external ? try coordinator
+      .accessParent(for: oldPreference) : nil
+    defer { sourceAccess?.cancel() }
+    _ = try registry.currentLease()
+    registry.suspend()
+    setState(.resolving)
+    do {
+      progress(CacheMoveProgress(message: "Checking downloaded files…"))
+      let inventory = try CacheInventoryBuilder().build(
+        rootURL: source,
+        checkCancellation: checkCancellation
+      )
+      try checkCancellation()
+      let move = CacheRelocationRecord(
+        source: source,
+        destination: destination,
+        oldPreference: oldPreference,
+        newPreference: preference,
+        cacheID: cacheID,
+        inventory: inventory
+      )
+      try atomicStore.write(move, to: relocationURL)
+      try CacheRelocationCopy.copy(move, progress: progress, checkCancellation: checkCancellation)
+      try checkCancellation()
+      progress(CacheMoveProgress(message: "Switching cache location…"))
+      // The single durable preference write is the commit point. On either side of a
+      // crash, finishRelocation can identify the authoritative copy without guessing.
+      try preferenceStore.save(preference)
+      _ = try bootstrap()
+      progress(CacheMoveProgress(message: "Removing the previous copy…"))
+      try CacheRelocationCopy.finish(move, committed: true)
+      try FileManager.default.removeItem(at: relocationURL)
+    } catch {
+      _ = try? bootstrap()
+      // Cleanup is idempotent. If a drive disappeared, retain the journal for Retry.
+      try? finishRelocation()
+      throw error
+    }
+  }
+
+  public static func defaultInternalRoot() throws -> URL {
+    if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil,
+       let injectedTestRoot = ProcessInfo.processInfo.environment["AMPERFY_CACHE_TEST_ROOT"],
+       !injectedTestRoot.isEmpty {
+      return URL(fileURLWithPath: injectedTestRoot, isDirectory: true)
+    }
+    guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+      throw CacheRootError.unavailable
+    }
+    let libraryURL = try FileManager.default.url(
+      for: .libraryDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: false
+    )
+    return libraryURL.appendingPathComponent(bundleIdentifier, isDirectory: true)
+  }
+}
+
+// MARK: - DurableAtomicFileStore
+
+public struct DurableAtomicFileStore: Sendable {
+  public init() {}
+
+  public func write<T: Encodable>(_ value: T, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    try write(encoder.encode(value), to: url)
+  }
+
+  public func read<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
+    try JSONDecoder().decode(type, from: Data(contentsOf: url))
+  }
+
+  public func write(_ data: Data, to url: URL) throws {
+    let fileManager = FileManager.default
+    let directory = url.deletingLastPathComponent()
+    try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    let temporaryURL = directory
+      .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+
+    guard fileManager.createFile(atPath: temporaryURL.path, contents: nil) else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+
+    do {
+      let handle = try FileHandle(forWritingTo: temporaryURL)
+      try handle.write(contentsOf: data)
+      try handle.synchronize()
+      try handle.close()
+
+      guard Darwin.rename(temporaryURL.path, url.path) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+      }
+      try synchronizeDirectory(at: directory)
+    } catch {
+      try? fileManager.removeItem(at: temporaryURL)
+      throw error
+    }
+  }
+
+  private func synchronizeDirectory(at url: URL) throws {
+    let descriptor = Darwin.open(url.path, O_RDONLY)
+    guard descriptor >= 0 else {
+      throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    defer { Darwin.close(descriptor) }
+    guard Darwin.fsync(descriptor) == 0 else {
+      throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+  }
+}
+
+// MARK: - CacheMigrationPhase
+
+public enum CacheMigrationPhase: String, Codable, Sendable {
+  case planned
+  case copying
+  case verifying
+  case readyToActivate
+  case activated
+  case accepted
+  case sourceRetired
+}
+
+// MARK: - CacheInventoryEntry
+
+public struct CacheInventoryEntry: Codable, Equatable, Sendable {
+  public let relativePath: String
+  public let byteCount: Int64
+  public let sha256: String
+
+  public init(relativePath: String, byteCount: Int64, sha256: String) {
+    self.relativePath = relativePath
+    self.byteCount = byteCount
+    self.sha256 = sha256
+  }
+}
+
+// MARK: - CacheMigrationJournal
+
+public struct CacheMigrationJournal: Codable, Equatable, Sendable {
+  public let transactionID: UUID
+  public let sourceCacheID: UUID
+  public let destinationCacheID: UUID
+  public var phase: CacheMigrationPhase
+  public let inventory: [CacheInventoryEntry]
+
+  public init(
+    transactionID: UUID,
+    sourceCacheID: UUID,
+    destinationCacheID: UUID,
+    phase: CacheMigrationPhase,
+    inventory: [CacheInventoryEntry]
+  ) {
+    self.transactionID = transactionID
+    self.sourceCacheID = sourceCacheID
+    self.destinationCacheID = destinationCacheID
+    self.phase = phase
+    self.inventory = inventory
+  }
+
+  public var inventoryBytes: Int64 {
+    inventory.reduce(0) { $0 + $1.byteCount }
+  }
+
+  public var inventoryDigest: String {
+    let canonical = inventory.sorted { $0.relativePath < $1.relativePath }
+      .map { "\($0.relativePath)\u{0}\($0.byteCount)\u{0}\($0.sha256)" }
+      .joined(separator: "\n")
+    return SHA256.hash(data: Data(canonical.utf8)).map { String(format: "%02x", $0) }.joined()
+  }
+}
+
+// MARK: - CacheActivationReceipt
+
+public struct CacheActivationReceipt: Codable, Equatable, Sendable {
+  public let transactionID: UUID
+  public let cacheID: UUID
+  public let inventoryDigest: String
+  public let phase: CacheMigrationPhase
+
+  public init(
+    transactionID: UUID,
+    cacheID: UUID,
+    inventoryDigest: String,
+    phase: CacheMigrationPhase = .activated
+  ) {
+    self.transactionID = transactionID
+    self.cacheID = cacheID
+    self.inventoryDigest = inventoryDigest
+    self.phase = phase
+  }
+}
+
+// MARK: - CacheActivationReconciliation
+
+public enum CacheActivationReconciliation: Equatable, Sendable {
+  case sourceActiveResumeOrAbandon
+  case blockCompleteReceiptsOrRollback
+  case destinationActive
+  case blockedInconsistent
+}
+
+// MARK: - CacheActivationEvidence
+
+public struct CacheActivationEvidence: Sendable {
+  public var finalDirectoryExists: Bool
+  public var destinationMarker: CacheMarker?
+  public var appReceipt: CacheActivationReceipt?
+  public var destinationReceipt: CacheActivationReceipt?
+  public var preferenceCacheID: UUID?
+
+  public init(
+    finalDirectoryExists: Bool,
+    destinationMarker: CacheMarker?,
+    appReceipt: CacheActivationReceipt?,
+    destinationReceipt: CacheActivationReceipt?,
+    preferenceCacheID: UUID?
+  ) {
+    self.finalDirectoryExists = finalDirectoryExists
+    self.destinationMarker = destinationMarker
+    self.appReceipt = appReceipt
+    self.destinationReceipt = destinationReceipt
+    self.preferenceCacheID = preferenceCacheID
+  }
+}
+
+// MARK: - CacheActivationReconciler
+
+public struct CacheActivationReconciler: Sendable {
+  public init() {}
+
+  public func reconcile(
+    journal: CacheMigrationJournal,
+    evidence: CacheActivationEvidence
+  )
+    -> CacheActivationReconciliation {
+    let expectedReceipt = CacheActivationReceipt(
+      transactionID: journal.transactionID,
+      cacheID: journal.destinationCacheID,
+      inventoryDigest: journal.inventoryDigest
+    )
+    let markerMatches = evidence.destinationMarker?.cacheID == journal.destinationCacheID
+    let appMatches = evidence.appReceipt == expectedReceipt
+    let destinationMatches = evidence.destinationReceipt == expectedReceipt
+
+    if !evidence.finalDirectoryExists,
+       evidence.destinationMarker == nil,
+       evidence.appReceipt == nil,
+       evidence.destinationReceipt == nil,
+       evidence.preferenceCacheID != journal.destinationCacheID {
+      return .sourceActiveResumeOrAbandon
+    }
+
+    if evidence.finalDirectoryExists,
+       markerMatches,
+       appMatches,
+       destinationMatches {
+      return .destinationActive
+    }
+
+    if evidence.finalDirectoryExists,
+       markerMatches,
+       appMatches || destinationMatches || evidence.preferenceCacheID == journal
+       .destinationCacheID {
+      return .blockCompleteReceiptsOrRollback
+    }
+
+    return .blockedInconsistent
+  }
+}
+
+// MARK: - CacheCapacityPolicy
+
+public struct CacheCapacityPolicy: Sendable {
+  public static let fiveGiB: Int64 = 5 * 1024 * 1024 * 1024
+
+  public init() {}
+
+  public func reserveBytes(for inventoryBytes: Int64) -> Int64 {
+    max(Self.fiveGiB, inventoryBytes / 10)
+  }
+
+  public func requiredCapacity(for inventoryBytes: Int64) -> Int64 {
+    inventoryBytes + reserveBytes(for: inventoryBytes)
+  }
+
+  public func validate(available: Int64, inventoryBytes: Int64) throws {
+    let required = requiredCapacity(for: inventoryBytes)
+    guard available >= required else {
+      throw CacheRootError.insufficientCapacity(required: required, available: available)
+    }
+  }
+}
+
+// MARK: - BackgroundStagingPolicy
+
+public struct BackgroundStagingPolicy: Sendable {
+  public static let twoGiB: Int64 = 2 * 1024 * 1024 * 1024
+  public static let maximumAge: TimeInterval = 24 * 60 * 60
+
+  public let absoluteByteLimit: Int64
+  public let containerCapacityFractionDivisor: Int64
+  public let maximumAge: TimeInterval
+
+  public init(
+    absoluteByteLimit: Int64 = Self.twoGiB,
+    containerCapacityFractionDivisor: Int64 = 10,
+    maximumAge: TimeInterval = Self.maximumAge
+  ) {
+    self.absoluteByteLimit = absoluteByteLimit
+    self.containerCapacityFractionDivisor = containerCapacityFractionDivisor
+    self.maximumAge = maximumAge
+  }
+
+  public func byteLimit(containerAvailableCapacity: Int64) -> Int64 {
+    min(absoluteByteLimit, containerAvailableCapacity / containerCapacityFractionDivisor)
+  }
+
+  public func permits(
+    stagedBytes: Int64,
+    oldestItemAge: TimeInterval,
+    containerAvailableCapacity: Int64
+  )
+    -> Bool {
+    stagedBytes <= byteLimit(containerAvailableCapacity: containerAvailableCapacity) &&
+      oldestItemAge <= maximumAge
+  }
+}
+
+// MARK: - CacheFileCommitReceipt
+
+/// Durable app-container evidence for the filesystem half of a cache/Core Data transaction.
+/// The recoverable staging file remains present until the Core Data commit succeeds.
+public struct CacheFileCommitReceipt: Codable, Equatable, Sendable {
+  public enum Phase: String, Codable, Sendable {
+    case staged
+    case filesystemCommitted
+  }
+
+  public let transactionID: UUID
+  public let relativeDestinationPath: String
+  public let stagedFileName: String
+  public let byteCount: Int64
+  public let sha256: String
+  public var phase: Phase
+
+  public init(
+    transactionID: UUID,
+    relativeDestinationPath: String,
+    stagedFileName: String,
+    byteCount: Int64,
+    sha256: String,
+    phase: Phase
+  ) {
+    self.transactionID = transactionID
+    self.relativeDestinationPath = relativeDestinationPath
+    self.stagedFileName = stagedFileName
+    self.byteCount = byteCount
+    self.sha256 = sha256
+    self.phase = phase
+  }
+}
+
+// MARK: - CacheInventoryBuilder
+
+public struct CacheInventoryBuilder: Sendable {
+  public static let rootControlFileNames: Set<String> = [
+    CacheMarker.fileName,
+    CacheMigrationEngine.journalFileName,
+    CacheMigrationEngine.receiptFileName,
+  ]
+
+  private let excludedRootControlFileNames: Set<String>
+
+  public init(excludedRootControlFileNames: Set<String> = Self.rootControlFileNames) {
+    self.excludedRootControlFileNames = excludedRootControlFileNames
+  }
+
+  public func build(
+    rootURL: URL,
+    checkCancellation: @Sendable () throws -> () = {}
+  ) throws
+    -> [CacheInventoryEntry] {
+    try checkCancellation()
+    let fileManager = FileManager.default
+    let rootValues = try rootURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+    guard rootValues.isDirectory == true, rootValues.isSymbolicLink != true else {
+      throw CacheRootError.pathEscapesRoot
+    }
+    var enumerationError: Error?
+    guard let enumerator = fileManager.enumerator(
+      at: rootURL,
+      includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey],
+      options: [], errorHandler: { _, error in enumerationError = error; return false }
+    ) else { throw CacheRootError.unavailable }
+
+    var entries = [CacheInventoryEntry]()
+    while let itemURL = enumerator.nextObject() as? URL {
+      try checkCancellation()
+      let values = try itemURL.resourceValues(forKeys: [
+        .isRegularFileKey,
+        .isSymbolicLinkKey,
+        .fileSizeKey,
+      ])
+      guard values.isSymbolicLink != true else { throw CacheRootError.pathEscapesRoot }
+      guard values.isRegularFile == true else { continue }
+
+      let rootPath = rootURL.standardizedFileURL.path.hasSuffix("/")
+        ? rootURL.standardizedFileURL.path
+        : rootURL.standardizedFileURL.path + "/"
+      let itemPath = itemURL.standardizedFileURL.path
+      guard itemPath.hasPrefix(rootPath) else { throw CacheRootError.pathEscapesRoot }
+      let relativePath = String(itemPath.dropFirst(rootPath.count))
+      let safeRelativePath = try CacheRelativePath(relativePath)
+      if safeRelativePath.components.count == 1,
+         excludedRootControlFileNames.contains(safeRelativePath.components[0]) {
+        continue
+      }
+      let handle = try FileHandle(forReadingFrom: itemURL)
+      defer { try? handle.close() }
+      var hash = SHA256()
+      var byteCount: Int64 = 0
+      while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+        try checkCancellation()
+        hash.update(data: data)
+        byteCount += Int64(data.count)
+      }
+      let digest = hash.finalize().map { String(format: "%02x", $0) }.joined()
+      entries.append(CacheInventoryEntry(
+        relativePath: safeRelativePath.string,
+        byteCount: byteCount,
+        sha256: digest
+      ))
+    }
+    if let enumerationError { throw enumerationError }
+    return entries.sorted { $0.relativePath < $1.relativePath }
+  }
+}
+
+// MARK: - CacheCapacityProviding
+
+public protocol CacheCapacityProviding: Sendable {
+  func availableCapacity(at url: URL) throws -> Int64
+}
+
+// MARK: - VolumeImportantUsageCapacityProvider
+
+public struct VolumeImportantUsageCapacityProvider: CacheCapacityProviding {
+  public init() {}
+
+  public func availableCapacity(at url: URL) throws -> Int64 {
+    let values = try url.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+    return values.volumeAvailableCapacityForImportantUsage ?? 0
+  }
+}
+
+// MARK: - CacheMigrationEngine
+
+/// Copy/verify/activate engine. Callers must quiesce all cache consumers before invoking it.
+/// The source is never deleted by this type.
+public struct CacheMigrationEngine: Sendable {
+  public static let journalFileName = ".amperfy-migration.json"
+  public static let receiptFileName = ".amperfy-activation.json"
+
+  private let inventoryBuilder: CacheInventoryBuilder
+  private let capacityProvider: any CacheCapacityProviding
+  private let capacityPolicy: CacheCapacityPolicy
+  private let atomicStore: DurableAtomicFileStore
+
+  public init(
+    inventoryBuilder: CacheInventoryBuilder = CacheInventoryBuilder(),
+    capacityProvider: any CacheCapacityProviding = VolumeImportantUsageCapacityProvider(),
+    capacityPolicy: CacheCapacityPolicy = CacheCapacityPolicy(),
+    atomicStore: DurableAtomicFileStore = DurableAtomicFileStore()
+  ) {
+    self.inventoryBuilder = inventoryBuilder
+    self.capacityProvider = capacityProvider
+    self.capacityPolicy = capacityPolicy
+    self.atomicStore = atomicStore
+  }
+
+  public func makeJournal(
+    sourceRoot: URL,
+    sourceCacheID: UUID,
+    destinationCacheID: UUID = UUID(),
+    transactionID: UUID = UUID()
+  ) throws
+    -> CacheMigrationJournal {
+    CacheMigrationJournal(
+      transactionID: transactionID,
+      sourceCacheID: sourceCacheID,
+      destinationCacheID: destinationCacheID,
+      phase: .planned,
+      inventory: try inventoryBuilder.build(rootURL: sourceRoot)
+    )
+  }
+
+  /// Copies and verifies a planned journal, atomically renames the final cache directory, writes
+  /// authoritative receipts, then updates the non-authoritative preference projection.
+  public func migrate(
+    journal initialJournal: CacheMigrationJournal,
+    sourceRoot: URL,
+    destinationParent: URL,
+    appContainerJournalURL: URL,
+    activationPreference: CacheLocationPreference,
+    projectPreference: @Sendable (CacheLocationPreference) throws -> ()
+  ) throws
+    -> URL {
+    let fileManager = FileManager.default
+    let finalRoot = destinationParent.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    guard !fileManager.fileExists(atPath: finalRoot.path) else {
+      throw CocoaError(.fileWriteFileExists)
+    }
+    guard activationPreference.mode == .external,
+          activationPreference.bookmarkData != nil,
+          activationPreference.cacheID == initialJournal.destinationCacheID
+    else { throw CacheRootError.inconsistentActivation }
+
+    var journal = initialJournal
+    let reserve = capacityPolicy.reserveBytes(for: journal.inventoryBytes)
+    try capacityPolicy.validate(
+      available: capacityProvider.availableCapacity(at: destinationParent),
+      inventoryBytes: journal.inventoryBytes
+    )
+
+    let stagingContainer = destinationParent.appendingPathComponent(
+      ".amperfy-migration-\(journal.transactionID.uuidString)",
+      isDirectory: true
+    )
+    let stagingRoot = stagingContainer.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    let destinationJournalURL = stagingContainer.appendingPathComponent(Self.journalFileName)
+    try fileManager.createDirectory(at: stagingRoot, withIntermediateDirectories: true)
+
+    journal.phase = .copying
+    try atomicStore.write(journal, to: appContainerJournalURL)
+    try atomicStore.write(journal, to: destinationJournalURL)
+
+    var copiedBytes: Int64 = 0
+    for entry in journal.inventory {
+      let remainingBytes = journal.inventoryBytes - copiedBytes
+      let available = try capacityProvider.availableCapacity(at: destinationParent)
+      guard available >= remainingBytes + reserve else {
+        throw CacheRootError.insufficientCapacity(
+          required: remainingBytes + reserve,
+          available: available
+        )
+      }
+
+      let relativePath = try CacheRelativePath(entry.relativePath)
+      let sourceURL = try containedURL(relativePath, below: sourceRoot)
+      let destinationURL = try containedURL(relativePath, below: stagingRoot)
+      try fileManager.createDirectory(
+        at: destinationURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      if fileManager.fileExists(atPath: destinationURL.path),
+         try fileMatchesInventory(destinationURL, entry: entry) {
+        copiedBytes += entry.byteCount
+        continue
+      }
+      try? fileManager.removeItem(at: destinationURL)
+      let partialURL = destinationURL.deletingLastPathComponent().appendingPathComponent(
+        ".\(destinationURL.lastPathComponent).\(journal.transactionID.uuidString).partial"
+      )
+      if fileManager.fileExists(atPath: partialURL.path) {
+        if try fileMatchesInventory(partialURL, entry: entry) {
+          guard Darwin.rename(partialURL.path, destinationURL.path) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+          }
+          copiedBytes += entry.byteCount
+          continue
+        }
+        try fileManager.removeItem(at: partialURL)
+      }
+      try fileManager.copyItem(at: sourceURL, to: partialURL)
+      let partialHandle = try FileHandle(forWritingTo: partialURL)
+      try partialHandle.synchronize()
+      try partialHandle.close()
+      guard try fileMatchesInventory(partialURL, entry: entry) else {
+        throw CacheRootError.inconsistentActivation
+      }
+      guard Darwin.rename(partialURL.path, destinationURL.path) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+      }
+      copiedBytes += entry.byteCount
+    }
+
+    journal.phase = .verifying
+    try atomicStore.write(journal, to: appContainerJournalURL)
+    try atomicStore.write(journal, to: destinationJournalURL)
+    let copiedInventory = try inventoryBuilder.build(rootURL: stagingRoot)
+    guard copiedInventory == journal.inventory else { throw CacheRootError.inconsistentActivation }
+
+    let marker = CacheMarker(cacheID: journal.destinationCacheID)
+    try atomicStore.write(marker, to: stagingRoot.appendingPathComponent(CacheMarker.fileName))
+    journal.phase = .readyToActivate
+    try atomicStore.write(journal, to: appContainerJournalURL)
+    try atomicStore.write(journal, to: destinationJournalURL)
+
+    try fileManager.moveItem(at: stagingRoot, to: finalRoot)
+    let finalDestinationJournalURL = finalRoot.appendingPathComponent(Self.journalFileName)
+    journal.phase = .activated
+    try atomicStore.write(journal, to: finalDestinationJournalURL)
+    let receipt = CacheActivationReceipt(
+      transactionID: journal.transactionID,
+      cacheID: journal.destinationCacheID,
+      inventoryDigest: journal.inventoryDigest
+    )
+    try atomicStore.write(receipt, to: finalRoot.appendingPathComponent(Self.receiptFileName))
+
+    try projectPreference(activationPreference)
+    try atomicStore.write(
+      receipt,
+      to: appContainerJournalURL.deletingLastPathComponent()
+        .appendingPathComponent(Self.receiptFileName)
+    )
+    try atomicStore.write(journal, to: appContainerJournalURL)
+    try? fileManager.removeItem(at: stagingContainer)
+    return finalRoot
+  }
+
+  private func containedURL(_ relativePath: CacheRelativePath, below rootURL: URL) throws -> URL {
+    let standardizedRoot = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+    let rootPath = standardizedRoot.path.hasSuffix("/")
+      ? standardizedRoot.path
+      : standardizedRoot.path + "/"
+    var result = standardizedRoot
+    for component in relativePath.components {
+      result.appendPathComponent(component, isDirectory: false)
+      var statBuffer = stat()
+      if lstat(result.path, &statBuffer) == 0,
+         statBuffer.st_mode & S_IFMT == S_IFLNK {
+        throw CacheRootError.pathEscapesRoot
+      }
+    }
+    result = result.standardizedFileURL
+    guard result.path.hasPrefix(rootPath) else { throw CacheRootError.pathEscapesRoot }
+    return result
+  }
+
+  private func fileMatchesInventory(_ url: URL, entry: CacheInventoryEntry) throws -> Bool {
+    let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+    guard Int64(data.count) == entry.byteCount else { return false }
+    let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    return digest == entry.sha256
+  }
+}

--- a/AmperfyKit/Storage/LibraryStorage.swift
+++ b/AmperfyKit/Storage/LibraryStorage.swift
@@ -25,6 +25,8 @@ import os.log
 
 // MARK: - PlayableFileCachable
 
+/// Legacy test seam retained while player tests are migrated. Production playback no longer uses
+/// this URL projection; `BackendAudioPlayer` holds its generation lease through insertion instead.
 protocol PlayableFileCachable {
   func getFileURL(forPlayable playable: AbstractPlayable) -> URL?
 }
@@ -2894,19 +2896,18 @@ public class LibraryStorage: PlayableFileCachable {
     return playlistDict
   }
 
+  /// Legacy test-only URL projection. Production reads must use `CacheFileManager.withCacheFile`.
   func getFileURL(forPlayable playable: AbstractPlayable) -> URL? {
-    var absFileURL: URL?
-    if let relFilePath = playable.relFilePath {
-      absFileURL = fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath)
-    } else {
+    guard let relFilePath = playable.relFilePath else {
       os_log(
         "File URL was not able to retrieve for: %s",
         log: log,
         type: .error,
         playable.displayString
       )
+      return nil
     }
-    return absFileURL
+    return fileManager.getAbsoluteAmperfyPath(relFilePath: relFilePath)
   }
 
   public func cleanStorageOfObsoleteAccountEntries(account: Account) {

--- a/AmperfyKit/Storage/PersistentStorage.swift
+++ b/AmperfyKit/Storage/PersistentStorage.swift
@@ -95,6 +95,33 @@ public actor AsyncCoreDataAccessWrapper {
     }
     return syncRequestedValue
   }
+
+  /// Performs a Core Data mutation only when a caller-supplied final commit validation succeeds.
+  /// Unlike the legacy `perform` APIs, this method propagates errors and rolls back instead of
+  /// saving changes from a failed body.
+  public func performWithCommitValidation<T: Sendable>(
+    body: @escaping @Sendable (_ asyncCompanion: CoreDataCompanion) throws -> T,
+    validateBeforeSave: @escaping @Sendable () throws -> ()
+  ) async throws
+    -> T {
+    let context = persistentContainer.newBackgroundContext()
+    NSPersistentContainer.configureContext(context)
+
+    return try await context.perform {
+      let asyncCompanion = CoreDataCompanion(context: context)
+      do {
+        let result = try body(asyncCompanion)
+        try validateBeforeSave()
+        if context.hasChanges {
+          try context.save()
+        }
+        return result
+      } catch {
+        context.rollback()
+        throw error
+      }
+    }
+  }
 }
 
 // MARK: - PersistentStorage

--- a/AmperfyKitTests/Cases/Storage/CacheRelocationTest.swift
+++ b/AmperfyKitTests/Cases/Storage/CacheRelocationTest.swift
@@ -1,0 +1,304 @@
+//
+//  CacheRelocationTest.swift
+//  AmperfyKit
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+@testable import AmperfyKit
+import XCTest
+
+// MARK: - CacheRelocationTest
+
+final class CacheRelocationTest: XCTestCase {
+  private var root: URL!
+  override func setUpWithError() throws {
+    root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws { try FileManager.default.removeItem(at: root) }
+
+  private func runtime(store: RelocationPreferenceStore) -> CacheRootRuntime {
+    CacheRootRuntime(
+      preferenceStore: store,
+      activationStore: DurableExternalCacheActivationStore(
+        transactionURL: root
+          .appendingPathComponent("activation.json")
+      ),
+      defaultRootProvider: { [root = root!] in
+        root.appendingPathComponent("internal")
+      },
+      bookmarkClient: RelocationBookmarkClient(),
+      relocationURL: root.appendingPathComponent("relocation.json")
+    )
+  }
+
+  private func destination() throws -> URL {
+    let parent = root.appendingPathComponent("external")
+    try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+    return parent
+  }
+
+  private func writePayload(_ source: URL) throws -> URL {
+    let file = source.appendingPathComponent("accounts/server/user/songs/a # % ?.mp3")
+    try FileManager.default.createDirectory(
+      at: file.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try Data(repeating: 47, count: 2 * 1024 * 1024).write(to: file)
+    return file
+  }
+
+  func testRoundTripPreservesBytesAndMovesBackToBuiltInStorage() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let internalRoot = try runtime.registry.currentLease().rootURL
+    let source = try writePayload(internalRoot)
+    let expected = try Data(contentsOf: source)
+    let parent = try destination()
+    let oldLease = try runtime.registry.currentLease()
+    try runtime.relocateCache(
+      to: runtime.prepareExternal(selectedParentURL: parent),
+      progress: { _ in }
+    )
+    XCTAssertThrowsError(try oldLease.validateCurrent())
+    XCTAssertEqual(try store.load().mode, .external)
+    let externalRoot = try runtime.registry.currentLease().rootURL
+    let file = externalRoot.appendingPathComponent("accounts/server/user/songs/a # % ?.mp3")
+    XCTAssertEqual(try Data(contentsOf: file), expected)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: source.path))
+    XCTAssertFalse(runtime.hasUnfinishedMove)
+    try runtime.relocateCache(to: nil, progress: { _ in })
+    XCTAssertEqual(try store.load().mode, .default)
+    XCTAssertEqual(try Data(contentsOf: source), expected)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: file.path))
+  }
+
+  func testCancellationDuringInventoryLeavesSourceAvailable() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let source = try writePayload(runtime.registry.currentLease().rootURL)
+    let parent = try destination()
+    XCTAssertThrowsError(try runtime.relocateCache(
+      to: runtime.prepareExternal(selectedParentURL: parent),
+      progress: { _ in },
+      checkCancellation: { throw CancellationError() }
+    ))
+    XCTAssertEqual(try store.load().mode, .default)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    XCTAssertTrue(try FileManager.default.contentsOfDirectory(atPath: parent.path).isEmpty)
+    XCTAssertFalse(runtime.hasUnfinishedMove)
+    XCTAssertTrue(runtime.isCacheAvailable)
+  }
+
+  func testCancellationDuringCopyPreservesSourceAndCleansTemporaryFiles() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let source = try writePayload(runtime.registry.currentLease().rootURL)
+    let parent = try destination()
+    let cancel = RelocationCancellation()
+    XCTAssertThrowsError(try runtime.relocateCache(
+      to: runtime.prepareExternal(selectedParentURL: parent),
+      progress: { update in if update.completedBytes > 0 { cancel.cancel() } },
+      checkCancellation: { try cancel.check() }
+    ))
+    XCTAssertEqual(try store.load().mode, .default)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    XCTAssertTrue(try FileManager.default.contentsOfDirectory(atPath: parent.path).isEmpty)
+    XCTAssertFalse(runtime.hasUnfinishedMove)
+    XCTAssertTrue(runtime.isCacheAvailable)
+  }
+
+  func testPreferenceFailureRollsBackVerifiedDestination() throws {
+    let store = RelocationPreferenceStore(failExternalSave: true)
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let source = try writePayload(runtime.registry.currentLease().rootURL)
+    let parent = try destination()
+    XCTAssertThrowsError(try runtime.relocateCache(
+      to: runtime.prepareExternal(selectedParentURL: parent),
+      progress: { _ in }
+    ))
+    XCTAssertEqual(try store.load().mode, .default)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    XCTAssertTrue(try FileManager.default.contentsOfDirectory(atPath: parent.path).isEmpty)
+  }
+
+  func testRecoveryAfterCopyBeforePreferenceCommitKeepsOriginal() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let sourceRoot = try runtime.registry.currentLease().rootURL
+    let file = try writePayload(sourceRoot)
+    let parent = try destination()
+    let prepared = try runtime.prepareExternal(selectedParentURL: parent)
+    defer { prepared.cancel() }
+    let id = UUID()
+    let move = CacheRelocationRecord(
+      source: sourceRoot,
+      destination: parent
+        .appendingPathComponent(CacheMarker.childDirectoryName),
+      oldPreference: try store.load(),
+      newPreference: CacheLocationPreference(
+        mode: .external,
+        bookmarkData: prepared.bookmarkData,
+        displayName: parent.lastPathComponent,
+        cacheID: id
+      ),
+      cacheID: id,
+      inventory: try CacheInventoryBuilder()
+        .build(rootURL: sourceRoot)
+    )
+    try DurableAtomicFileStore().write(move, to: root.appendingPathComponent("relocation.json"))
+    try CacheRelocationCopy.copy(move, progress: { _ in }, checkCancellation: {})
+    let restarted = self.runtime(store: store)
+    try restarted.bootstrap()
+    try restarted.finishInterruptedMove()
+    XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: move.destination.path))
+    XCTAssertFalse(restarted.hasUnfinishedMove)
+  }
+
+  func testRecoveryAfterPreferenceCommitFinishesSourceCleanup() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let sourceRoot = try runtime.registry.currentLease().rootURL
+    let original = try writePayload(sourceRoot)
+    let parent = try destination()
+    let prepared = try runtime.prepareExternal(selectedParentURL: parent)
+    defer { prepared.cancel() }
+    let id = UUID()
+    let preference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: prepared.bookmarkData,
+      displayName: parent.lastPathComponent,
+      cacheID: id
+    )
+    let move = CacheRelocationRecord(
+      source: sourceRoot,
+      destination: parent
+        .appendingPathComponent(CacheMarker.childDirectoryName),
+      oldPreference: try store.load(),
+      newPreference: preference,
+      cacheID: id,
+      inventory: try CacheInventoryBuilder()
+        .build(rootURL: sourceRoot)
+    )
+    try DurableAtomicFileStore().write(move, to: root.appendingPathComponent("relocation.json"))
+    try CacheRelocationCopy.copy(move, progress: { _ in }, checkCancellation: {})
+    try store.save(preference)
+    let restarted = self.runtime(store: store)
+    try restarted.bootstrap()
+    try restarted.finishInterruptedMove()
+    XCTAssertFalse(FileManager.default.fileExists(atPath: original.path))
+    XCTAssertTrue(FileManager.default.fileExists(
+      atPath: move.destination
+        .appendingPathComponent("accounts/server/user/songs/a # % ?.mp3").path
+    ))
+    XCTAssertFalse(restarted.hasUnfinishedMove)
+  }
+
+  func testPopulatedDestinationIsNeverOverwritten() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    let source = try writePayload(runtime.registry.currentLease().rootURL)
+    let parent = try destination()
+    let existing = parent.appendingPathComponent(CacheMarker.childDirectoryName)
+    let otherFile = try writePayload(existing)
+    let marker = CacheMarker(cacheID: UUID())
+    try DurableAtomicFileStore().write(
+      marker,
+      to: existing.appendingPathComponent(CacheMarker.fileName)
+    )
+    XCTAssertThrowsError(try runtime.relocateCache(
+      to: runtime.prepareExternal(selectedParentURL: parent),
+      progress: { _ in }
+    ))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: otherFile.path))
+    XCTAssertEqual(try DurableAtomicFileStore().read(
+      CacheMarker.self,
+      from: existing.appendingPathComponent(CacheMarker.fileName)
+    ), marker)
+    XCTAssertTrue(runtime.isCacheAvailable)
+  }
+
+  func testMissingSourceCannotBeInventoriedAsEmpty() throws {
+    XCTAssertThrowsError(
+      try CacheInventoryBuilder()
+        .build(rootURL: root.appendingPathComponent("missing"))
+    )
+  }
+
+  func testUnpluggedCacheRejectsLeaseAndReconnectsWithoutFallback() throws {
+    let store = RelocationPreferenceStore()
+    let runtime = runtime(store: store)
+    try runtime.bootstrap()
+    _ = try writePayload(runtime.registry.currentLease().rootURL)
+    let parent = try destination()
+    try runtime.relocateCache(
+      to: runtime.prepareExternal(selectedParentURL: parent),
+      progress: { _ in }
+    )
+    let lease = try runtime.registry.currentLease()
+    let detached = root.appendingPathComponent("detached")
+    try FileManager.default.moveItem(at: parent, to: detached)
+    XCTAssertThrowsError(try lease.validateCurrent())
+    runtime.refreshAvailability()
+    XCTAssertFalse(runtime.isCacheAvailable)
+    XCTAssertEqual(try store.load().mode, .external)
+    try FileManager.default.moveItem(at: detached, to: parent)
+    runtime.refreshAvailability()
+    XCTAssertTrue(runtime.isCacheAvailable)
+    XCTAssertEqual(try runtime.registry.currentLease().rootURL, lease.rootURL)
+  }
+}
+
+// MARK: - RelocationPreferenceStore
+
+private final class RelocationPreferenceStore: CacheLocationPreferenceStoring, @unchecked Sendable {
+  private let lock = NSLock()
+  private var value = CacheLocationPreference(mode: .default)
+  let failExternalSave: Bool
+  init(failExternalSave: Bool = false) { self.failExternalSave = failExternalSave }
+  func load() throws -> CacheLocationPreference { lock.withLock { value } }
+  func save(_ preference: CacheLocationPreference) throws {
+    if failExternalSave, preference.mode == .external { throw CocoaError(.fileWriteUnknown) }
+    lock.withLock { value = preference }
+  }
+}
+
+// MARK: - RelocationBookmarkClient
+
+private struct RelocationBookmarkClient: SecurityScopedBookmarkClient {
+  func createBookmark(for url: URL) throws -> Data { Data(url.path.utf8) }
+  func resolveBookmark(_ data: Data) throws -> ResolvedCacheBookmark {
+    ResolvedCacheBookmark(
+      url: URL(fileURLWithPath: String(decoding: data, as: UTF8.self)),
+      isStale: false
+    )
+  }
+
+  func startAccessing(_ url: URL) -> Bool { true }
+  func stopAccessing(_ url: URL) {}
+}
+
+// MARK: - RelocationCancellation
+
+private final class RelocationCancellation: @unchecked Sendable {
+  let lock = NSLock()
+  private var canceled = false
+  func cancel() { lock.withLock { canceled = true } }
+  func check() throws { if lock.withLock({ canceled }) { throw CancellationError() } }
+}

--- a/AmperfyKitTests/Cases/Storage/ExternalCacheTest.swift
+++ b/AmperfyKitTests/Cases/Storage/ExternalCacheTest.swift
@@ -1,0 +1,1472 @@
+//
+//  ExternalCacheTest.swift
+//  AmperfyKitTests
+//
+//  Copyright (c) 2026 Amperfy contributors. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+
+@testable import AmperfyKit
+import Foundation
+import XCTest
+
+// MARK: - ExternalCacheTest
+
+final class ExternalCacheTest: XCTestCase {
+  private var temporaryDirectory: URL!
+
+  override func setUpWithError() throws {
+    temporaryDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ExternalCacheTest-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: temporaryDirectory,
+      withIntermediateDirectories: true
+    )
+  }
+
+  override func tearDownWithError() throws {
+    if let temporaryDirectory {
+      try? FileManager.default.removeItem(at: temporaryDirectory)
+    }
+  }
+
+  func testRootTransitionInvalidatesPriorLease() throws {
+    let registry = CacheRootRegistry()
+    let firstRoot = temporaryDirectory.appendingPathComponent("first", isDirectory: true)
+    let secondRoot = temporaryDirectory.appendingPathComponent("second", isDirectory: true)
+    let firstLease = registry.activate(rootURL: firstRoot)
+    XCTAssertNoThrow(try firstLease.validateCurrent())
+
+    let secondLease = registry.activate(rootURL: secondRoot)
+    XCTAssertThrowsError(try firstLease.validateCurrent()) { error in
+      XCTAssertEqual(error as? CacheRootError, .staleGeneration)
+    }
+    XCTAssertNoThrow(try secondLease.validateCurrent())
+  }
+
+  func testBlockedRegistryRejectsExistingLease() throws {
+    let registry = CacheRootRegistry()
+    let lease = registry.activate(rootURL: temporaryDirectory)
+    registry.block()
+    XCTAssertThrowsError(try lease.validateCurrent()) { error in
+      XCTAssertEqual(error as? CacheRootError, .unavailable)
+    }
+    XCTAssertThrowsError(try registry.currentLease())
+  }
+
+  func testRelativeResolutionPreservesAccountLayoutAndRejectsEscape() throws {
+    let registry = CacheRootRegistry()
+    let lease = registry.activate(rootURL: temporaryDirectory)
+    let relative = URL(string: "accounts/server-hash/user-hash/songs/song.flac")!
+    let resolved = try lease.resolve(relativePath: relative)
+    XCTAssertEqual(
+      resolved.path,
+      temporaryDirectory.appendingPathComponent(relative.path).path
+    )
+
+    XCTAssertThrowsError(try lease.resolve(relativePath: URL(string: "../../escape")!)) {
+      error in
+      XCTAssertEqual(error as? CacheRootError, .pathEscapesRoot)
+    }
+  }
+
+  func testCommitBoundaryRejectsStaleGenerationBeforeWrite() throws {
+    let registry = CacheRootRegistry()
+    let firstRoot = temporaryDirectory.appendingPathComponent("first", isDirectory: true)
+    let lease = registry.activate(rootURL: firstRoot)
+    registry.activate(rootURL: temporaryDirectory.appendingPathComponent("second"))
+    let destination = firstRoot.appendingPathComponent("should-not-exist")
+
+    XCTAssertThrowsError(try lease.performAtCommitBoundary {
+      try Data("unsafe".utf8).write(to: destination)
+    })
+    XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+  }
+
+  func testCapacityPolicyUsesFiveGiBOrTenPercent() throws {
+    let policy = CacheCapacityPolicy()
+    let oneGiB: Int64 = 1024 * 1024 * 1024
+    XCTAssertEqual(policy.reserveBytes(for: oneGiB), 5 * oneGiB)
+    XCTAssertEqual(policy.reserveBytes(for: 100 * oneGiB), 10 * oneGiB)
+    XCTAssertEqual(policy.requiredCapacity(for: oneGiB), 6 * oneGiB)
+
+    XCTAssertThrowsError(try policy.validate(available: 6 * oneGiB - 1, inventoryBytes: oneGiB)) {
+      error in
+      XCTAssertEqual(
+        error as? CacheRootError,
+        .insufficientCapacity(required: 6 * oneGiB, available: 6 * oneGiB - 1)
+      )
+    }
+  }
+
+  func testBackgroundStagingPolicyEnforcesByteAndAgeLimits() {
+    let policy = BackgroundStagingPolicy(
+      absoluteByteLimit: 200,
+      containerCapacityFractionDivisor: 10,
+      maximumAge: 60
+    )
+    XCTAssertEqual(policy.byteLimit(containerAvailableCapacity: 1_000), 100)
+    XCTAssertTrue(policy.permits(
+      stagedBytes: 100,
+      oldestItemAge: 60,
+      containerAvailableCapacity: 1_000
+    ))
+    XCTAssertFalse(policy.permits(
+      stagedBytes: 101,
+      oldestItemAge: 10,
+      containerAvailableCapacity: 1_000
+    ))
+    XCTAssertFalse(policy.permits(
+      stagedBytes: 10,
+      oldestItemAge: 61,
+      containerAvailableCapacity: 1_000
+    ))
+  }
+
+  func testExternalSelectionCreatesNeutralMarkerAndBalancesScope() throws {
+    let selectedParent = temporaryDirectory.appendingPathComponent("Selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let registry = CacheRootRegistry()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let coordinator = CacheRootCoordinator(
+      registry: registry,
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+
+    let prepared = try coordinator.prepareExternal(selectedParentURL: selectedParent)
+    let cacheID = UUID()
+    let preference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: prepared.bookmarkData,
+      displayName: selectedParent.lastPathComponent,
+      cacheID: cacheID
+    )
+    let transaction = ExternalCacheActivationTransaction(
+      cacheID: cacheID,
+      oldPreference: CacheLocationPreference(mode: .default),
+      oldRootURL: temporaryDirectory.appendingPathComponent("old"),
+      newPreference: preference,
+      newRootURL: selectedParent.appendingPathComponent(CacheMarker.childDirectoryName),
+      phase: .prepared
+    )
+    XCTAssertEqual(
+      try coordinator.materializeExternal(prepared: prepared, transaction: transaction),
+      preference
+    )
+    _ = try coordinator.activatePreparedExternal(prepared: prepared, preference: preference)
+    XCTAssertEqual(preference.mode, .external)
+    XCTAssertEqual(
+      try registry.currentLease().rootURL.lastPathComponent,
+      CacheMarker.childDirectoryName
+    )
+    XCTAssertTrue(FileManager.default.fileExists(
+      atPath: selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+        .appendingPathComponent(CacheMarker.fileName).path
+    ))
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 0)
+
+    coordinator.block(reason: "test complete")
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testStaleBookmarkIsRefreshedBeforeExternalRootBecomesReady() throws {
+    let selectedParent = temporaryDirectory.appendingPathComponent("Renamed", isDirectory: true)
+    let root = selectedParent.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    try DurableAtomicFileStore().write(
+      CacheMarker(cacheID: cacheID),
+      to: root.appendingPathComponent(CacheMarker.fileName)
+    )
+    let registry = CacheRootRegistry()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent, isStale: true)
+    let coordinator = CacheRootCoordinator(
+      registry: registry,
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    let original = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("old".utf8),
+      displayName: "Selected",
+      cacheID: cacheID
+    )
+
+    let refreshed = try coordinator.resolveExternal(preference: original)
+    XCTAssertEqual(refreshed.bookmarkData, FakeBookmarkClient.refreshedBookmark)
+    XCTAssertEqual(refreshed.displayName, "Renamed")
+    XCTAssertNoThrow(try registry.currentLease().validateCurrent())
+    coordinator.block(reason: "test complete")
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testNonStaleBookmarkRefreshesDisplayNameFromResolvedParent() throws {
+    let selectedParent = temporaryDirectory.appendingPathComponent("Resolved", isDirectory: true)
+    let root = selectedParent.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    try DurableAtomicFileStore().write(
+      CacheMarker(cacheID: cacheID),
+      to: root.appendingPathComponent(CacheMarker.fileName)
+    )
+    let registry = CacheRootRegistry()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent, isStale: false)
+    let coordinator = CacheRootCoordinator(
+      registry: registry,
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    let originalBookmark = Data("original".utf8)
+    let original = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: originalBookmark,
+      displayName: "Old Name",
+      cacheID: cacheID
+    )
+
+    let refreshed = try coordinator.resolveExternal(preference: original)
+    XCTAssertEqual(refreshed.bookmarkData, originalBookmark)
+    XCTAssertEqual(refreshed.displayName, "Resolved")
+    XCTAssertEqual(bookmarks.createCount, 0)
+    coordinator.block(reason: "test complete")
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testMarkerMismatchBlocksRegistryWithoutFallback() throws {
+    let selectedParent = temporaryDirectory.appendingPathComponent("Selected", isDirectory: true)
+    let root = selectedParent.appendingPathComponent(
+      CacheMarker.childDirectoryName,
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    try DurableAtomicFileStore().write(
+      CacheMarker(cacheID: UUID()),
+      to: root.appendingPathComponent(CacheMarker.fileName)
+    )
+    let registry = CacheRootRegistry()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let coordinator = CacheRootCoordinator(
+      registry: registry,
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    let preference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      cacheID: UUID()
+    )
+
+    do {
+      _ = try coordinator.resolveExternal(preference: preference)
+      XCTFail("Marker mismatch must fail closed")
+    } catch {
+      XCTAssertEqual(error as? CacheRootError, .markerMismatch)
+    }
+    XCTAssertThrowsError(try registry.currentLease())
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testDurableAtomicStoreOverwritesCompleteRecord() throws {
+    struct Record: Codable, Equatable {
+      let value: String
+    }
+    let store = DurableAtomicFileStore()
+    let url = temporaryDirectory.appendingPathComponent("receipt.json")
+    try store.write(Record(value: "before"), to: url)
+    try store.write(Record(value: "after"), to: url)
+    XCTAssertEqual(try store.read(Record.self, from: url), Record(value: "after"))
+    XCTAssertEqual(
+      try FileManager.default.contentsOfDirectory(atPath: temporaryDirectory.path),
+      ["receipt.json"]
+    )
+  }
+
+  func testActivationReconciliationCoversEveryCrashBoundary() {
+    let transactionID = UUID()
+    let destinationCacheID = UUID()
+    let journal = CacheMigrationJournal(
+      transactionID: transactionID,
+      sourceCacheID: UUID(),
+      destinationCacheID: destinationCacheID,
+      phase: .activated,
+      inventory: [CacheInventoryEntry(relativePath: "song", byteCount: 4, sha256: "hash")]
+    )
+    let marker = CacheMarker(cacheID: destinationCacheID)
+    let receipt = CacheActivationReceipt(
+      transactionID: transactionID,
+      cacheID: destinationCacheID,
+      inventoryDigest: journal.inventoryDigest
+    )
+    let reconciler = CacheActivationReconciler()
+
+    XCTAssertEqual(reconciler.reconcile(
+      journal: journal,
+      evidence: CacheActivationEvidence(
+        finalDirectoryExists: false,
+        destinationMarker: nil,
+        appReceipt: nil,
+        destinationReceipt: nil,
+        preferenceCacheID: nil
+      )
+    ), .sourceActiveResumeOrAbandon)
+
+    XCTAssertEqual(reconciler.reconcile(
+      journal: journal,
+      evidence: CacheActivationEvidence(
+        finalDirectoryExists: true,
+        destinationMarker: marker,
+        appReceipt: nil,
+        destinationReceipt: receipt,
+        preferenceCacheID: nil
+      )
+    ), .blockCompleteReceiptsOrRollback)
+
+    XCTAssertEqual(reconciler.reconcile(
+      journal: journal,
+      evidence: CacheActivationEvidence(
+        finalDirectoryExists: true,
+        destinationMarker: marker,
+        appReceipt: nil,
+        destinationReceipt: receipt,
+        preferenceCacheID: destinationCacheID
+      )
+    ), .blockCompleteReceiptsOrRollback)
+
+    XCTAssertEqual(reconciler.reconcile(
+      journal: journal,
+      evidence: CacheActivationEvidence(
+        finalDirectoryExists: true,
+        destinationMarker: marker,
+        appReceipt: receipt,
+        destinationReceipt: receipt,
+        preferenceCacheID: destinationCacheID
+      )
+    ), .destinationActive)
+
+    XCTAssertEqual(reconciler.reconcile(
+      journal: journal,
+      evidence: CacheActivationEvidence(
+        finalDirectoryExists: true,
+        destinationMarker: CacheMarker(cacheID: UUID()),
+        appReceipt: receipt,
+        destinationReceipt: receipt,
+        preferenceCacheID: destinationCacheID
+      )
+    ), .blockedInconsistent)
+  }
+
+  func testMigrationCopiesVerifiesActivatesAndPreservesSource() throws {
+    let sourceRoot = temporaryDirectory.appendingPathComponent("source", isDirectory: true)
+    let destinationParent = temporaryDirectory.appendingPathComponent(
+      "destination",
+      isDirectory: true
+    )
+    let appContainer = temporaryDirectory.appendingPathComponent("app", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: sourceRoot.appendingPathComponent("accounts/server/user/songs"),
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+      at: destinationParent,
+      withIntermediateDirectories: true
+    )
+    let sourceFile = sourceRoot.appendingPathComponent("accounts/server/user/songs/song.flac")
+    try Data("synthetic media".utf8).write(to: sourceFile)
+
+    let capacity = FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    let engine = CacheMigrationEngine(capacityProvider: capacity)
+    let journal = try engine.makeJournal(sourceRoot: sourceRoot, sourceCacheID: UUID())
+    let projection = LockedPreferenceProjection()
+    let appJournalURL = appContainer.appendingPathComponent("migration.json")
+    let activationPreference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      displayName: "destination",
+      cacheID: journal.destinationCacheID
+    )
+    let finalRoot = try engine.migrate(
+      journal: journal,
+      sourceRoot: sourceRoot,
+      destinationParent: destinationParent,
+      appContainerJournalURL: appJournalURL,
+      activationPreference: activationPreference
+    ) { preference in
+      projection.set(preference)
+    }
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: sourceFile.path))
+    XCTAssertEqual(
+      try Data(
+        contentsOf: finalRoot
+          .appendingPathComponent("accounts/server/user/songs/song.flac")
+      ),
+      Data("synthetic media".utf8)
+    )
+    XCTAssertTrue(FileManager.default.fileExists(
+      atPath: finalRoot.appendingPathComponent(CacheMarker.fileName).path
+    ))
+    XCTAssertTrue(FileManager.default.fileExists(
+      atPath: finalRoot.appendingPathComponent(CacheMigrationEngine.receiptFileName).path
+    ))
+    XCTAssertEqual(projection.value()?.cacheID, journal.destinationCacheID)
+  }
+
+  func testMigrationLowSpaceFailureDoesNotActivate() throws {
+    let sourceRoot = temporaryDirectory.appendingPathComponent("source", isDirectory: true)
+    let destinationParent = temporaryDirectory.appendingPathComponent(
+      "destination",
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+      at: destinationParent,
+      withIntermediateDirectories: true
+    )
+    try Data("synthetic media".utf8).write(to: sourceRoot.appendingPathComponent("song"))
+
+    let engine = CacheMigrationEngine(capacityProvider: FixedCapacityProvider(available: 1))
+    let journal = try engine.makeJournal(sourceRoot: sourceRoot, sourceCacheID: UUID())
+    let activationPreference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      cacheID: journal.destinationCacheID
+    )
+    XCTAssertThrowsError(try engine.migrate(
+      journal: journal,
+      sourceRoot: sourceRoot,
+      destinationParent: destinationParent,
+      appContainerJournalURL: temporaryDirectory.appendingPathComponent("app/journal"),
+      activationPreference: activationPreference
+    ) { _ in
+      XCTFail("Preference projection must not run on low-space failure")
+    })
+    XCTAssertFalse(FileManager.default.fileExists(
+      atPath: destinationParent.appendingPathComponent(CacheMarker.childDirectoryName).path
+    ))
+  }
+
+  func testBootstrapIsSingleAuthorityAndCreatesNothingBeforeDecision() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("not-created", isDirectory: true)
+    let registry = CacheRootRegistry()
+    let store = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let runtime = CacheRootRuntime(
+      registry: registry,
+      preferenceStore: store,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: FakeBookmarkClient(resolvedURL: defaultRoot),
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024),
+      backgroundStagingRoot: temporaryDirectory.appendingPathComponent("staging")
+    )
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: defaultRoot.path))
+    XCTAssertThrowsError(try registry.currentLease())
+    XCTAssertThrowsError(try runtime.fileManager.currentRootLease())
+
+    let state = try runtime.bootstrap()
+    guard case let .ready(preference, rootURL) = state else {
+      return XCTFail("Expected ready bootstrap")
+    }
+    XCTAssertEqual(preference.mode, .default)
+    XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: defaultRoot.path))
+    XCTAssertEqual(
+      try runtime.fileManager.currentRootLease().generation,
+      try registry.currentLease().generation
+    )
+  }
+
+  func testIncompleteExternalPreferenceBlocksWithoutDefaultFallback() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("must-not-exist")
+    let runtime = CacheRootRuntime(
+      preferenceStore: FakePreferenceStore(preference: CacheLocationPreference(mode: .external)),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: FakeBookmarkClient(resolvedURL: temporaryDirectory),
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+
+    XCTAssertThrowsError(try runtime.bootstrap())
+    XCTAssertFalse(FileManager.default.fileExists(atPath: defaultRoot.path))
+    XCTAssertThrowsError(try runtime.fileManager.currentRootLease())
+    guard case .blocked = runtime.state else { return XCTFail("Expected blocked state") }
+  }
+
+  func testCacheLocationPresentationIsDeterministicAndFailClosed() {
+    let root = URL(fileURLWithPath: "/deterministic/cache")
+    XCTAssertEqual(
+      CacheLocationPresentation(state: .ready(
+        preference: CacheLocationPreference(mode: .external),
+        rootURL: root
+      )),
+      CacheLocationPresentation(state: .ready(
+        preference: CacheLocationPreference(mode: .external),
+        rootURL: root
+      ))
+    )
+    let blocked = CacheLocationPresentation(state: .blocked(reason: "Drive unavailable"))
+    XCTAssertTrue(blocked.blocksNormalOperation)
+    XCTAssertEqual(blocked.statusText, "Unavailable — Drive unavailable")
+    XCTAssertTrue(CacheLocationPresentation(state: .unresolved).blocksNormalOperation)
+    XCTAssertTrue(CacheLocationPresentation(state: .resolving).blocksNormalOperation)
+  }
+
+  func testPendingCacheLocationSelectionIsInMemoryAndNonActivating() throws {
+    let registry = CacheRootRegistry()
+    let activeRoot = temporaryDirectory.appendingPathComponent("active", isDirectory: true)
+    let originalLease = registry.activate(rootURL: activeRoot)
+    let preferenceStore = FakePreferenceStore(
+      preference: CacheLocationPreference(mode: .default)
+    )
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    var selection = PendingCacheLocationSelection()
+
+    selection.beginChoosing()
+    selection.select(selectedParent)
+
+    XCTAssertEqual(selection.parentURL, selectedParent)
+    XCTAssertFalse(selection.isPickerPresented)
+    XCTAssertEqual(try registry.currentLease().generation, originalLease.generation)
+    XCTAssertEqual(try preferenceStore.load().mode, .default)
+    XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: selectedParent.path), [])
+  }
+
+  func testPendingCacheLocationCancellationDoesNotMutateCandidateOrDurableState() throws {
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let preferenceStore = FakePreferenceStore(
+      preference: CacheLocationPreference(mode: .default)
+    )
+    var selection = PendingCacheLocationSelection()
+    selection.select(selectedParent)
+
+    selection.beginChoosing()
+    selection.cancel()
+
+    XCTAssertEqual(selection.parentURL, selectedParent)
+    XCTAssertFalse(selection.isPickerPresented)
+    XCTAssertEqual(try preferenceStore.load().mode, .default)
+    XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: selectedParent.path), [])
+  }
+
+  func testPreparedSelectionCancelPreservesDefaultReadyAndBalancesScope() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let registry = CacheRootRegistry()
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let activations = FakeActivationStore()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let runtime = CacheRootRuntime(
+      registry: registry,
+      preferenceStore: preferences,
+      activationStore: activations,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+    let originalLease = try registry.currentLease()
+
+    let prepared = try runtime.prepareExternal(selectedParentURL: selectedParent)
+    XCTAssertEqual(try registry.currentLease().generation, originalLease.generation)
+    XCTAssertEqual(runtime.state, .ready(
+      preference: CacheLocationPreference(mode: .default),
+      rootURL: defaultRoot.standardizedFileURL.resolvingSymlinksInPath()
+    ))
+    XCTAssertEqual(try preferences.load().mode, .default)
+    XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: selectedParent.path), [])
+
+    prepared.cancel()
+    prepared.cancel()
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testPreparationFailurePreservesDefaultReadyWithoutScopeLeak() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let registry = CacheRootRegistry()
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent, startSucceeds: false)
+    let runtime = CacheRootRuntime(
+      registry: registry,
+      preferenceStore: preferences,
+      activationStore: FakeActivationStore(),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+    let originalLease = try registry.currentLease()
+
+    XCTAssertThrowsError(try runtime.prepareExternal(selectedParentURL: selectedParent))
+    XCTAssertEqual(try registry.currentLease().generation, originalLease.generation)
+    XCTAssertEqual(try preferences.load().mode, .default)
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 0)
+  }
+
+  func testPayloadPresentRefusesDirectActivationAndRequiresMigration() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: FakeActivationStore(),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+    let payload = defaultRoot.appendingPathComponent("accounts/server/user/songs/song.flac")
+    try FileManager.default.createDirectory(
+      at: payload.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try Data("cached".utf8).write(to: payload)
+    let prepared = try runtime.prepareExternal(selectedParentURL: selectedParent)
+
+    XCTAssertThrowsError(try runtime.confirmPreparedExternal(prepared)) {
+      XCTAssertEqual($0 as? CacheRootError, .migrationRequired)
+    }
+    guard case let .ready(preference, rootURL) = runtime.state else {
+      return XCTFail("Default must remain ready")
+    }
+    XCTAssertEqual(preference.mode, .default)
+    XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL.resolvingSymlinksInPath())
+    XCTAssertFalse(FileManager.default.fileExists(
+      atPath: selectedParent.appendingPathComponent(CacheMarker.childDirectoryName).path
+    ))
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 0)
+    prepared.cancel()
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testCompletedExternalControlFilesPermitDirectActivation() throws {
+    let root = temporaryDirectory.appendingPathComponent("current", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: root.appendingPathComponent("accounts", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+    let cacheID = UUID()
+    let atomicStore = DurableAtomicFileStore()
+    try atomicStore.write(
+      CacheMarker(cacheID: cacheID),
+      to: root.appendingPathComponent(CacheMarker.fileName)
+    )
+    try atomicStore.write(
+      ExternalCacheActivationTransaction(
+        cacheID: cacheID,
+        oldPreference: CacheLocationPreference(mode: .default),
+        oldRootURL: temporaryDirectory.appendingPathComponent("old"),
+        newPreference: CacheLocationPreference(mode: .external, cacheID: cacheID),
+        newRootURL: root,
+        phase: .completed
+      ),
+      to: root.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+    )
+
+    let renamedRoot = temporaryDirectory.appendingPathComponent("renamed", isDirectory: true)
+    try FileManager.default.moveItem(at: root, to: renamedRoot)
+    XCTAssertNoThrow(try CacheDirectActivationInventoryGate().validate(rootURL: renamedRoot))
+  }
+
+  func testUnresolvedExternalControlReceiptRequiresMigration() throws {
+    let root = temporaryDirectory.appendingPathComponent("current", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    let atomicStore = DurableAtomicFileStore()
+    try atomicStore.write(
+      CacheMarker(cacheID: cacheID),
+      to: root.appendingPathComponent(CacheMarker.fileName)
+    )
+    try atomicStore.write(
+      ExternalCacheActivationTransaction(
+        cacheID: cacheID,
+        oldPreference: CacheLocationPreference(mode: .default),
+        oldRootURL: temporaryDirectory.appendingPathComponent("old"),
+        newPreference: CacheLocationPreference(mode: .external, cacheID: cacheID),
+        newRootURL: root,
+        phase: .preferencePersisted
+      ),
+      to: root.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+    )
+
+    XCTAssertThrowsError(try CacheDirectActivationInventoryGate().validate(rootURL: root)) {
+      XCTAssertEqual($0 as? CacheRootError, .migrationRequired)
+    }
+  }
+
+  func testConfirmedEmptyRootPersistsCompletePreferenceAndMirroredReceipts() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let activations = FakeActivationStore()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: activations,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+    try FileManager.default.createDirectory(
+      at: defaultRoot.appendingPathComponent("accounts"),
+      withIntermediateDirectories: true
+    )
+    let prepared = try runtime.prepareExternal(selectedParentURL: selectedParent)
+    XCTAssertFalse(FileManager.default.fileExists(
+      atPath: selectedParent.appendingPathComponent(CacheMarker.childDirectoryName).path
+    ))
+
+    let preference = try runtime.confirmPreparedExternal(prepared)
+    let root = selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+    XCTAssertEqual(preference.mode, .external)
+    XCTAssertNotNil(preference.bookmarkData)
+    XCTAssertNotNil(preference.cacheID)
+    XCTAssertEqual(try preferences.load(), preference)
+    XCTAssertEqual(try activations.load()?.phase, .completed)
+    XCTAssertEqual(
+      try DurableAtomicFileStore().read(
+        ExternalCacheActivationTransaction.self,
+        from: root.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+      ),
+      try activations.load()
+    )
+    XCTAssertEqual(
+      try DurableAtomicFileStore().read(
+        CacheMarker.self,
+        from: root.appendingPathComponent(CacheMarker.fileName)
+      ).cacheID,
+      preference.cacheID
+    )
+    XCTAssertTrue(FileManager.default.fileExists(atPath: defaultRoot.path))
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 0)
+    runtime.block(reason: "test complete")
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testConfirmedExternalRestartsWithSameCacheIDAndBalancedScope() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let activations = FakeActivationStore()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let first = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: activations,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try first.bootstrap()
+    let confirmed = try first.confirmPreparedExternal(
+      try first.prepareExternal(selectedParentURL: selectedParent)
+    )
+    first.block(reason: "simulate quit")
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 1)
+
+    let second = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: activations,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    guard case let .ready(restarted, rootURL) = try second.bootstrap() else {
+      return XCTFail("External cache must restart ready")
+    }
+    XCTAssertEqual(restarted.cacheID, confirmed.cacheID)
+    XCTAssertEqual(
+      rootURL,
+      selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+        .standardizedFileURL.resolvingSymlinksInPath()
+    )
+    XCTAssertEqual(bookmarks.startCount, 2)
+    XCTAssertEqual(bookmarks.stopCount, 1)
+    second.block(reason: "test complete")
+    XCTAssertEqual(bookmarks.stopCount, 2)
+  }
+
+  func testActivationFailuresAtEveryBoundaryRollbackToDefaultReady() throws {
+    let boundaries: [ExternalCacheActivationPhase] = [
+      .prepared,
+      .destinationMaterialized,
+      .preferencePersisted,
+      .registryActivated,
+    ]
+    for boundary in boundaries {
+      let caseRoot = temporaryDirectory.appendingPathComponent(boundary.rawValue)
+      let defaultRoot = caseRoot.appendingPathComponent("default", isDirectory: true)
+      let selectedParent = caseRoot.appendingPathComponent("selected", isDirectory: true)
+      try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+      let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+      let activations = FakeActivationStore()
+      let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+      let runtime = CacheRootRuntime(
+        preferenceStore: preferences,
+        activationStore: activations,
+        defaultRootProvider: { defaultRoot },
+        bookmarkClient: bookmarks,
+        capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024),
+        activationBoundary: { phase in
+          if phase == boundary { throw InjectedActivationError.boundary }
+        }
+      )
+      _ = try runtime.bootstrap()
+      let prepared = try runtime.prepareExternal(selectedParentURL: selectedParent)
+
+      XCTAssertThrowsError(try runtime.confirmPreparedExternal(prepared))
+      guard case let .ready(preference, rootURL) = runtime.state else {
+        return XCTFail("\(boundary) must rollback to Ready")
+      }
+      XCTAssertEqual(preference.mode, .default)
+      XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL.resolvingSymlinksInPath())
+      XCTAssertEqual(try preferences.load().mode, .default)
+      XCTAssertEqual(try activations.load()?.phase, .rolledBack)
+      XCTAssertFalse(FileManager.default.fileExists(
+        atPath: selectedParent.appendingPathComponent(CacheMarker.childDirectoryName).path
+      ))
+      XCTAssertEqual(bookmarks.startCount, 1)
+      XCTAssertEqual(bookmarks.stopCount, 1)
+    }
+  }
+
+  func testPreferencePersistenceFailureRollsBackWithoutMixedRoots() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let preferences = FailExternalPreferenceStore()
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: FakeActivationStore(),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+
+    XCTAssertThrowsError(try runtime.confirmPreparedExternal(
+      try runtime.prepareExternal(selectedParentURL: selectedParent)
+    ))
+    guard case let .ready(preference, rootURL) = runtime.state else {
+      return XCTFail("Default must remain ready")
+    }
+    XCTAssertEqual(preference.mode, .default)
+    XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL.resolvingSymlinksInPath())
+    XCTAssertEqual(try preferences.load().mode, .default)
+    XCTAssertFalse(FileManager.default.fileExists(
+      atPath: selectedParent.appendingPathComponent(CacheMarker.childDirectoryName).path
+    ))
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testBookmarkCreationFailurePreservesDefaultReadyAndBalancesScope() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    try FileManager.default.createDirectory(at: selectedParent, withIntermediateDirectories: true)
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let bookmarks = FakeBookmarkClient(
+      resolvedURL: selectedParent,
+      bookmarkCreationError: InjectedActivationError.bookmark
+    )
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: FakeActivationStore(),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+
+    XCTAssertThrowsError(try runtime.prepareExternal(selectedParentURL: selectedParent))
+    guard case let .ready(preference, rootURL) = runtime.state else {
+      return XCTFail("Default must remain ready")
+    }
+    XCTAssertEqual(preference.mode, .default)
+    XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL.resolvingSymlinksInPath())
+    XCTAssertEqual(try preferences.load().mode, .default)
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testPreexistingDestinationRefusesMaterializationWithoutChangingDefault() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    let preexistingRoot = selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+    try FileManager.default.createDirectory(at: preexistingRoot, withIntermediateDirectories: true)
+    let sentinel = preexistingRoot.appendingPathComponent("unrelated.txt")
+    try Data("preserve".utf8).write(to: sentinel)
+    let preferences = FakePreferenceStore(preference: CacheLocationPreference(mode: .default))
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: FakeActivationStore(),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    _ = try runtime.bootstrap()
+
+    XCTAssertThrowsError(try runtime.confirmPreparedExternal(
+      try runtime.prepareExternal(selectedParentURL: selectedParent)
+    )) {
+      XCTAssertEqual($0 as? CacheRootError, .markerMismatch)
+    }
+    guard case let .ready(preference, rootURL) = runtime.state else {
+      return XCTFail("Default must remain ready")
+    }
+    XCTAssertEqual(preference.mode, .default)
+    XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL.resolvingSymlinksInPath())
+    XCTAssertEqual(try Data(contentsOf: sentinel), Data("preserve".utf8))
+    XCTAssertEqual(bookmarks.startCount, 1)
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testInterruptedMaterializationReconcilesToOldRootAndRemovesOwnedDestination() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    let newRoot = selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+    try FileManager.default.createDirectory(at: newRoot, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    let newPreference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      displayName: selectedParent.lastPathComponent,
+      cacheID: cacheID
+    )
+    let transaction = ExternalCacheActivationTransaction(
+      cacheID: cacheID,
+      oldPreference: CacheLocationPreference(mode: .default),
+      oldRootURL: defaultRoot,
+      newPreference: newPreference,
+      newRootURL: newRoot,
+      phase: .destinationMaterialized
+    )
+    let atomic = DurableAtomicFileStore()
+    try atomic.write(
+      CacheMarker(cacheID: cacheID),
+      to: newRoot.appendingPathComponent(CacheMarker.fileName)
+    )
+    try atomic.write(
+      transaction,
+      to: newRoot.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+    )
+    let preferences = FakePreferenceStore(preference: newPreference)
+    let activations = FakeActivationStore(transaction: transaction)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: activations,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: FakeBookmarkClient(resolvedURL: selectedParent),
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+
+    guard case let .ready(preference, rootURL) = try runtime.bootstrap() else {
+      return XCTFail("Interrupted materialization must reconcile to Default")
+    }
+    XCTAssertEqual(preference.mode, .default)
+    XCTAssertEqual(rootURL, defaultRoot.standardizedFileURL.resolvingSymlinksInPath())
+    XCTAssertEqual(try preferences.load().mode, .default)
+    XCTAssertEqual(try activations.load()?.phase, .rolledBack)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: newRoot.path))
+  }
+
+  func testInterruptedRegistryActivationCompletesOnlyFromMatchingReceipts() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    let newRoot = selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+    try FileManager.default.createDirectory(at: newRoot, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    let newPreference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      displayName: selectedParent.lastPathComponent,
+      cacheID: cacheID
+    )
+    let transaction = ExternalCacheActivationTransaction(
+      cacheID: cacheID,
+      oldPreference: CacheLocationPreference(mode: .default),
+      oldRootURL: defaultRoot,
+      newPreference: newPreference,
+      newRootURL: newRoot,
+      phase: .registryActivated
+    )
+    let atomic = DurableAtomicFileStore()
+    try atomic.write(
+      CacheMarker(cacheID: cacheID),
+      to: newRoot.appendingPathComponent(CacheMarker.fileName)
+    )
+    try atomic.write(
+      transaction,
+      to: newRoot.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+    )
+    let preferences = FakePreferenceStore(preference: newPreference)
+    let activations = FakeActivationStore(transaction: transaction)
+    let bookmarks = FakeBookmarkClient(resolvedURL: selectedParent)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: activations,
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: bookmarks,
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+
+    guard case let .ready(preference, rootURL) = try runtime.bootstrap() else {
+      return XCTFail("Matching receipts must complete the external activation")
+    }
+    XCTAssertEqual(preference, newPreference)
+    XCTAssertEqual(rootURL, newRoot.standardizedFileURL.resolvingSymlinksInPath())
+    XCTAssertEqual(try activations.load()?.phase, .completed)
+    XCTAssertEqual(bookmarks.startCount, 1)
+    runtime.block(reason: "test complete")
+    XCTAssertEqual(bookmarks.stopCount, 1)
+  }
+
+  func testInterruptedActivationReceiptMismatchBlocksWithoutHeuristicCleanup() throws {
+    let defaultRoot = temporaryDirectory.appendingPathComponent("default", isDirectory: true)
+    let selectedParent = temporaryDirectory.appendingPathComponent("selected", isDirectory: true)
+    let newRoot = selectedParent.appendingPathComponent(CacheMarker.childDirectoryName)
+    try FileManager.default.createDirectory(at: newRoot, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    let newPreference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      displayName: selectedParent.lastPathComponent,
+      cacheID: cacheID
+    )
+    let transaction = ExternalCacheActivationTransaction(
+      cacheID: cacheID,
+      oldPreference: CacheLocationPreference(mode: .default),
+      oldRootURL: defaultRoot,
+      newPreference: newPreference,
+      newRootURL: newRoot,
+      phase: .destinationMaterialized
+    )
+    var mismatched = transaction
+    mismatched.failureDescription = "different receipt"
+    let atomic = DurableAtomicFileStore()
+    try atomic.write(
+      CacheMarker(cacheID: cacheID),
+      to: newRoot.appendingPathComponent(CacheMarker.fileName)
+    )
+    try atomic.write(
+      mismatched,
+      to: newRoot.appendingPathComponent(CacheMigrationEngine.receiptFileName)
+    )
+    let preferences = FakePreferenceStore(preference: newPreference)
+    let runtime = CacheRootRuntime(
+      preferenceStore: preferences,
+      activationStore: FakeActivationStore(transaction: transaction),
+      defaultRootProvider: { defaultRoot },
+      bookmarkClient: FakeBookmarkClient(resolvedURL: selectedParent),
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+
+    XCTAssertThrowsError(try runtime.bootstrap()) {
+      XCTAssertEqual($0 as? CacheRootError, .inconsistentActivation)
+    }
+    guard case .blocked = runtime.state else { return XCTFail("Ambiguity must block") }
+    XCTAssertTrue(FileManager.default.fileExists(atPath: newRoot.path))
+    XCTAssertEqual(try preferences.load(), newPreference)
+  }
+
+  func testDurablePreferenceIsAuthoritativeOverProjection() throws {
+    let configurationURL = temporaryDirectory.appendingPathComponent("configuration.json")
+    let projectedExternal = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("projection-only".utf8),
+      displayName: "Ignored",
+      cacheID: UUID()
+    )
+    let projection = FakePreferenceStore(preference: projectedExternal)
+    let store = DurableCacheLocationPreferenceStore(
+      configurationURL: configurationURL,
+      projection: projection
+    )
+
+    XCTAssertEqual(try store.load(), CacheLocationPreference(mode: .default))
+    let authoritative = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("complete".utf8),
+      displayName: "Selected",
+      cacheID: UUID()
+    )
+    try store.save(authoritative)
+    XCTAssertEqual(try store.load(), authoritative)
+    XCTAssertEqual(try projection.load(), authoritative)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: configurationURL.path))
+  }
+
+  func testRelativePathsPreserveFilesystemCharactersAndRejectSymlinkEscape() throws {
+    let registry = CacheRootRegistry()
+    let lease = registry.activate(rootURL: temporaryDirectory)
+    let composed = "café.flac"
+    let decomposed = "cafe\u{301}.flac"
+    let names = [
+      "space name.flac",
+      "hash#.flac",
+      "percent%.flac",
+      "query?.flac",
+      "colon:.flac",
+      composed,
+      decomposed,
+    ]
+
+    for name in names {
+      let relative = try CacheRelativePath("accounts/server/user/songs/\(name)")
+      let resolved = try lease.resolve(relativePath: relative)
+      XCTAssertEqual(resolved.lastPathComponent, name)
+    }
+    for traversal in ["../escape", "a/../../escape", "/absolute", "a//b", "a/./b"] {
+      XCTAssertThrowsError(try CacheRelativePath(traversal))
+    }
+
+    let outside = temporaryDirectory.deletingLastPathComponent()
+      .appendingPathComponent("outside-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: outside) }
+    try FileManager.default.createSymbolicLink(
+      at: temporaryDirectory.appendingPathComponent("link"),
+      withDestinationURL: outside
+    )
+    XCTAssertThrowsError(try lease.resolve(relativePath: CacheRelativePath("link/escape"))) {
+      XCTAssertEqual($0 as? CacheRootError, .pathEscapesRoot)
+    }
+  }
+
+  func testInventoryIncludesHiddenFilesAndOnlyExcludesRootControlFiles() throws {
+    let nested = temporaryDirectory.appendingPathComponent("nested", isDirectory: true)
+    try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+    try Data("hidden".utf8).write(to: temporaryDirectory.appendingPathComponent(".hidden-media"))
+    for controlName in CacheInventoryBuilder.rootControlFileNames {
+      try Data("control".utf8).write(to: temporaryDirectory.appendingPathComponent(controlName))
+      try Data("user-data".utf8).write(to: nested.appendingPathComponent(controlName))
+    }
+
+    let paths = try CacheInventoryBuilder().build(rootURL: temporaryDirectory)
+      .map(\.relativePath)
+    XCTAssertTrue(paths.contains(".hidden-media"))
+    for controlName in CacheInventoryBuilder.rootControlFileNames {
+      XCTAssertFalse(paths.contains(controlName))
+      XCTAssertTrue(paths.contains("nested/\(controlName)"))
+    }
+  }
+
+  func testMigrationResumesVerifiedPartialFilesWithFilesystemSafeNames() throws {
+    let sourceRoot = temporaryDirectory.appendingPathComponent("resume-source", isDirectory: true)
+    let destinationParent = temporaryDirectory.appendingPathComponent("resume-destination")
+    let specialDirectory = sourceRoot.appendingPathComponent("accounts/server/user/songs")
+    try FileManager.default.createDirectory(at: specialDirectory, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+      at: destinationParent,
+      withIntermediateDirectories: true
+    )
+    let names = ["space # % ? :.flac", "cafe\u{301}.flac"]
+    for name in names {
+      try Data("payload-\(name)".utf8).write(to: specialDirectory.appendingPathComponent(name))
+    }
+
+    let engine = CacheMigrationEngine(
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    let transactionID = UUID()
+    var journal = try engine.makeJournal(
+      sourceRoot: sourceRoot,
+      sourceCacheID: UUID(),
+      transactionID: transactionID
+    )
+    journal.phase = .copying
+    let first = journal.inventory[0]
+    let stagingRoot = destinationParent
+      .appendingPathComponent(".amperfy-migration-\(transactionID.uuidString)")
+      .appendingPathComponent(CacheMarker.childDirectoryName)
+    let firstDestination = stagingRoot.appendingPathComponent(first.relativePath)
+    try FileManager.default.createDirectory(
+      at: firstDestination.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let verifiedPartial = firstDestination.deletingLastPathComponent().appendingPathComponent(
+      ".\(firstDestination.lastPathComponent).\(transactionID.uuidString).partial"
+    )
+    try FileManager.default.copyItem(
+      at: sourceRoot.appendingPathComponent(first.relativePath),
+      to: verifiedPartial
+    )
+    let second = journal.inventory[1]
+    let secondDestination = stagingRoot.appendingPathComponent(second.relativePath)
+    let corruptPartial = secondDestination.deletingLastPathComponent().appendingPathComponent(
+      ".\(secondDestination.lastPathComponent).\(transactionID.uuidString).partial"
+    )
+    try Data("truncated".utf8).write(to: corruptPartial)
+
+    let preference = CacheLocationPreference(
+      mode: .external,
+      bookmarkData: Data("bookmark".utf8),
+      cacheID: journal.destinationCacheID
+    )
+    let finalRoot = try engine.migrate(
+      journal: journal,
+      sourceRoot: sourceRoot,
+      destinationParent: destinationParent,
+      appContainerJournalURL: temporaryDirectory.appendingPathComponent("resume-app/journal"),
+      activationPreference: preference,
+      projectPreference: { _ in }
+    )
+
+    for name in names {
+      XCTAssertEqual(
+        try Data(
+          contentsOf: finalRoot
+            .appendingPathComponent("accounts/server/user/songs/\(name)")
+        ),
+        Data("payload-\(name)".utf8)
+      )
+    }
+    XCTAssertFalse(FileManager.default.fileExists(atPath: verifiedPartial.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: corruptPartial.path))
+  }
+
+  func testMigrationRejectsIncompleteBookmarkProjectionBeforeCopy() throws {
+    let source = temporaryDirectory.appendingPathComponent("incomplete-source")
+    let destination = temporaryDirectory.appendingPathComponent("incomplete-destination")
+    try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    try Data("media".utf8).write(to: source.appendingPathComponent("song"))
+    let engine = CacheMigrationEngine(
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+    let journal = try engine.makeJournal(sourceRoot: source, sourceCacheID: UUID())
+    XCTAssertThrowsError(try engine.migrate(
+      journal: journal,
+      sourceRoot: source,
+      destinationParent: destination,
+      appContainerJournalURL: temporaryDirectory.appendingPathComponent("incomplete-app/journal"),
+      activationPreference: CacheLocationPreference(
+        mode: .external,
+        cacheID: journal.destinationCacheID
+      ),
+      projectPreference: { _ in XCTFail("Projection must not run") }
+    ))
+    XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: destination.path), [])
+  }
+
+  func testFilesystemCommitRemainsRecoverableWhenGenerationChangesBeforeCoreDataSave() throws {
+    let root = temporaryDirectory.appendingPathComponent("race-root", isDirectory: true)
+    let staging = temporaryDirectory.appendingPathComponent("race-staging", isDirectory: true)
+    let registry = CacheRootRegistry()
+    let manager = CacheFileManager(rootRegistry: registry, backgroundStagingRoot: staging)
+    let lease = registry.activate(rootURL: root)
+    try manager.rootDidActivate(using: lease)
+    let source = temporaryDirectory.appendingPathComponent("download.tmp")
+    try Data("recoverable media".utf8).write(to: source)
+    let relative = try CacheRelativePath("accounts/server/user/songs/song.flac")
+    let destination = try manager.getAbsoluteAmperfyPath(relativePath: relative, using: lease)
+    let account = AccountInfo(serverHash: "server", userHash: "user", apiType: .notDetected)
+
+    let transaction = try manager.prepareRecoverableFileCommit(
+      sourceURL: source,
+      destinationURL: destination,
+      accountInfo: account,
+      using: lease
+    )
+    registry.block() // injected boundary: filesystem committed, Core Data not yet saved
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: transaction.recoverableFileURL.path))
+    XCTAssertEqual(transaction.receipt.phase, .filesystemCommitted)
+    XCTAssertThrowsError(try transaction.cancel())
+    XCTAssertTrue(FileManager.default.fileExists(atPath: transaction.recoverableFileURL.path))
+  }
+
+  func testExistingMarkerRequiresKnownIDOrExplicitAdoption() throws {
+    let parent = temporaryDirectory.appendingPathComponent("existing-parent")
+    let root = parent.appendingPathComponent(CacheMarker.childDirectoryName)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let cacheID = UUID()
+    try DurableAtomicFileStore().write(
+      CacheMarker(cacheID: cacheID),
+      to: root.appendingPathComponent(CacheMarker.fileName)
+    )
+    let coordinator = CacheRootCoordinator(
+      registry: CacheRootRegistry(),
+      bookmarkClient: FakeBookmarkClient(resolvedURL: parent),
+      capacityProvider: FixedCapacityProvider(available: 20 * 1024 * 1024 * 1024)
+    )
+
+    let mismatchedPrepared = try coordinator.prepareExternal(selectedParentURL: parent)
+    XCTAssertThrowsError(try coordinator.activateExistingPreparedExternal(
+      prepared: mismatchedPrepared,
+      expectedCacheID: UUID()
+    )) {
+      XCTAssertEqual($0 as? CacheRootError, .markerMismatch)
+    }
+    mismatchedPrepared.cancel()
+    let matchingPrepared = try coordinator.prepareExternal(selectedParentURL: parent)
+    XCTAssertNoThrow(try coordinator.activateExistingPreparedExternal(
+      prepared: matchingPrepared,
+      expectedCacheID: cacheID
+    ))
+  }
+}
+
+// MARK: - FixedCapacityProvider
+
+private struct FixedCapacityProvider: CacheCapacityProviding {
+  let available: Int64
+
+  func availableCapacity(at url: URL) throws -> Int64 {
+    available
+  }
+}
+
+// MARK: - FakePreferenceStore
+
+private final class FakePreferenceStore: CacheLocationPreferenceStoring, @unchecked Sendable {
+  private let lock = NSLock()
+  private var preference: CacheLocationPreference
+
+  init(preference: CacheLocationPreference) {
+    self.preference = preference
+  }
+
+  func load() throws -> CacheLocationPreference {
+    lock.withLock { preference }
+  }
+
+  func save(_ preference: CacheLocationPreference) throws {
+    lock.withLock { self.preference = preference }
+  }
+}
+
+// MARK: - FailExternalPreferenceStore
+
+private final class FailExternalPreferenceStore: CacheLocationPreferenceStoring,
+  @unchecked Sendable {
+  private let lock = NSLock()
+  private var preference = CacheLocationPreference(mode: .default)
+
+  func load() throws -> CacheLocationPreference {
+    lock.withLock { preference }
+  }
+
+  func save(_ preference: CacheLocationPreference) throws {
+    if preference.mode == .external { throw InjectedActivationError.preference }
+    lock.withLock { self.preference = preference }
+  }
+}
+
+// MARK: - FakeActivationStore
+
+private final class FakeActivationStore: ExternalCacheActivationStoring, @unchecked Sendable {
+  private let lock = NSLock()
+  private var transaction: ExternalCacheActivationTransaction?
+
+  init(transaction: ExternalCacheActivationTransaction? = nil) {
+    self.transaction = transaction
+  }
+
+  func load() throws -> ExternalCacheActivationTransaction? {
+    lock.withLock { transaction }
+  }
+
+  func save(_ transaction: ExternalCacheActivationTransaction) throws {
+    lock.withLock { self.transaction = transaction }
+  }
+}
+
+// MARK: - InjectedActivationError
+
+private enum InjectedActivationError: Error {
+  case boundary
+  case bookmark
+  case preference
+}
+
+// MARK: - LockedPreferenceProjection
+
+private final class LockedPreferenceProjection: @unchecked Sendable {
+  private let lock = NSLock()
+  private var preference: CacheLocationPreference?
+
+  func set(_ value: CacheLocationPreference) {
+    lock.withLock { preference = value }
+  }
+
+  func value() -> CacheLocationPreference? {
+    lock.withLock { preference }
+  }
+}
+
+// MARK: - FakeBookmarkClient
+
+private final class FakeBookmarkClient: SecurityScopedBookmarkClient, @unchecked Sendable {
+  static let refreshedBookmark = Data("refreshed".utf8)
+
+  private let lock = NSLock()
+  private let resolvedURL: URL
+  private let isStale: Bool
+  private let startSucceeds: Bool
+  private let bookmarkCreationError: Error?
+  private var _createCount = 0
+  private var _startCount = 0
+  private var _stopCount = 0
+
+  init(
+    resolvedURL: URL,
+    isStale: Bool = false,
+    startSucceeds: Bool = true,
+    bookmarkCreationError: Error? = nil
+  ) {
+    self.resolvedURL = resolvedURL
+    self.isStale = isStale
+    self.startSucceeds = startSucceeds
+    self.bookmarkCreationError = bookmarkCreationError
+  }
+
+  var createCount: Int { lock.withLock { _createCount } }
+  var startCount: Int { lock.withLock { _startCount } }
+  var stopCount: Int { lock.withLock { _stopCount } }
+
+  func createBookmark(for url: URL) throws -> Data {
+    if let bookmarkCreationError { throw bookmarkCreationError }
+    lock.withLock { _createCount += 1 }
+    return Self.refreshedBookmark
+  }
+
+  func resolveBookmark(_ data: Data) throws -> ResolvedCacheBookmark {
+    ResolvedCacheBookmark(url: resolvedURL, isStale: isStale)
+  }
+
+  func startAccessing(_ url: URL) -> Bool {
+    lock.withLock { _startCount += 1 }
+    return startSucceeds
+  }
+
+  func stopAccessing(_ url: URL) {
+    lock.withLock { _stopCount += 1 }
+  }
+}


### PR DESCRIPTION
Adds a Cache Location option under Settings → Library on Mac, so downloaded music can be stored on an external drive.

Existing downloads can be moved to the new location, with an option to move them back to built-in storage. Amperfy shows progress and checks the new copy before removing the old files. The move can be canceled before the location changes.

If the drive is unavailable, downloads pause. You can still browse your library and stream music, and the cache becomes available again when the drive reconnects.

All 414 AmperfyKitTests pass. Moving files in both directions and offline playback have also been checked in the app. Missing drive recovery was tested with an unavailable test folder; physically unplugging a drive during a move still needs testing.